### PR TITLE
Pre-W5 capture pipeline hardening (#135, #132)

### DIFF
--- a/configs/aat_direct.env
+++ b/configs/aat_direct.env
@@ -31,7 +31,11 @@ SCENARIO_DOMAIN_SCOPE="multi_domain"
 MODEL_PROVIDER="vllm"
 SERVING_STACK="insomnia_vllm"
 QUANTIZATION_MODE="fp16"
-MAX_MODEL_LEN=8192
+# 32768 matches the repo's canonical benchmark-context lane (configs/example_*.env,
+# configs/experiment2/*.env). Smoke configs (configs/aat_*_smoke.env) stay at
+# 8192. See #135 for context: Cell A run 8979314 hit a replay context-window
+# exceeded path at 8192 → 8193 input tokens; 32768 is the proven replay headroom.
+MAX_MODEL_LEN=32768
 TEMPERATURE=0.0
 MAX_TOKENS=0
 

--- a/configs/aat_mcp_baseline.env
+++ b/configs/aat_mcp_baseline.env
@@ -29,7 +29,8 @@ SCENARIO_DOMAIN_SCOPE="multi_domain"
 MODEL_PROVIDER="vllm"
 SERVING_STACK="insomnia_vllm"
 QUANTIZATION_MODE="fp16"
-MAX_MODEL_LEN=8192
+# 32768 matches the repo's canonical benchmark-context lane. See #135.
+MAX_MODEL_LEN=32768
 TEMPERATURE=0.0
 MAX_TOKENS=0
 

--- a/configs/aat_mcp_optimized.env
+++ b/configs/aat_mcp_optimized.env
@@ -28,7 +28,8 @@ SCENARIO_DOMAIN_SCOPE="multi_domain"
 MODEL_PROVIDER="vllm"
 SERVING_STACK="insomnia_vllm"
 QUANTIZATION_MODE="fp16"
-MAX_MODEL_LEN=8192
+# 32768 matches the repo's canonical benchmark-context lane. See #135.
+MAX_MODEL_LEN=32768
 TEMPERATURE=0.0
 MAX_TOKENS=0
 

--- a/configs/example_baseline.env
+++ b/configs/example_baseline.env
@@ -42,7 +42,8 @@ SCENARIO_DOMAIN_SCOPE="multi_domain"
 MODEL_PROVIDER="vllm"
 SERVING_STACK="insomnia_vllm"
 QUANTIZATION_MODE="fp16"
-MAX_MODEL_LEN=8192
+# 32768 matches the repo's canonical benchmark-context lane. See #135.
+MAX_MODEL_LEN=32768
 TEMPERATURE=0.0
 MAX_TOKENS=0
 JUDGE_MODEL=""

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -230,6 +230,32 @@ for cmd in python3 curl uv; do
   fi
 done
 
+# Resolve the GPU model name once at job start so config.json / summary.json
+# stamp the actual hardware (e.g. "NVIDIA RTX A6000", "NVIDIA L40S") instead
+# of "unknown". nvidia-smi does NOT honor CUDA_VISIBLE_DEVICES on its own, so
+# we filter explicitly. Falls back to "unknown" if nvidia-smi is missing
+# (login-node / non-GPU runs, dry runs) or the query fails. Caller-provided
+# GPU_TYPE wins so smoke / replay paths can override. (#132)
+#
+# Quirk: nvidia-smi prints diagnostic messages like "No devices were found"
+# to STDOUT and exits non-zero, so we must check the exit code rather than
+# only redirecting stderr — otherwise an error message lands as the GPU
+# name in the JSON.
+if [ -z "${GPU_TYPE:-}" ]; then
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    if _gpu_name="$(nvidia-smi --id="${CUDA_VISIBLE_DEVICES:-0}" \
+        --query-gpu=name --format=csv,noheader 2>/dev/null)"; then
+      GPU_TYPE="$(printf '%s\n' "$_gpu_name" \
+          | head -1 \
+          | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    fi
+    unset _gpu_name
+  fi
+  GPU_TYPE="${GPU_TYPE:-unknown}"
+fi
+export GPU_TYPE
+echo "GPU type: $GPU_TYPE"
+
 # Support both WatsonX env spellings across repos/tooling.
 if [ -n "${WATSONX_API_KEY:-}" ] && [ -z "${WATSONX_APIKEY:-}" ]; then
   export WATSONX_APIKEY="$WATSONX_API_KEY"


### PR DESCRIPTION
## Summary

Two W5-blocking pre-capture fixes bundled — both small, both share the same deadline (W5 captures for #25 reruns / #36 / #66 / #85 start tonight, 2026-04-28).

## #135 — bump `MAX_MODEL_LEN` from 8192 to 32768

Cell A run `8979314` hit a replay context-window-exceeded path at 8193 input tokens vs the 8192 cap. 32768 matches the repo's existing benchmark-context lane (`configs/example_*.env`, `configs/experiment2/*.env`), not 16384 — so it stays consistent with what the rest of the team's runs already use.

**Bumped (canonical):**
- `configs/aat_direct.env` (Cell A)
- `configs/aat_mcp_baseline.env` (Cell B)
- `configs/aat_mcp_optimized.env` (Cell C — lane2 PR #129 rebases pick this up)
- `configs/example_baseline.env` (template)

**Kept at 8192 (smoke-only):**
- `configs/aat_direct_smoke.env`
- `configs/aat_mcp_baseline_smoke.env`
- `configs/aat_mcp_baseline_upstream_smoke.env`
- `configs/issue3_aob_harness_smoke.env`

## #132 — capture `gpu_type` from nvidia-smi into `config.json` + `summary.json`

`summary.json:gpu_type` was hardcoded to `os.environ.get('GPU_TYPE', 'unknown')` and nothing populated `GPU_TYPE` — every prior run shipped with `gpu_type: 'unknown'`. Fix in `scripts/run_experiment.sh`:

```bash
if [ -z "${GPU_TYPE:-}" ]; then
  if command -v nvidia-smi >/dev/null 2>&1; then
    if _gpu_name="$(nvidia-smi --id="${CUDA_VISIBLE_DEVICES:-0}" \
        --query-gpu=name --format=csv,noheader 2>/dev/null)"; then
      GPU_TYPE="$(printf '%s\n' "$_gpu_name" | head -1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
    fi
    unset _gpu_name
  fi
  GPU_TYPE="${GPU_TYPE:-unknown}"
fi
export GPU_TYPE
echo "GPU type: $GPU_TYPE"
```

Verified locally:

| Scenario | Result |
|---|---|
| nvidia-smi succeeds | `GPU_TYPE=NVIDIA GeForce RTX 3070` (laptop test) |
| nvidia-smi exits non-zero (--id=9999 → "No devices were found", exit 6) | `GPU_TYPE=unknown` |
| caller pre-sets `GPU_TYPE=user-override` | `GPU_TYPE=user-override` (caller wins) |

**Quirk worth flagging in the diff comment:** nvidia-smi prints diagnostic messages like `"No devices were found"` to **stdout** (not stderr) and exits non-zero. The check uses the exit code rather than only redirecting stderr — otherwise a `nvidia-smi` failure would silently land the error string as the GPU name in `summary.json`.

Filtering with `--id="${CUDA_VISIBLE_DEVICES:-0}"` matters on multi-GPU nodes where Slurm allocates one GPU but nvidia-smi doesn't honor `CUDA_VISIBLE_DEVICES`.

## Test plan

- [x] `bash -n scripts/run_experiment.sh` clean.
- [x] All three GPU_TYPE paths (nvidia-smi succeeds / fails / caller-override) verified locally.
- [x] `grep MAX_MODEL_LEN` audit confirms only the four canonical/template configs were bumped; smoke configs unchanged.
- [ ] **(Reviewer)** Spot-check that the first W5 run's `summary.json` shows `gpu_type: "NVIDIA RTX A6000"` (or whatever the Slurm-allocated card is) and `context_window: 32768`.

## Closes

- #135 — MAX_MODEL_LEN bump
- #132 — gpu_type capture

## Linked / merge-order notes

- PR #129 (Lane 2) rebases on this — the `aat_mcp_optimized.env` change here will combine cleanly with the Lane 2 `EXTRA_VLLM_ARGS` line.
- PR #134 (Akshat, Cell C batch) doesn't touch these lines.