### PR TITLE
Define canonical WandB schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Remediated cross-repo review findings across scenario validation, synthetic/public-safe data generation, MCP server safeguards, and Insomnia/WatsonX operational scripts.
 - Generalized team-facing docs away from local-machine assumptions and aligned runbook/compute instructions with the current org repo `main` branch workflow.
+- Added a canonical WandB metrics schema doc and linked benchmark/results planning docs to that source of truth for future instrumentation and reproducibility work.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,22 +6,24 @@ Raw latency and throughput measurements from end-to-end experiment runs. Each su
 
 ```
 benchmarks/
-├── baseline/              # pre-optimization runs (direct Python, MCP baseline)
-│   ├── config.json        # model, scenario set, hardware, date, git SHA
+├── cell_A_direct/         # direct-tool baseline, no MCP
+│   ├── config.json        # includes WandB linkage fields from docs/wandb_schema.md
 │   ├── raw/               # one file per trial (CSV or JSONL)
-│   │   └── 2026-04-14_llama8b_mcp_run01.csv
+│   │   └── 2026-04-14_A_llama8b_aat_direct_run01.csv
 │   └── summary.json       # mean, p50, p95, throughput (derived)
-└── optimized/             # post-optimization runs
-    ├── int8/              # INT8 quantization
-    ├── kv_cache/          # KV-cache tuning
-    └── batched/           # batched tool-call scheduling
-    # each with the same config.json / raw/ / summary.json shape
+├── cell_B_mcp_baseline/   # shared cell between Experiment 1 and Experiment 2
+├── cell_C_mcp_optimized/  # optimized MCP path for Experiment 1
+├── cell_Y_plan_execute/   # Plan-Execute on MCP baseline
+└── cell_Z_hybrid/         # Hybrid on MCP baseline, if mentor-cleared
+    # each cell dir keeps the same config.json / raw/ / summary.json shape
 ```
 
 ## Conventions
 
-- **File naming:** `<date>_<model>_<harness>_run<NN>.csv` (e.g. `2026-04-14_llama8b_mcp_run01.csv`)
-- **Config files** must include: model ID, scenario set hash, GPU/host, git SHA of the code used to run, WandB run URL
+- **File naming:** `<date>_<cell>_<model-short>_<orchestration>_<mcp-mode>_run<NN>.csv` (e.g. `2026-04-14_B_llama8b_aat_baseline_run01.csv`)
+- **Canonical WandB schema:** see `docs/wandb_schema.md`
+- **Config files** must include the required reproducibility fields from `docs/wandb_schema.md`; do not treat the examples in this README as a complete schema
+- **Cell-to-directory mapping:** use the `cell_<ID>_*` top-level directory that matches `experiment_cell`; Cell B is intentionally shared across both experiment families
 - **Summary files** are regenerated from `raw/` via a notebook in `notebooks/` — never edit by hand
 - **Before committing a benchmark run**, make sure the corresponding config + summary are also committed so the run is reproducible
 - **What goes here vs. `results/`:** `benchmarks/` holds the *raw, untransformed* outputs of measurement runs. `results/` holds *curated, publication-ready* metrics derived from those benchmarks. The bridge is notebooks.

--- a/docs/execution_plan.md
+++ b/docs/execution_plan.md
@@ -35,7 +35,7 @@ The four foundation tasks above form a single bottleneck: **all four must comple
 | Run one existing benchmark scenario end-to-end on the canonical stack | Akshat | Tanisha's hardened MCP, Aaron's vLLM | All benchmarks, all scoring |
 | 15+ Smart Grid scenarios authored | Akshat | (nothing — can write in parallel) | All benchmarks (the test set) |
 | Profiling harness scripts (PyTorch Profiler wrappers) | Aaron | vLLM up | Experiment 1 capture |
-| WandB instrumentation (metrics schema in MCP servers + eval harness) | Alex | Tanisha's MCP, Akshat's harness | All experiment logging |
+| WandB instrumentation (metrics schema in MCP servers + eval harness; schema in `docs/wandb_schema.md`) | Alex | Tanisha's MCP, Akshat's harness | All experiment logging |
 | Generic Slurm experiment template | Aaron | vLLM, harness, MCP, WandB | Async benchmarking |
 
 #### Tier 2 — Experimental design (W2-W3, depends on Tier 1)
@@ -131,6 +131,10 @@ Once Tier 1 setup is in place, running an experiment cell is **submit-and-walk-a
    computes statistics, generates figures.
 
 NOBODY was online during steps 3-5.
+
+All WandB config / summary fields for that run should conform to
+`docs/wandb_schema.md`, so the benchmark config, run logs, and exported results
+stay joinable.
 ```
 
 ### Role clarifications

--- a/docs/wandb_schema.md
+++ b/docs/wandb_schema.md
@@ -1,0 +1,299 @@
+# WandB Metrics Schema
+
+*Owner: Alex (`#14`)*
+
+Canonical schema for experiment tracking in the org repo. This doc defines what
+`#61` should emit in code and what `#21` / `#28` should prove with the first
+real logged runs.
+
+## Scope
+
+This schema covers the shared metadata and metrics for:
+- benchmark cells in `benchmarks/`
+- end-to-end scenario runs and trajectories
+- LLM-as-Judge scoring outputs
+- exported reproducibility artifacts in `results/`
+
+The goal is not to log every raw token or event to WandB. The goal is to make
+every run attributable, comparable, and reproducible across:
+- orchestration condition
+- MCP mode
+- model / serving stack
+- scenario set
+- hardware / host
+- git revision
+
+## Canonical run structure
+
+Each WandB run should represent one experiment execution under one config. That
+execution may contain multiple scenarios and multiple trials.
+
+One run should map cleanly back to:
+- one benchmark config file
+- one git SHA
+- one model / serving stack
+- one orchestration condition
+- one MCP condition
+- one hardware environment
+
+## Initialization order
+
+`wandb_run_url` cannot be populated until after `wandb.init()` returns. The
+intended pattern for `#61` is:
+
+1. build the pre-init config dict with every other required field, including `benchmark_summary_path` if the benchmark directory layout is already deterministic from the config
+2. call `run = wandb.init(...)`
+3. patch `wandb_run_url` into `wandb.config`
+4. retroactively patch the benchmark `config.json` and later `summary.json` with
+   that URL before committing reproducibility artifacts
+
+This avoids the chicken-and-egg problem where the run URL is required for
+artifact linkage but only exists after the WandB run is live.
+
+## Required WandB config fields
+
+These fields should be written into `wandb.config` for every tracked run.
+
+### Identity and reproducibility
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `schema_version` | string | yes | Start with `v1` so future notebook logic can branch cleanly if needed |
+| `wandb_entity` | string | yes | Team / org slug used in the run URL; full run URL should follow `https://wandb.ai/<wandb_entity>/<project_name>/runs/<run_id>` |
+| `project_name` | string | yes | Expected value: `assetopsbench-smartgrid` |
+| `run_name` | string | yes | Human-readable unique run name |
+| `git_sha` | string | yes | Full SHA preferred for reproducibility; short SHA is acceptable only for temporary smoke runs |
+| `git_branch` | string | recommended | Helpful during active development |
+| `run_timestamp` | string | yes | ISO 8601 timestamp |
+| `benchmark_config_path` | string | yes | Repo-relative path to the config that launched the run |
+| `benchmark_summary_path` | string | yes | Repo-relative path once generated; this should be populated before the run is treated as reproducible and committed |
+| `wandb_run_url` | string | yes | Required, but only available after `wandb.init()` returns; write the rest of config first, then patch this field with `wandb.config.update(...)` |
+
+### Experiment design
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `experiment_family` | string | yes | Primary experiment family for the run: `exp1_mcp_overhead`, `exp2_orchestration`, `smoke`, or similar. For shared Cell B runs, use `exp1_mcp_overhead` here and record the dual-use explicitly in `contributing_experiments` and tags |
+| `contributing_experiments` | list[string] | recommended | Use this when one run contributes to multiple analyses; Cell B should list both `exp1_mcp_overhead` and `exp2_orchestration` |
+| `experiment_cell` | string | yes | Example: `A`, `B`, `C`, `Y`, `Z` |
+| `orchestration_mode` | string | yes | `aat`, `plan_execute`, `hybrid`, or `none` for infrastructure-only smoke runs |
+| `mcp_mode` | string | yes | `direct`, `baseline`, `optimized`, or `none` |
+| `trial_count` | integer | yes | Number of repeated trials in the run |
+| `scenario_count` | integer | yes | Number of scenarios attempted |
+| `scenario_set_name` | string | yes | Example: `smartgrid_v1` |
+| `scenario_set_hash` | string | yes | Compute as SHA-256 of the newline-joined lowercase hex-encoded per-file SHA-256 digests of the repo-relative scenario file paths sorted lexicographically, where each file is first canonicalized as UTF-8 JSON with sorted keys, no extra whitespace between elements, and normalized `\\n` line endings |
+| `scenario_domain_scope` | string | recommended | `single_domain`, `multi_domain`, or mixed summary |
+| `judge_model` | string | recommended | Example: `maverick-17b` when scoring is enabled |
+| `judge_pass_threshold` | number | recommended | Required whenever `judge_pass_rate` is logged so pass/fail is comparable across runs |
+
+### Model and serving stack
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `model_id` | string | yes | Example: `meta-llama/Llama-3.1-8B-Instruct` |
+| `model_provider` | string | yes | Example: `vllm`, `watsonx`, `openai` |
+| `serving_stack` | string | yes | Example: `insomnia_vllm`, `watsonx_api` |
+| `quantization_mode` | string | recommended | Example: `fp16`, `int8`, `none` |
+| `context_window` | integer | recommended | Effective max context used for the run |
+| `temperature` | number | recommended | Log explicit inference settings when controlled |
+| `max_tokens` | integer | recommended | Output cap used for the run |
+
+### Hardware and runtime environment
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `host_name` | string | yes | Example: `insomnia-a6000-01` |
+| `compute_env` | string | yes | Example: `insomnia`, `gcp`, `local` |
+| `gpu_type` | string | yes | Example: `A6000`, `A100`, `none` |
+| `gpu_count` | integer | yes | Usually `1` for current runs |
+| `runtime_owner` | string | recommended | Who launched the run |
+| `slurm_job_id` | string | recommended | Required when submitted through Slurm |
+
+## Required WandB summary metrics
+
+These fields should be written into `wandb.summary` once the run completes.
+
+### Run outcome
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `run_status` | string | yes | `success`, `partial`, `failed` |
+| `scenarios_attempted` | integer | yes | Count attempted |
+| `scenarios_completed` | integer | yes | Count completed without an unhandled exception; judge outcome does not affect this field |
+| `success_rate` | number | yes | `scenarios_completed / scenarios_attempted`; this is operational completion rate, not judge pass rate |
+| `failure_count` | integer | yes | Count of failed scenario executions |
+
+### Latency and throughput
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `wall_clock_seconds_total` | number | yes | Total runtime for the whole run |
+| `latency_seconds_mean` | number | yes | Mean end-to-end latency per scenario-trial |
+| `latency_seconds_p50` | number | yes | Median |
+| `latency_seconds_p95` | number | yes | Tail latency |
+| `tokens_per_second_mean` | number | recommended | For inference / throughput comparisons |
+
+### Token usage
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `input_tokens_total` | integer | recommended | Across the full run |
+| `output_tokens_total` | integer | recommended | Across the full run |
+| `tool_call_count_total` | integer | recommended | Across the full run |
+| `tool_call_count_mean` | number | recommended | Per scenario-trial average |
+
+### MCP / tool metrics
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `mcp_latency_seconds_mean` | number | required for `mcp_mode=baseline` or `mcp_mode=optimized` runs | Mean end-to-end MCP call time from client dispatch to client receipt |
+| `mcp_latency_seconds_p95` | number | required for `mcp_mode=baseline` or `mcp_mode=optimized` runs | Tail end-to-end MCP call latency |
+| `tool_latency_seconds_mean` | number | required for `mcp_mode=baseline` or `mcp_mode=optimized` runs | Mean server-side tool handler execution time inside the MCP server |
+| `tool_error_count` | integer | recommended | Contract / execution failures |
+
+For Experiment 1 analysis:
+- `mcp_latency_seconds_*` measures end-to-end MCP call time, including protocol and tool execution
+- `tool_latency_seconds_mean` measures tool handler execution time only
+- MCP protocol overhead can then be estimated as `mcp_latency_seconds_mean - tool_latency_seconds_mean`
+
+### Judge metrics
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `judge_score_mean` | number | required when scoring enabled | Aggregate average score |
+| `judge_score_p50` | number | recommended | Median judge score |
+| `judge_score_p95` | number | recommended | Upper tail of quality scores; useful but not the failure tail |
+| `judge_score_p5` | number | recommended | Lower failure-tail summary for weak trajectories |
+| `judge_pass_rate` | number | recommended | Fraction above `judge_pass_threshold`; only log when that threshold is explicitly set for the run |
+
+### Dimension-level judge metrics
+
+When the 6-dimension judge path is enabled, log the fields below. This path is
+considered enabled when `judge_model` is set and the judge returns a structured
+rubric response with per-dimension outputs.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `judge_dim_task_completion_mean` | number | recommended | |
+| `judge_dim_correctness_mean` | number | recommended | |
+| `judge_dim_tool_usage_mean` | number | recommended | |
+| `judge_dim_grounding_mean` | number | recommended | |
+| `judge_dim_efficiency_mean` | number | recommended | |
+| `judge_dim_safety_mean` | number | recommended | |
+
+## Required artifacts and file back-references
+
+WandB should not be the only source of truth. Each run must still have durable
+repo artifacts or exportable artifacts.
+
+### Benchmark config linkage
+
+Each benchmark `config.json` should include:
+- `schema_version`
+- `wandb_entity`
+- `benchmark_summary_path`
+- `model_id`
+- `scenario_set_name`
+- `scenario_set_hash`
+- `experiment_family`
+- `contributing_experiments` when applicable
+- `experiment_cell`
+- `orchestration_mode`
+- `mcp_mode`
+- `git_sha`
+- `host_name`
+- `gpu_type`
+- `wandb_run_url`
+
+`config.json` is typically written before the run starts, so the harness should
+patch in `wandb_run_url` after `wandb.init()` succeeds.
+
+### Benchmark summary linkage
+
+Each benchmark `summary.json` should include:
+- the same identifying config fields needed for reproducibility, especially `schema_version`, `wandb_entity`, `experiment_family`, `contributing_experiments` when applicable, `experiment_cell`, `scenario_set_name`, `scenario_set_hash`, `orchestration_mode`, `mcp_mode`, `git_sha`, `host_name`, and `gpu_type`
+- aggregate latency metrics
+- aggregate success metrics
+- `wandb_run_url`
+
+### Results linkage
+
+`results/metrics/scenario_scores.jsonl` should include enough fields to join back
+to WandB and benchmark artifacts:
+- `run_name`
+- `wandb_run_url`
+- `scenario_id`
+- `trial_index`
+- `experiment_cell`
+- `orchestration_mode`
+- `mcp_mode`
+- `judge_model`
+- judge score outputs
+
+### WandB exports
+
+Long-lived reproducibility snapshots under `results/wandb_exports/` should retain:
+- run config
+- run summary
+- tags
+- artifact references if exported
+
+## Required tags
+
+Each WandB run should include tags that make filtering easy in the UI.
+
+Required tags:
+- `experiment:<family>`
+- `cell:<cell>`
+- `orchestration:<mode>`
+- `mcp:<mode>`
+- `model:<short-name>`
+- `env:<compute-env>`
+
+Special case:
+- Cell B should carry both `experiment:exp1_mcp_overhead` and
+  `experiment:exp2_orchestration`, even if `experiment_family` is recorded as a
+  single primary family in config
+
+Recommended tags:
+- `gpu:<gpu-type>`
+- `judge:<model>`
+- `scenario-set:<name>`
+
+## Run naming convention
+
+Recommended run-name template:
+
+`<date>_<experiment-family>_<cell>_<model-short>_<orchestration>_<mcp-mode>`
+
+Example:
+
+`2026-04-10_exp1_mcp_overhead_B_llama8b_aat_baseline`
+
+The name should stay human-readable and stable enough to line up with:
+- benchmark directory names
+- notebook analysis outputs
+- issue / PR discussion
+
+Run names are for human-readable traceability, not for strict parsing. Notebook
+joins should prefer explicit config fields and tags rather than parsing tokens
+back out of `run_name`.
+
+## Minimum viable first run for #21
+
+The first run used to close `#21` does not need the entire final experiment stack.
+It does need:
+- a real WandB run in the shared project
+- the required identity / experiment / model / hardware config fields above
+- basic run outcome fields
+- at least one latency metric
+- a valid `wandb_run_url`
+
+That first run is the proof point that the schema and instrumentation path are real.
+
+## Dependencies
+
+- `#14` defines the schema in this document
+- `#61` should implement instrumentation against this schema
+- `#21` should use the first real run emitted with this schema
+- `#28` should only close once the shared-project logging path is visibly working

--- a/results/README.md
+++ b/results/README.md
@@ -22,8 +22,10 @@ results/
 ## Conventions
 
 - Every figure in `figures/` must trace back to a CSV in `metrics/`, which traces back to a run dir in `benchmarks/`. Keep that chain intact — reviewers need it.
+- The canonical WandB field definitions live in `docs/wandb_schema.md`.
 - **Don't edit files in this dir by hand** — regenerate from notebooks. If you catch yourself tweaking a PDF directly, that's a smell.
 - WandB exports are snapshots in time. If a WandB run is deleted or the project is wiped, the exports here are the only remaining record.
+- `scenario_scores.jsonl` should retain the run-level join keys needed to line up with WandB and benchmark artifacts, especially `run_name`, `wandb_run_url`, `scenario_id`, `trial_index`, `experiment_cell`, `orchestration_mode`, `mcp_mode`, and `judge_model`.
 - Filenames should be **stable** (so the paper can reference them by path) — avoid renames once a figure is committed to a report draft.
 
 ## Status (Apr 7, 2026)


### PR DESCRIPTION
## Summary
- add a canonical WandB schema doc for issue #14
- define required run config, summary metrics, tags, and artifact join keys
- point benchmark/results/execution docs at that source of truth

## Test Plan
- `git diff --check`
- `rg -n "docs/wandb_schema.md" benchmarks/README.md results/README.md docs/execution_plan.md`

## Links
- Closes #14
