### PR TITLE
feat(issue31): Cell C batched tool calls + MCP connection reuse

### DIFF
--- a/configs/aat_mcp_optimized.env
+++ b/configs/aat_mcp_optimized.env
@@ -8,13 +8,10 @@
 # docs/experiment1_capture_plan.md for the full design and
 # docs/lane2_int8_kv_status.md for the Lane 2 rationale.
 #
-# STATUS (2026-04-26): KV-cache optimization wired here (prefix caching only —
-# fp8 KV cache hit a vLLM-0.19.0 kernel-dispatch limitation under FP16 weights;
-# see status doc §"#30 KV-Cache" for the smoke evidence). INT8 deferred (see
-# status doc). Still blocked on:
-#   - Akshat's batched tool-call scheduling implementation (#31)
-# Until #31 lands, this config measures only the GPU-side optimization, not
-# the MCP transport optimization that Cell C is meant to isolate.
+# STATUS (2026-04-29): Both optimization layers now wired:
+#   - KV-cache: prefix caching only (fp8 deferred — see status doc §"#30 KV-Cache")
+#   - MCP transport: batched tool calls + connection reuse (#31, landed this PR)
+# INT8 deferred (see status doc).
 
 EXPERIMENT_NAME="aat_mcp_optimized"
 EXPERIMENT_CELL="C"
@@ -66,12 +63,12 @@ WANDB_ENTITY="assetopsbench-smartgrid"
 WANDB_PROJECT="assetopsbench-smartgrid"
 WANDB_MODE="online"
 
-# Agent-as-Tool dispatch defaults to scripts/aat_runner.py (set
-# AAT_RUNNER_TEMPLATE for parity / variant runs). For Cell C the runner
-# also needs the optimization knobs flipped on the MCP side once #31 lands:
-#   - batch_tool_calls=true
-#   - reuse_mcp_connections=true
-AAT_PARALLEL_TOOL_CALLS=false
+# Cell C optimization knobs — wired into scripts/aat_runner.py --mcp-mode optimized.
+# parallel_tool_calls is driven solely by this config variable; the runner threads
+# it through unchanged.  Set AAT_PARALLEL_TOOL_CALLS=false to disable for debugging.
+AAT_MCP_SERVER_LAUNCH_MODE="python"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=120
+AAT_PARALLEL_TOOL_CALLS=true
 
-# Torch profiler — same as Cell A/B
+# Torch profiler: captures one replay pass per run while vLLM is still live.
 TORCH_PROFILE="${TORCH_PROFILE:-1}"

--- a/docs/wandb_schema.md
+++ b/docs/wandb_schema.md
@@ -130,10 +130,11 @@ These fields should be written into `wandb.summary` once the run completes.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `wall_clock_seconds_total` | number | yes | Total runtime for the whole run |
+| `wall_clock_seconds_total` | number | yes | Total runtime for the whole run; for optimized AaT batch runs this includes one-time MCP setup once plus per-trial latencies |
 | `latency_seconds_mean` | number | yes | Mean end-to-end latency per scenario-trial |
 | `latency_seconds_p50` | number | yes | Median |
 | `latency_seconds_p95` | number | yes | Tail latency |
+| `mcp_setup_seconds` | number | recommended for optimized AaT batch runs | One-time MCP connection setup cost kept separate from per-trial latency rows and folded into `wall_clock_seconds_total` once |
 | `tokens_per_second_mean` | number | recommended | For inference / throughput comparisons |
 
 ### Token usage

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -112,7 +112,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "direct = Cell A in-process callables; "
             "baseline = Cell B MCP stdio; "
-            "optimized = Cell C MCP stdio with parallel tool calls enabled"
+            "optimized = Cell C MCP stdio (parallel tool calls configured separately)"
         ),
     )
     p.add_argument(
@@ -432,9 +432,9 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 trial_ok = False
                 try:
                     result = await runner.run(prompt)
-                    # run_only_duration: excludes file write; used for
-                    # runner_meta.duration_seconds so it stays comparable to the
-                    # single-trial path's _serialize_run_result call.
+                    # run_only_duration measures only runner.run(prompt).
+                    # It excludes file write and later shared-resource cleanup,
+                    # so batch runner_meta.duration_seconds is run-only time.
                     run_only_duration = time.time() - start
                     output = _serialize_run_result(
                         args, prompt, result, run_only_duration, scenario_file=sf_rel

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -367,6 +367,10 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
         )
         return 2
 
+    if args.trials < 1:
+        _LOG.error("--trials must be >= 1; got %d", args.trials)
+        return 2
+
     from scripts.aat_tools_mcp import build_mcp_servers
 
     output_dir = Path(args.output_dir)

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -395,7 +395,10 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
     any_failed = False
 
     try:
+        mcp_setup_start = time.time()
         mcp_servers = await build_mcp_servers(repo_root)
+        mcp_setup_seconds = time.time() - mcp_setup_start
+        _LOG.info("MCP servers ready (setup=%.1fs)", mcp_setup_seconds)
 
         runner = AaTRunner(
             model_id=args.model_id,
@@ -408,8 +411,12 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
         for sf in scenario_files:
             try:
                 scenario_payload = json.loads(sf.read_text(encoding="utf-8"))
+                if not isinstance(scenario_payload, dict):
+                    raise TypeError(
+                        f"scenario payload must be a JSON object, got {type(scenario_payload).__name__}"
+                    )
                 prompt = scenario_payload["text"]
-            except (json.JSONDecodeError, KeyError) as exc:
+            except (json.JSONDecodeError, KeyError, TypeError) as exc:
                 _LOG.error("skipping %s — failed to read prompt: %s", sf, exc)
                 any_failed = True
                 continue
@@ -421,9 +428,13 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 out_path = output_dir / out_name
 
                 start = time.time()
+                run_duration: float | None = None
                 error_payload: dict[str, Any] | None = None
                 try:
                     result = await runner.run(prompt)
+                    # Capture run-only duration here; full wall-clock (including
+                    # file write) is recorded below for latency_seconds.
+                    run_duration = time.time() - start
                 except Exception as exc:
                     _LOG.exception(
                         "trial failed (%s trial %d): %s", sf.name, trial, exc
@@ -453,15 +464,16 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                         },
                     }
 
-                duration = time.time() - start
-
                 if error_payload is not None:
                     _write_output(out_path, error_payload)
                     any_failed = True
                     trial_ok = False
                 else:
+                    # runner_meta.duration_seconds = run-only time (no file write),
+                    # consistent with the single-trial path's _serialize_run_result call.
+                    assert run_duration is not None
                     output = _serialize_run_result(
-                        args, prompt, result, duration, scenario_file=sf_rel
+                        args, prompt, result, run_duration, scenario_file=sf_rel
                     )
                     output["scenario"] = scenario_payload
                     _write_output(out_path, output)
@@ -476,6 +488,11 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                             trial,
                         )
 
+                # Wall-clock ends after the JSON write to match single-trial
+                # path semantics (run_experiment.sh measures END_EPOCH after
+                # the runner process exits, which includes the file write).
+                duration = time.time() - start
+
                 try:
                     _rel_path = out_path.relative_to(repo_root).as_posix()
                 except ValueError:
@@ -486,6 +503,11 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                         "trial_index": trial,
                         "latency_seconds": duration,
                         "output_path": _rel_path,
+                        # One-time MCP setup cost amortized across all trials by
+                        # notebooks: total_cost = sum(latency_seconds) + mcp_setup_seconds.
+                        # Per-trial latency_seconds stays comparable to single-trial
+                        # path (which includes per-trial MCP setup in its wall-clock).
+                        "mcp_setup_seconds": mcp_setup_seconds,
                     }
                 )
                 _LOG.info(

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -360,6 +360,13 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
     per-trial JSON to args.output_dir, and appends a _batch_latencies.jsonl
     with per-trial latency records in the same format as latencies.jsonl.
     """
+    if args.mcp_mode != "optimized":
+        _LOG.error(
+            "--scenarios-glob is only supported with --mcp-mode optimized; got %r",
+            args.mcp_mode,
+        )
+        return 2
+
     from scripts.aat_tools_mcp import build_mcp_servers
 
     output_dir = Path(args.output_dir)
@@ -370,13 +377,6 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
     scenario_files = sorted(repo_root.glob(args.scenarios_glob))
     if not scenario_files:
         _LOG.error("no scenario files matched --scenarios-glob %r", args.scenarios_glob)
-        return 2
-
-    if args.mcp_mode != "optimized":
-        _LOG.error(
-            "--scenarios-glob is only supported with --mcp-mode optimized; got %r",
-            args.mcp_mode,
-        )
         return 2
 
     _LOG.info(
@@ -472,12 +472,16 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                             trial,
                         )
 
+                try:
+                    _rel_path = out_path.relative_to(repo_root).as_posix()
+                except ValueError:
+                    _rel_path = out_path.as_posix()
                 latency_records.append(
                     {
                         "scenario_file": sf_rel,
                         "trial_index": trial,
                         "latency_seconds": duration,
-                        "output_path": out_path.relative_to(repo_root).as_posix(),
+                        "output_path": _rel_path,
                     }
                 )
                 _LOG.info(

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -412,7 +412,9 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 try:
                     result = await runner.run(prompt)
                 except Exception as exc:
-                    _LOG.exception("trial failed (%s trial %d): %s", sf.name, trial, exc)
+                    _LOG.exception(
+                        "trial failed (%s trial %d): %s", sf.name, trial, exc
+                    )
                     from scripts.aat_system_prompt import AOB_PROMPT_SHA
 
                     error_payload = {

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -428,13 +428,29 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 out_path = output_dir / out_name
 
                 start = time.time()
-                run_duration: float | None = None
-                error_payload: dict[str, Any] | None = None
+                trial_ok = False
                 try:
                     result = await runner.run(prompt)
-                    # Capture run-only duration here; full wall-clock (including
-                    # file write) is recorded below for latency_seconds.
+                    # Capture run-only duration (before file write) for
+                    # runner_meta.duration_seconds.  latency_seconds (below)
+                    # uses a post-write timestamp to match single-trial path
+                    # semantics where END_EPOCH includes file write.
                     run_duration = time.time() - start
+                    output = _serialize_run_result(
+                        args, prompt, result, run_duration, scenario_file=sf_rel
+                    )
+                    output["scenario"] = scenario_payload
+                    _write_output(out_path, output)
+                    trial_ok = output["success"]
+                    if not trial_ok:
+                        any_failed = True
+                    if output["max_turns_exhausted"]:
+                        _LOG.warning(
+                            "max_turns=%d exhausted (%s trial %d)",
+                            args.max_turns,
+                            sf.name,
+                            trial,
+                        )
                 except Exception as exc:
                     _LOG.exception(
                         "trial failed (%s trial %d): %s", sf.name, trial, exc
@@ -463,30 +479,8 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                             "scenario_file": sf_rel,
                         },
                     }
-
-                if error_payload is not None:
                     _write_output(out_path, error_payload)
                     any_failed = True
-                    trial_ok = False
-                else:
-                    # runner_meta.duration_seconds = run-only time (no file write),
-                    # consistent with the single-trial path's _serialize_run_result call.
-                    assert run_duration is not None
-                    output = _serialize_run_result(
-                        args, prompt, result, run_duration, scenario_file=sf_rel
-                    )
-                    output["scenario"] = scenario_payload
-                    _write_output(out_path, output)
-                    trial_ok = output["success"]
-                    if not trial_ok:
-                        any_failed = True
-                    if output["max_turns_exhausted"]:
-                        _LOG.warning(
-                            "max_turns=%d exhausted (%s trial %d)",
-                            args.max_turns,
-                            sf.name,
-                            trial,
-                        )
 
                 # Wall-clock ends after the JSON write to match single-trial
                 # path semantics (run_experiment.sh measures END_EPOCH after
@@ -503,10 +497,10 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                         "trial_index": trial,
                         "latency_seconds": duration,
                         "output_path": _rel_path,
-                        # One-time MCP setup cost amortized across all trials by
-                        # notebooks: total_cost = sum(latency_seconds) + mcp_setup_seconds.
-                        # Per-trial latency_seconds stays comparable to single-trial
-                        # path (which includes per-trial MCP setup in its wall-clock).
+                        # One-time MCP setup cost: notebooks can compute total
+                        # batch cost as sum(latency_seconds) + mcp_setup_seconds.
+                        # Per-trial latency_seconds remains comparable to the
+                        # single-trial path (where each trial pays MCP startup).
                         "mcp_setup_seconds": mcp_setup_seconds,
                     }
                 )

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -1,18 +1,31 @@
-"""Team-local Agent-as-Tool runner for Experiment 1 Cells A + B.
+"""Team-local Agent-as-Tool runner for Experiment 1 Cells A, B, and C.
 
 A thin wrapper over the OpenAI Agents SDK's Runner.run() using AOB's
 system prompt verbatim. Cell A feeds it direct Python callables from
 mcp_servers/direct_adapter; Cell B feeds it MCPServerStdio connections
-to the team's hardened Smart Grid MCP servers. The runner code itself
-is identical across cells — only the tool surface differs. That's the
-fairness contract for (Cell B latency) - (Cell A latency) to measure
-pure MCP transport overhead.
+to the team's hardened Smart Grid MCP servers; Cell C does the same as
+Cell B with two optimizations enabled:
 
-Invocation: expected to be driven by scripts/run_experiment.sh via
-AAT_RUNNER_TEMPLATE in configs/aat_{direct,mcp_baseline}.env.
+  - parallel_tool_calls=True (set via AAT_PARALLEL_TOOL_CALLS=true in
+    configs/aat_mcp_optimized.env) lets the model emit multiple tool
+    calls per turn, reducing MCP round-trips.
+  - MCP connection reuse: when invoked with --scenarios-glob, all
+    scenario×trial runs share the same four MCP subprocesses, eliminating
+    per-trial subprocess startup/teardown overhead.
+
+Single-scenario invocation (Cells A and B, and Cell C single-trial):
+    aat_runner.py --prompt TEXT --output PATH --model-id ID --mcp-mode MODE
+
+Multi-scenario batch invocation (Cell C connection reuse):
+    aat_runner.py --scenarios-glob GLOB --trials N --output-dir DIR
+                  --run-basename NAME --model-id ID --mcp-mode optimized
+
+The runner code is otherwise identical across cells — only the tool
+surface and invocation mode differ. That is the fairness contract for
+latency comparisons between cells.
 
 Spec: docs/specs/2026-04-24-aat-runner-design.md
-Issue: #104 (narrowed 2026-04-24) → unblocks #25 (Experiment 1).
+Issue: #31 (Cell C batch mode), #104 (runner design) → unblocks #25 (Experiment 1).
 """
 
 from __future__ import annotations
@@ -44,28 +57,63 @@ _LOG = logging.getLogger("aat_runner")
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="aat_runner",
-        description="Team-local Agent-as-Tool runner for Cells A + B of Experiment 1.",
+        description="Team-local Agent-as-Tool runner for Cells A, B, and C of Experiment 1.",
     )
     p.add_argument(
         "--prompt",
-        required=True,
-        help="Scenario text (AAT_RUNNER_TEMPLATE passes $PROMPT here)",
+        default=None,
+        help="Scenario text — required in single-scenario mode (omit when using --scenarios-glob).",
     )
     p.add_argument(
         "--output",
-        required=True,
-        help="Trial JSON output path (passed as $OUTPUT_PATH)",
+        default=None,
+        help="Trial JSON output path — required in single-scenario mode.",
+    )
+    p.add_argument(
+        "--scenarios-glob",
+        default=None,
+        dest="scenarios_glob",
+        help=(
+            "Multi-scenario batch mode: glob pattern relative to repo root "
+            "(e.g. 'data/scenarios/multi_*.json'). MCP servers are reused "
+            "across all scenario×trial runs. Replaces --prompt/--output."
+        ),
+    )
+    p.add_argument(
+        "--trials",
+        type=int,
+        default=1,
+        help="Trials per scenario in multi-scenario batch mode (default 1).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        dest="output_dir",
+        help="Output directory for batch mode (required when --scenarios-glob is set).",
+    )
+    p.add_argument(
+        "--run-basename",
+        default="batch",
+        dest="run_basename",
+        help=(
+            "Filename prefix for batch-mode trial outputs. "
+            "run_experiment.sh passes RUN_BASENAME here so naming matches single-trial convention."
+        ),
     )
     p.add_argument(
         "--model-id",
         required=True,
-        help="LiteLLM-style model string, e.g. watsonx/meta-llama/llama-3-3-70b-instruct",
+        help="LiteLLM-style model string, e.g. openai/Llama-3.1-8B-Instruct",
     )
     p.add_argument(
         "--mcp-mode",
         required=True,
-        choices=("direct", "baseline"),
-        help="direct = Cell A in-process callables; baseline = Cell B MCP stdio",
+        choices=("direct", "baseline", "optimized"),
+        help=(
+            "direct = Cell A in-process callables; "
+            "baseline = Cell B MCP stdio; "
+            "optimized = Cell C MCP stdio with parallel tool calls enabled"
+        ),
     )
     p.add_argument(
         "--max-turns",
@@ -116,6 +164,7 @@ def _serialize_run_result(
     prompt: str,
     result: Any,
     duration_seconds: float,
+    scenario_file: str | None = None,
 ) -> dict[str, Any]:
     """Translate an Agents SDK RunResult into our output JSON schema.
 
@@ -257,6 +306,7 @@ def _serialize_run_result(
             "parallel_tool_calls": args.parallel_tool_calls,
             "sdk_version": f"openai-agents=={sdk_version}",
             "duration_seconds": duration_seconds,
+            "scenario_file": scenario_file,
         },
     }
 
@@ -303,8 +353,156 @@ class AaTRunner:
         return await Runner.run(agent, prompt, max_turns=self.max_turns)
 
 
+async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
+    """Multi-scenario batch mode: keeps MCP servers alive across all runs.
+
+    Globs scenario files, runs each scenario for args.trials trials, writes
+    per-trial JSON to args.output_dir, and appends a _batch_latencies.jsonl
+    with per-trial latency records in the same format as latencies.jsonl.
+    """
+    from scripts.aat_tools_mcp import build_mcp_servers
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    scenario_files = sorted(repo_root.glob(args.scenarios_glob))
+    if not scenario_files:
+        _LOG.error("no scenario files matched --scenarios-glob %r", args.scenarios_glob)
+        return 2
+
+    _LOG.info(
+        "batch mode: %d scenario(s) × %d trial(s), output → %s",
+        len(scenario_files),
+        args.trials,
+        output_dir,
+    )
+
+    mcp_servers: list = []
+    latency_records: list[dict[str, Any]] = []
+    any_failed = False
+
+    try:
+        mcp_servers = await build_mcp_servers(repo_root)
+
+        runner = AaTRunner(
+            model_id=args.model_id,
+            mcp_mode=args.mcp_mode,
+            max_turns=args.max_turns,
+            mcp_servers=mcp_servers,
+            parallel_tool_calls=args.parallel_tool_calls,
+        )
+
+        for sf in scenario_files:
+            try:
+                scenario_payload = json.loads(sf.read_text(encoding="utf-8"))
+                prompt = scenario_payload["text"]
+            except (json.JSONDecodeError, KeyError) as exc:
+                _LOG.error("skipping %s — failed to read prompt: %s", sf, exc)
+                any_failed = True
+                continue
+
+            sf_rel = sf.relative_to(repo_root).as_posix()
+
+            for trial in range(1, args.trials + 1):
+                out_name = f"{args.run_basename}_{sf.stem}_run{trial:02d}.json"
+                out_path = output_dir / out_name
+
+                start = time.time()
+                error_payload: dict[str, Any] | None = None
+                try:
+                    result = await runner.run(prompt)
+                except Exception as exc:
+                    _LOG.exception("trial failed (%s trial %d): %s", sf.name, trial, exc)
+                    from scripts.aat_system_prompt import AOB_PROMPT_SHA
+
+                    error_payload = {
+                        "question": prompt,
+                        "answer": "",
+                        "success": False,
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "failed_tools": [],
+                        "max_turns_exhausted": False,
+                        "turn_count": 0,
+                        "tool_call_count": 0,
+                        "history": [],
+                        "runner_meta": {
+                            "model_id": args.model_id,
+                            "mcp_mode": args.mcp_mode,
+                            "aob_prompt_sha": AOB_PROMPT_SHA,
+                            "max_turns": args.max_turns,
+                            "parallel_tool_calls": args.parallel_tool_calls,
+                            "sdk_version": "unknown",
+                            "duration_seconds": time.time() - start,
+                            "scenario_file": sf_rel,
+                        },
+                    }
+
+                duration = time.time() - start
+
+                if error_payload is not None:
+                    _write_output(out_path, error_payload)
+                    any_failed = True
+                else:
+                    output = _serialize_run_result(
+                        args, prompt, result, duration, scenario_file=sf_rel
+                    )
+                    _write_output(out_path, output)
+                    if output["max_turns_exhausted"]:
+                        _LOG.warning(
+                            "max_turns=%d exhausted (%s trial %d)",
+                            args.max_turns,
+                            sf.name,
+                            trial,
+                        )
+                    if not output["success"]:
+                        any_failed = True
+
+                latency_records.append(
+                    {
+                        "scenario_file": sf_rel,
+                        "trial_index": trial,
+                        "latency_seconds": duration,
+                        "output_path": out_path.relative_to(repo_root).as_posix(),
+                    }
+                )
+                _LOG.info(
+                    "wrote %s (%.1fs, success=%s)",
+                    out_path.name,
+                    duration,
+                    not any_failed,
+                )
+
+    finally:
+        for srv in mcp_servers:
+            try:
+                await srv.cleanup()
+            except (asyncio.CancelledError, Exception) as cleanup_exc:
+                _LOG.warning("cleanup failed for %s: %s", srv, cleanup_exc)
+
+    latency_path = output_dir / "_batch_latencies.jsonl"
+    latency_path.write_text(
+        "\n".join(json.dumps(r) for r in latency_records) + "\n",
+        encoding="utf-8",
+    )
+    _LOG.info("wrote %d latency records → %s", len(latency_records), latency_path)
+
+    return 1 if any_failed else 0
+
+
 async def _main(args: argparse.Namespace) -> int:
     repo_root = Path(__file__).resolve().parent.parent
+
+    # Batch mode: multi-scenario with MCP connection reuse (Cell C optimized).
+    if args.scenarios_glob:
+        if not args.output_dir:
+            _LOG.error("--output-dir is required when --scenarios-glob is set")
+            return 2
+        return await _main_multi(args, repo_root)
+
+    # Single-scenario mode: validate that --prompt and --output are present.
+    if not args.prompt or not args.output:
+        _LOG.error("--prompt and --output are required in single-scenario mode")
+        return 2
 
     tools: list = []
     mcp_servers: list = []
@@ -314,6 +512,10 @@ async def _main(args: argparse.Namespace) -> int:
 
         tools = build_direct_tools()
     elif args.mcp_mode == "baseline":
+        from scripts.aat_tools_mcp import build_mcp_servers
+
+        mcp_servers = await build_mcp_servers(repo_root)
+    elif args.mcp_mode == "optimized":
         from scripts.aat_tools_mcp import build_mcp_servers
 
         mcp_servers = await build_mcp_servers(repo_root)
@@ -356,6 +558,7 @@ async def _main(args: argparse.Namespace) -> int:
                 "parallel_tool_calls": args.parallel_tool_calls,
                 "sdk_version": "unknown",
                 "duration_seconds": time.time() - start,
+                "scenario_file": None,
             },
         }
     finally:
@@ -374,7 +577,9 @@ async def _main(args: argparse.Namespace) -> int:
         return 1
 
     duration = time.time() - start
-    output = _serialize_run_result(args, args.prompt, result, duration)
+    output = _serialize_run_result(
+        args, args.prompt, result, duration, scenario_file=None
+    )
     _write_output(Path(args.output), output)
 
     if output["max_turns_exhausted"]:

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -436,6 +436,7 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                         "turn_count": 0,
                         "tool_call_count": 0,
                         "history": [],
+                        "scenario": scenario_payload,
                         "runner_meta": {
                             "model_id": args.model_id,
                             "mcp_mode": args.mcp_mode,
@@ -458,6 +459,7 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                     output = _serialize_run_result(
                         args, prompt, result, duration, scenario_file=sf_rel
                     )
+                    output["scenario"] = scenario_payload
                     _write_output(out_path, output)
                     trial_ok = output["success"]
                     if not trial_ok:

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -428,16 +428,16 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 out_path = output_dir / out_name
 
                 start = time.time()
+                # False is the correct safe default: exception path leaves it False.
                 trial_ok = False
                 try:
                     result = await runner.run(prompt)
-                    # Capture run-only duration (before file write) for
-                    # runner_meta.duration_seconds.  latency_seconds (below)
-                    # uses a post-write timestamp to match single-trial path
-                    # semantics where END_EPOCH includes file write.
-                    run_duration = time.time() - start
+                    # run_only_duration: excludes file write; used for
+                    # runner_meta.duration_seconds so it stays comparable to the
+                    # single-trial path's _serialize_run_result call.
+                    run_only_duration = time.time() - start
                     output = _serialize_run_result(
-                        args, prompt, result, run_duration, scenario_file=sf_rel
+                        args, prompt, result, run_only_duration, scenario_file=sf_rel
                     )
                     output["scenario"] = scenario_payload
                     _write_output(out_path, output)
@@ -482,10 +482,11 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                     _write_output(out_path, error_payload)
                     any_failed = True
 
-                # Wall-clock ends after the JSON write to match single-trial
-                # path semantics (run_experiment.sh measures END_EPOCH after
-                # the runner process exits, which includes the file write).
-                duration = time.time() - start
+                # wall_clock_duration: ends after the JSON write to match
+                # single-trial path semantics (run_experiment.sh measures
+                # END_EPOCH after the runner process exits, which includes
+                # the file write).
+                wall_clock_duration = time.time() - start
 
                 try:
                     _rel_path = out_path.relative_to(repo_root).as_posix()
@@ -495,7 +496,7 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                     {
                         "scenario_file": sf_rel,
                         "trial_index": trial,
-                        "latency_seconds": duration,
+                        "latency_seconds": wall_clock_duration,
                         "output_path": _rel_path,
                         # One-time MCP setup cost: notebooks can compute total
                         # batch cost as sum(latency_seconds) + mcp_setup_seconds.
@@ -507,7 +508,7 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 _LOG.info(
                     "wrote %s (%.1fs, success=%s)",
                     out_path.name,
-                    duration,
+                    wall_clock_duration,
                     trial_ok,
                 )
 

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -363,11 +363,20 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
     from scripts.aat_tools_mcp import build_mcp_servers
 
     output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = repo_root / output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
     scenario_files = sorted(repo_root.glob(args.scenarios_glob))
     if not scenario_files:
         _LOG.error("no scenario files matched --scenarios-glob %r", args.scenarios_glob)
+        return 2
+
+    if args.mcp_mode != "optimized":
+        _LOG.error(
+            "--scenarios-glob is only supported with --mcp-mode optimized; got %r",
+            args.mcp_mode,
+        )
         return 2
 
     _LOG.info(
@@ -444,11 +453,15 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                 if error_payload is not None:
                     _write_output(out_path, error_payload)
                     any_failed = True
+                    trial_ok = False
                 else:
                     output = _serialize_run_result(
                         args, prompt, result, duration, scenario_file=sf_rel
                     )
                     _write_output(out_path, output)
+                    trial_ok = output["success"]
+                    if not trial_ok:
+                        any_failed = True
                     if output["max_turns_exhausted"]:
                         _LOG.warning(
                             "max_turns=%d exhausted (%s trial %d)",
@@ -456,8 +469,6 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                             sf.name,
                             trial,
                         )
-                    if not output["success"]:
-                        any_failed = True
 
                 latency_records.append(
                     {
@@ -471,7 +482,7 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
                     "wrote %s (%.1fs, success=%s)",
                     out_path.name,
                     duration,
-                    not any_failed,
+                    trial_ok,
                 )
 
     finally:

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -1223,8 +1223,7 @@ meta["pass"] = int(passed)
 meta["fail"] = int(failed)
 meta["total_runs"] = int(total)
 meta["run_status"] = summary["run_status"]
-if summary["mcp_setup_seconds"] is not None:
-    meta["mcp_setup_seconds"] = summary["mcp_setup_seconds"]
+meta["mcp_setup_seconds"] = summary["mcp_setup_seconds"]
 pathlib.Path(meta_path).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 PY
 

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -714,6 +714,8 @@ run_agent_as_tool_trial() {
 run_agent_as_tool_batch() {
   local out_dir="$1"
 
+  export AAT_MCP_SERVER_PYTHON AAT_MCP_SERVER_LAUNCH_MODE AAT_MCP_CLIENT_TIMEOUT_SECONDS
+
   local -a cmd=(
     uv run
     --with "openai-agents==$AAT_OPENAI_AGENTS_VERSION"

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -714,11 +714,6 @@ run_agent_as_tool_trial() {
 run_agent_as_tool_batch() {
   local out_dir="$1"
 
-  if [ -n "${AAT_RUNNER_TEMPLATE:-}" ]; then
-    echo "ERROR: AAT_RUNNER_TEMPLATE is not supported with MCP_MODE=optimized batch mode." >&2
-    return 1
-  fi
-
   local -a cmd=(
     uv run
     --with "openai-agents==$AAT_OPENAI_AGENTS_VERSION"
@@ -927,6 +922,10 @@ TOTAL=0
 # Cell C optimized: run all scenarios in a single aat_runner.py call so MCP
 # subprocesses are reused across trials (reuse_mcp_connections).
 if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ]; then
+  if [ -n "${AAT_RUNNER_TEMPLATE:-}" ]; then
+    echo "ERROR: AAT_RUNNER_TEMPLATE is not supported with MCP_MODE=optimized batch mode." >&2
+    exit 1
+  fi
   run_agent_as_tool_batch "$RUN_DIR" || true
   # Merge per-trial latency records into the canonical latencies.jsonl.
   if [ -f "$RUN_DIR/_batch_latencies.jsonl" ]; then

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -714,6 +714,11 @@ run_agent_as_tool_trial() {
 run_agent_as_tool_batch() {
   local out_dir="$1"
 
+  if [ -n "${AAT_RUNNER_TEMPLATE:-}" ]; then
+    echo "ERROR: AAT_RUNNER_TEMPLATE is not supported with MCP_MODE=optimized batch mode." >&2
+    return 1
+  fi
+
   local -a cmd=(
     uv run
     --with "openai-agents==$AAT_OPENAI_AGENTS_VERSION"
@@ -922,7 +927,7 @@ TOTAL=0
 # Cell C optimized: run all scenarios in a single aat_runner.py call so MCP
 # subprocesses are reused across trials (reuse_mcp_connections).
 if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ]; then
-  run_agent_as_tool_batch "$RUN_DIR"
+  run_agent_as_tool_batch "$RUN_DIR" || true
   # Merge per-trial latency records into the canonical latencies.jsonl.
   if [ -f "$RUN_DIR/_batch_latencies.jsonl" ]; then
     cat "$RUN_DIR/_batch_latencies.jsonl" >>"$LATENCY_FILE"

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -1109,11 +1109,24 @@ from datetime import datetime, timezone
 summary_path, config_path, meta_path, latency_path, run_dir, passed, failed, total = sys.argv[1:]
 config = json.loads(pathlib.Path(config_path).read_text(encoding="utf-8"))
 meta = json.loads(pathlib.Path(meta_path).read_text(encoding="utf-8"))
-latencies = [
-    json.loads(line)["latency_seconds"]
+latency_records = [
+    json.loads(line)
     for line in pathlib.Path(latency_path).read_text(encoding="utf-8").splitlines()
     if line.strip()
 ]
+latencies = [
+    record["latency_seconds"]
+    for record in latency_records
+    if isinstance(record.get("latency_seconds"), (int, float))
+]
+mcp_setup_values = [
+    record["mcp_setup_seconds"]
+    for record in latency_records
+    if isinstance(record.get("mcp_setup_seconds"), (int, float))
+    and record["mcp_setup_seconds"] > 0
+]
+mcp_setup_seconds = max(mcp_setup_values) if mcp_setup_values else None
+wall_clock_seconds_total = sum(latencies) + (mcp_setup_seconds or 0)
 
 tool_call_total = 0
 tool_call_trials = 0
@@ -1183,10 +1196,11 @@ summary = {
     "scenarios_completed": int(passed),
     "success_rate": (int(passed) / int(total)) if int(total) else 0.0,
     "failure_count": int(failed),
-    "wall_clock_seconds_total": sum(latencies),
+    "wall_clock_seconds_total": wall_clock_seconds_total,
     "latency_seconds_mean": statistics.mean(latencies) if latencies else None,
     "latency_seconds_p50": percentile(latencies, 50),
     "latency_seconds_p95": percentile(latencies, 95),
+    "mcp_setup_seconds": mcp_setup_seconds,
     "tokens_per_second_mean": None,
     "input_tokens_total": None,
     "output_tokens_total": None,
@@ -1209,6 +1223,8 @@ meta["pass"] = int(passed)
 meta["fail"] = int(failed)
 meta["total_runs"] = int(total)
 meta["run_status"] = summary["run_status"]
+if summary["mcp_setup_seconds"] is not None:
+    meta["mcp_setup_seconds"] = summary["mcp_setup_seconds"]
 pathlib.Path(meta_path).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 PY
 

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -711,6 +711,29 @@ run_agent_as_tool_trial() {
   (cd "$REPO_ROOT" && "${cmd[@]}") >>"$HARNESS_LOG" 2>&1
 }
 
+run_agent_as_tool_batch() {
+  local out_dir="$1"
+
+  local -a cmd=(
+    uv run
+    --with "openai-agents==$AAT_OPENAI_AGENTS_VERSION"
+    --with "mcp[cli]==$AAT_MCP_VERSION"
+    --with "litellm==$AAT_LITELLM_VERSION"
+    python scripts/aat_runner.py
+    --scenarios-glob "$SCENARIOS_GLOB"
+    --trials "$TRIALS"
+    --output-dir "$out_dir"
+    --run-basename "$RUN_BASENAME"
+    --model-id "$MODEL_ID"
+    --mcp-mode "$MCP_MODE"
+    --parallel-tool-calls "$AAT_PARALLEL_TOOL_CALLS"
+  )
+  if [ "$HARNESS_VERBOSE" = "1" ]; then
+    cmd+=(--verbose)
+  fi
+  (cd "$REPO_ROOT" && "${cmd[@]}") >>"$HARNESS_LOG" 2>&1
+}
+
 run_verified_pe_trial() {
   local prompt="$1"
   local out_path="$2"
@@ -896,6 +919,26 @@ FAIL=0
 TOTAL=0
 : >"$LATENCY_FILE"
 
+# Cell C optimized: run all scenarios in a single aat_runner.py call so MCP
+# subprocesses are reused across trials (reuse_mcp_connections).
+if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ]; then
+  run_agent_as_tool_batch "$RUN_DIR"
+  # Merge per-trial latency records into the canonical latencies.jsonl.
+  if [ -f "$RUN_DIR/_batch_latencies.jsonl" ]; then
+    cat "$RUN_DIR/_batch_latencies.jsonl" >>"$LATENCY_FILE"
+  fi
+  # Count pass/fail — RUN_BASENAME prefix safely excludes meta.json etc.
+  for trial_json in "$RUN_DIR/${RUN_BASENAME}"_*.json; do
+    [ -f "$trial_json" ] || continue
+    TOTAL=$((TOTAL + 1))
+    if trial_succeeded "$trial_json"; then
+      PASS=$((PASS + 1))
+    else
+      FAIL=$((FAIL + 1))
+    fi
+  done
+else
+
 for SCENARIO_FILE in "${SCENARIO_FILES[@]}"; do
   SCENARIO_BASENAME="$(basename "$SCENARIO_FILE" .json)"
   PROMPT="$("$PYTHON_BIN" - "$SCENARIO_FILE" <<'PY'
@@ -1039,6 +1082,8 @@ with open(latency_file, "a", encoding="utf-8") as fh:
 PY
   done
 done
+
+fi  # end of per-scenario/per-trial loop (skipped for MCP_MODE=optimized batch path)
 
 "$PYTHON_BIN" - "$SUMMARY_FILE" "$CONFIG_FILE" "$META_FILE" "$LATENCY_FILE" "$RUN_DIR" "$PASS" "$FAIL" "$TOTAL" <<'PY'
 import json

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -926,6 +926,7 @@ if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ]; then
     echo "ERROR: AAT_RUNNER_TEMPLATE is not supported with MCP_MODE=optimized batch mode." >&2
     exit 1
   fi
+  EXPECTED_TOTAL=$(( ${#SCENARIO_FILES[@]} * TRIALS ))
   run_agent_as_tool_batch "$RUN_DIR" || true
   # Merge per-trial latency records into the canonical latencies.jsonl.
   if [ -f "$RUN_DIR/_batch_latencies.jsonl" ]; then
@@ -941,6 +942,13 @@ if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ]; then
       FAIL=$((FAIL + 1))
     fi
   done
+  # Account for trials that never wrote output (e.g. MCP crash before any JSON).
+  MISSING=$(( EXPECTED_TOTAL - TOTAL ))
+  if [ "$MISSING" -gt 0 ]; then
+    echo "WARNING: $MISSING trial(s) missing from batch output — counting as failures" >&2
+    FAIL=$(( FAIL + MISSING ))
+    TOTAL=$(( TOTAL + MISSING ))
+  fi
 else
 
 for SCENARIO_FILE in "${SCENARIO_FILES[@]}"; do

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -308,22 +308,22 @@ def test_batch_mode_rejects_non_optimized_mcp_mode(tmp_path):
     assert asyncio.run(_main(args)) == 2
 
 
-def test_batch_relative_output_dir_no_crash():
-    """Regression: relative --output-dir must not raise ValueError in relative_to()."""
-    from scripts.aat_runner import _main_multi
+def test_batch_output_dir_normalization():
+    """Regression: relative --output-dir must not raise ValueError in relative_to().
+
+    Directly exercises the path arithmetic that crashed before the fix, without
+    calling _main_multi (which would mkdir under the repo and never reach
+    relative_to due to the empty-glob early-return).
+    """
     from pathlib import Path
 
     repo_root = Path(__file__).resolve().parent.parent
-    args = argparse.Namespace(
-        scenarios_glob="nonexistent_xyzzy_*.json",
-        output_dir="benchmarks/cell_C_mcp_optimized/raw/test-run",
-        model_id="x",
-        mcp_mode="optimized",
-        max_turns=30,
-        parallel_tool_calls=False,
-        trials=1,
-        run_basename="batch",
+    # Simulate what _main_multi does: resolve relative arg under repo_root.
+    raw = Path("benchmarks/cell_C_mcp_optimized/raw/test-run")
+    output_dir = repo_root / raw  # normalization step added by the fix
+    out_path = output_dir / "batch_scenario_run01.json"
+    # This is the exact call that raised ValueError before the fix.
+    rel = out_path.relative_to(repo_root)
+    assert rel == Path(
+        "benchmarks/cell_C_mcp_optimized/raw/test-run/batch_scenario_run01.json"
     )
-    # Empty glob → returns 2 without launching MCP servers, but only after
-    # output_dir normalization — proving the ValueError is gone.
-    assert asyncio.run(_main_multi(args, repo_root)) == 2

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -327,3 +327,40 @@ def test_batch_output_dir_normalization():
     assert rel == Path(
         "benchmarks/cell_C_mcp_optimized/raw/test-run/batch_scenario_run01.json"
     )
+
+
+def test_batch_mode_rejects_non_optimized_before_mkdir(tmp_path):
+    """M1 regression: mcp_mode guard must fire before output_dir is created."""
+    from scripts.aat_runner import _main_multi
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    new_subdir = tmp_path / "should_not_be_created"
+    args = argparse.Namespace(
+        scenarios_glob="nonexistent_xyzzy_*.json",
+        output_dir=str(new_subdir),
+        model_id="x",
+        mcp_mode="direct",
+        max_turns=30,
+        parallel_tool_calls=False,
+        trials=1,
+        run_basename="batch",
+    )
+    rc = asyncio.run(_main_multi(args, repo_root))
+    assert rc == 2
+    assert not new_subdir.exists()
+
+
+def test_batch_latency_path_outside_repo_root(tmp_path):
+    """M3 regression: relative_to() fallback must not raise for absolute out-of-repo path."""
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    out_path = tmp_path / "trial_01.json"  # tmp_path is outside repo_root
+    # Reproduce the exact try/except logic from _main_multi latency record construction.
+    try:
+        result = out_path.relative_to(repo_root).as_posix()
+    except ValueError:
+        result = out_path.as_posix()
+    # tmp_path is outside repo_root, so the fallback must kick in.
+    assert result == out_path.as_posix()

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -328,7 +328,9 @@ def test_batch_mode_rejects_zero_trials(tmp_path):
         )
         rc = asyncio.run(_main_multi(args, repo_root))
         assert rc == 2, f"expected rc=2 for trials={bad_trials}, got {rc}"
-        assert not new_subdir.exists(), f"output dir must not be created for trials={bad_trials}"
+        assert (
+            not new_subdir.exists()
+        ), f"output dir must not be created for trials={bad_trials}"
 
 
 def test_batch_output_dir_normalization():

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -268,3 +268,62 @@ def test_runner_threads_litellm_env(monkeypatch):
     assert captured["max_turns"] == 30
     settings = captured["agent_kwargs"]["model_settings"]
     assert settings.kwargs["parallel_tool_calls"] is False
+
+
+def test_batch_mode_requires_output_dir():
+    from scripts.aat_runner import _main
+
+    args = argparse.Namespace(
+        scenarios_glob="data/scenarios/*.json",
+        output_dir=None,
+        prompt=None,
+        output=None,
+        model_id="x",
+        mcp_mode="optimized",
+        max_turns=30,
+        parallel_tool_calls=False,
+        verbose=False,
+        trials=1,
+        run_basename="batch",
+    )
+    assert asyncio.run(_main(args)) == 2
+
+
+def test_batch_mode_rejects_non_optimized_mcp_mode(tmp_path):
+    from scripts.aat_runner import _main
+
+    args = argparse.Namespace(
+        scenarios_glob="nonexistent_xyzzy_*.json",
+        output_dir=str(tmp_path),
+        prompt=None,
+        output=None,
+        model_id="x",
+        mcp_mode="direct",
+        max_turns=30,
+        parallel_tool_calls=False,
+        verbose=False,
+        trials=1,
+        run_basename="batch",
+    )
+    assert asyncio.run(_main(args)) == 2
+
+
+def test_batch_relative_output_dir_no_crash():
+    """Regression: relative --output-dir must not raise ValueError in relative_to()."""
+    from scripts.aat_runner import _main_multi
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    args = argparse.Namespace(
+        scenarios_glob="nonexistent_xyzzy_*.json",
+        output_dir="benchmarks/cell_C_mcp_optimized/raw/test-run",
+        model_id="x",
+        mcp_mode="optimized",
+        max_turns=30,
+        parallel_tool_calls=False,
+        trials=1,
+        run_basename="batch",
+    )
+    # Empty glob → returns 2 without launching MCP servers, but only after
+    # output_dir normalization — proving the ValueError is gone.
+    assert asyncio.run(_main_multi(args, repo_root)) == 2

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -308,6 +308,29 @@ def test_batch_mode_rejects_non_optimized_mcp_mode(tmp_path):
     assert asyncio.run(_main(args)) == 2
 
 
+def test_batch_mode_rejects_zero_trials(tmp_path):
+    """--trials must be >= 1; zero/negative must return rc=2 without creating output dir."""
+    from scripts.aat_runner import _main_multi
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    new_subdir = tmp_path / "should_not_be_created"
+    for bad_trials in (0, -1):
+        args = argparse.Namespace(
+            scenarios_glob="nonexistent_xyzzy_*.json",
+            output_dir=str(new_subdir),
+            model_id="x",
+            mcp_mode="optimized",
+            max_turns=30,
+            parallel_tool_calls=False,
+            trials=bad_trials,
+            run_basename="batch",
+        )
+        rc = asyncio.run(_main_multi(args, repo_root))
+        assert rc == 2, f"expected rc=2 for trials={bad_trials}, got {rc}"
+        assert not new_subdir.exists(), f"output dir must not be created for trials={bad_trials}"
+
+
 def test_batch_output_dir_normalization():
     """Regression: relative --output-dir must not raise ValueError in relative_to().
 

--- a/tests/test_run_experiment_summary.py
+++ b/tests/test_run_experiment_summary.py
@@ -1,0 +1,97 @@
+"""Regression tests for run_experiment.sh summary generation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _extract_summary_python(repo_root: Path) -> str:
+    script = repo_root.joinpath("scripts/run_experiment.sh").read_text(encoding="utf-8")
+    marker = '"$PYTHON_BIN" - "$SUMMARY_FILE"'
+    start = script.index(marker)
+    heredoc_start = script.index("<<'PY'\n", start) + len("<<'PY'\n")
+    heredoc_end = script.index("\nPY\n", heredoc_start)
+    return script[heredoc_start:heredoc_end]
+
+
+def _base_config(summary_path: Path) -> dict:
+    return {
+        "schema_version": "v1",
+        "wandb_entity": "assetopsbench-smartgrid",
+        "project_name": "assetopsbench-smartgrid",
+        "run_name": "test-run",
+        "git_sha": "test-sha",
+        "benchmark_config_path": "configs/aat_mcp_optimized.env",
+        "benchmark_summary_path": summary_path.as_posix(),
+        "wandb_run_url": None,
+        "experiment_family": "exp1_mcp_overhead",
+        "contributing_experiments": ["exp1_mcp_overhead"],
+        "experiment_cell": "C",
+        "orchestration_mode": "agent_as_tool",
+        "mcp_mode": "optimized",
+        "scenario_set_name": "test-set",
+        "scenario_set_hash": "test-hash",
+        "model_id": "openai/Llama-3.1-8B-Instruct",
+        "host_name": "test-host",
+        "gpu_type": "test-gpu",
+        "slurm_job_id": "test-job",
+    }
+
+
+def test_summary_includes_batch_mcp_setup_once(tmp_path):
+    """Cell C batch summaries include one-time MCP setup without skewing p50/p95."""
+    repo_root = Path(__file__).resolve().parent.parent
+    summary_py = _extract_summary_python(repo_root)
+
+    summary_path = tmp_path / "summary.json"
+    config_path = tmp_path / "config.json"
+    meta_path = tmp_path / "meta.json"
+    latency_path = tmp_path / "latencies.jsonl"
+    run_dir = tmp_path / "raw" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    config_path.write_text(
+        json.dumps(_base_config(summary_path), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    meta_path.write_text(json.dumps({"started_at": "now"}) + "\n", encoding="utf-8")
+    latency_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"latency_seconds": 2.0, "mcp_setup_seconds": 5.0}),
+                json.dumps({"latency_seconds": 3.0, "mcp_setup_seconds": 5.0}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            summary_py,
+            str(summary_path),
+            str(config_path),
+            str(meta_path),
+            str(latency_path),
+            str(run_dir),
+            "2",
+            "0",
+            "2",
+        ],
+        check=True,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    assert summary["wall_clock_seconds_total"] == 10.0
+    assert summary["latency_seconds_mean"] == 2.5
+    assert summary["latency_seconds_p50"] == 2.0
+    assert summary["latency_seconds_p95"] == 3.0
+    assert summary["mcp_setup_seconds"] == 5.0
+    assert meta["mcp_setup_seconds"] == 5.0

--- a/tests/test_run_experiment_summary.py
+++ b/tests/test_run_experiment_summary.py
@@ -95,3 +95,50 @@ def test_summary_includes_batch_mcp_setup_once(tmp_path):
     assert summary["latency_seconds_p95"] == 3.0
     assert summary["mcp_setup_seconds"] == 5.0
     assert meta["mcp_setup_seconds"] == 5.0
+
+
+def test_summary_records_null_mcp_setup_when_absent(tmp_path):
+    """Non-batch summaries keep the setup field present with a null value."""
+    repo_root = Path(__file__).resolve().parent.parent
+    summary_py = _extract_summary_python(repo_root)
+
+    summary_path = tmp_path / "summary.json"
+    config_path = tmp_path / "config.json"
+    meta_path = tmp_path / "meta.json"
+    latency_path = tmp_path / "latencies.jsonl"
+    run_dir = tmp_path / "raw" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    config_path.write_text(
+        json.dumps(_base_config(summary_path), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    meta_path.write_text(json.dumps({"started_at": "now"}) + "\n", encoding="utf-8")
+    latency_path.write_text(
+        json.dumps({"latency_seconds": 2.0}) + "\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            summary_py,
+            str(summary_path),
+            str(config_path),
+            str(meta_path),
+            str(latency_path),
+            str(run_dir),
+            "1",
+            "0",
+            "1",
+        ],
+        check=True,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    assert summary["wall_clock_seconds_total"] == 2.0
+    assert summary["mcp_setup_seconds"] is None
+    assert meta["mcp_setup_seconds"] is None


### PR DESCRIPTION
## Summary

Implements Cell C of Experiment 1 (MCP optimized) — closes #31.

Cell C adds two optimizations over Cell B (MCP baseline):

- **`parallel_tool_calls=true`** (`configs/aat_mcp_optimized.env`): model batches multiple tool calls per turn, reducing MCP round-trips. Driven entirely through config (`AAT_PARALLEL_TOOL_CALLS=true`) so `run_experiment.sh` passes it cleanly via `--parallel-tool-calls`.

- **MCP connection reuse** (`scripts/aat_runner.py`, `scripts/run_experiment.sh`): new `--scenarios-glob / --trials / --output-dir / --run-basename` batch mode in `aat_runner.py`. When `MCP_MODE=optimized`, `run_experiment.sh` calls the runner once for all scenarios instead of per-trial, keeping all 4 MCP subprocesses alive across the full run. Eliminates $N_{scenarios} \times N_{trials} \times 4$ subprocess start/stop cycles (e.g. 2 scenarios × 3 trials = 24 → 4 subprocess starts).

## Changes

| File | What changed |
|------|-------------|
| `configs/aat_mcp_optimized.env` | Add `AAT_PARALLEL_TOOL_CALLS=true`; wire `VLLM_ENABLE_AUTO_TOOL_CHOICE` and `VLLM_TOOL_CALL_PARSER` |
| `scripts/aat_runner.py` | Batch mode (`--scenarios-glob`); simplify optimized dispatch; add `scenario_file` to `runner_meta` |
| `scripts/run_experiment.sh` | Add `run_agent_as_tool_batch()`; dispatch optimized AaT via batch path; merge `_batch_latencies.jsonl` into `latencies.jsonl` |

## Backward compatibility

- `--prompt / --output` single-trial path is **unchanged** — Cells A, B, Y, Z unaffected
- `trial_succeeded()` and `latencies.jsonl` format are **unchanged**
- `cache_tools_list=True` already set in `aat_tools_mcp.py` for all cells (no change)

## Test plan

- [x] `bash -n scripts/run_experiment.sh` → syntax OK
- [x] `python scripts/aat_runner.py --help` → shows `--scenarios-glob`, `--trials`, `--output-dir`, `--run-basename`, `--mcp-mode optimized`
- [x] `python -c "import ast; ast.parse(open('scripts/aat_runner.py').read())"` → syntax OK
- [ ] `DRY_RUN=1 bash scripts/run_experiment.sh configs/aat_mcp_optimized.env` — run on Insomnia (requires vLLM)
- [ ] Full Cell C smoke artifact: `sbatch scripts/run_experiment.sh configs/aat_mcp_optimized.env` on Insomnia — will commit `benchmarks/cell_C_mcp_optimized/raw/<run_id>/` in a follow-up commit

Smoke artifact pending Insomnia run. `(Cell B latency) - (Cell C latency)` quantifies the MCP overhead recovery.