### PR TITLE
Update Insomnia runbook and profiling docs after PR #143 / #144

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ models/
 # Profiling traces (large)
 profiling/traces/
 *.pt.trace.json
+*.pt.trace.json.gz
 
 # WandB
 wandb/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,122 @@
 # Changelog
 
+## 2026-04-28
+
+### Documentation
+
+- Expanded `docs/insomnia_runbook.md` with operational gaps surfaced after the
+  Apr 27 PR `#143` / `#144` landings and the Apr 26 worktree-perms incident:
+  - New "Filesystem topology" section with ASCII tree of
+    `/insomnia001/depts/edu/users/team13/` (canonical checkout, `worktrees/`
+    sibling, `AssetOpsBench/` upstream, `.venv-insomnia/`), plus `quota -s`
+    and `df -h` storage-headroom commands.
+  - New "Worktrees on Insomnia" subsection: three-flavor `git worktree add`
+    recipe (existing local branch, remote-only branch via `-b`, brand-new
+    branch off `team13/main`) with explicit warning against passing a
+    remote-tracking ref directly (which detaches HEAD). Shared-venv guidance,
+    `worktrees/` parent perms gotcha (`drwxrws---` required or teammates
+    can't create new worktrees), and `git worktree remove --force`
+    data-loss warning.
+  - Foreground vLLM example split into "completions-only sanity serve" vs
+    "tool-call serve for any benchmark / AaT / PE reproduction."
+    `run_experiment.sh:90-104` defaults `VLLM_ENABLE_AUTO_TOOL_CHOICE=1`
+    and selects a model-family parser; the top-level Cell A / Cell B
+    configs pin those values explicitly, while `configs/experiment2/*.env`,
+    `configs/aat_mcp_optimized.env`, and the example configs inherit the
+    defaults. Manual reproductions need
+    `--enable-auto-tool-choice --tool-call-parser <parser>` regardless of
+    cell; the recipe now sources the target config so `MAX_MODEL_LEN`
+    matches what the harness expects (`32768` for Cell Y/Z PE configs;
+    `8192` for current Cell A/B AaT configs) instead of hard-coding `8192`,
+    AND re-applies the same `${VAR:-default}` shell defaults that
+    `run_experiment.sh:90-104` would (otherwise sourcing a Cell Y config
+    leaves `VLLM_SERVED_MODEL_NAME`, `VLLM_ENABLE_AUTO_TOOL_CHOICE`, and
+    `VLLM_TOOL_CALL_PARSER` empty and the manual launch fails on argument
+    validation).
+  - vLLM 0.19.0 torch profiler change documented across the full doc/script
+    cascade: `VLLM_TORCH_PROFILER_DIR` env var dropped, replaced by
+    `--profiler-config '{"profiler":"torch","torch_profiler_dir":"..."}'`
+    (absolute path, `run_experiment.sh:783-785`). `docs/insomnia_runbook.md`
+    Debugging section, `docs/runbook.md` § 4.3, `profiling/README.md`
+    PyTorch-Profiler section, and `profiling/scripts/run_vllm_torch_profile.sh`
+    header comments + error messages all updated. Canonical capture route is
+    now `TORCH_PROFILE=1 bash scripts/run_experiment.sh <config>`; the manual
+    foreground recipe is documented for ad-hoc debugging only and now warns
+    against env-prefix overrides (cell configs assign `LAUNCH_VLLM=1`
+    unconditionally, which clobbers `LAUNCH_VLLM=0` env values when the
+    script sources the config) — recommended targets are
+    `scripts/replay_scenarios.sh` or a direct `curl` against the foreground
+    server, with a temp-config copy reserved for full-harness runs.
+    `scripts/vllm_serve.sh` does not
+    currently inject `--profiler-config`, flagged in `profiling/README.md`
+    for future patch. Profiler artifact references updated from
+    `pt.trace.json` to the actual vLLM 0.19 form `*.pt.trace.json.gz`
+    (gzipped); `chrome://tracing` requires `gunzip -k` first,
+    `https://ui.perfetto.dev` accepts the `.gz` directly. `.gitignore`
+    extended to cover `*.pt.trace.json.gz` alongside the existing
+    `*.pt.trace.json` and `profiling/traces/` patterns.
+  - `profiling/README.md` § Status replaced (was "Apr 14, 2026" stub
+    documenting "first profiling runs scheduled for W3" — superseded by
+    actual proof runs in `docs/validation_log.md`). New text points to
+    `docs/validation_log.md` for capture provenance and
+    `docs/insomnia_runbook.md` for operational notes; notebook input
+    dependencies (`latencies.jsonl`, `nvidia_smi.csv`) retained.
+  - Manual profiler ad-hoc recipe rewritten to avoid the `LAUNCH_VLLM=1`
+    config-clobber footgun: cell configs assign `LAUNCH_VLLM=1` (not
+    `${LAUNCH_VLLM:-1}`), so an env-prefix `LAUNCH_VLLM=0` is overwritten
+    when `run_experiment.sh` sources the config. Doc now recommends
+    targeting `scripts/replay_scenarios.sh <bench-run-dir> direct` (skips
+    server launch, replays against existing `LITELLM_BASE_URL`) or a direct
+    `curl /v1/chat/completions` probe; the only safe full-harness path is
+    a temp config copy with `LAUNCH_VLLM=0` and `TORCH_PROFILE=0` appended
+    after the original assignment.
+  - `scripts/run_exp1_ab_capture.sh` stale `pt.trace.json` references
+    (lines 34, 128) updated to `*.pt.trace.json.gz` with explicit
+    perfetto/gunzip guidance, matching the doc cascade.
+  - `profile_meta.json` "notes" field (emitted by
+    `profiling/scripts/run_vllm_torch_profile.sh`) now mirrors the README
+    gzip wording so a shared trace artifact is self-explanatory without
+    the README.
+  - `docs/runbook.md` § 2.2 venv-recovery pointer fixed: replaced stale
+    quoted heading "If you need a newer vLLM" (does not exist in
+    `insomnia_runbook.md`) with the actual fragment
+    `#recreate-the-shared-env-when-needed`.
+  - New "Trial output contract (PR `#143`)" subsection: per-trial JSONs now
+    carry `data["scenario"]` (full source scenario JSON object, with
+    `scenario.id` consumed by Notebook 03) and `data["success"]` (preserved
+    if runner wrote a bool, otherwise derived from history step-failure
+    signals + answer truthiness). Default `TRIALS=3`. Documented retrofit
+    invocations: `python3 scripts/backfill_canonical_scenario.py [--apply]
+    [--cell A|B|C|Y|Z]` — script walks `benchmarks/cell_<X>/raw/<run_id>/`
+    from the repo root, no positional capture-dir.
+  - Email-notifications section rewritten to make
+    `MAIL_USER="${USER}@columbia.edu"` the default pattern, with a concrete
+    `sbatch ... scripts/run_experiment.sh configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env`
+    invocation.
+  - New "Excluding bad nodes" section with the `--exclude=ins082` pattern for
+    routing around individual nodes that surface
+    `RuntimeError: CUDA unknown error - this may be due to an incorrectly set up environment ...`
+    (multi-comma form for multiple bad nodes; RCS ticket advice if a node
+    stays bad >1 day).
+  - Compute-node hostname pattern (`ins0XX`) and live read commands
+    (`hostname`, `$SLURMD_NODENAME`) called out near the inference-test recipe.
+  - GPU-type list pinned to live `sinfo -o '%P %.6D %.20G %N'` output instead
+    of relying on the static A6000/L40/L40S/H100 enumeration.
+  - `requirements-insomnia.txt` overlay relationship explained
+    (`-r requirements.txt` head-line); pin updates: `mcp[cli]==1.27.0`
+    (was `>=1.26.0`), `openai-agents==0.14.5` added.
+  - `## See also` cross-links extended to `runbook.md` § WandB,
+    `governance/model_registry.yaml`, `scripts/run_experiment.sh`, and
+    `scripts/backfill_canonical_scenario.py`.
+  - `docs/runbook.md` last-updated bumped to 2026-04-28; obsolete
+    `../hpml-worktree-<branch>` worktree snippet replaced with cross-link to
+    `insomnia_runbook.md#worktrees-on-insomnia`; profiling cross-links
+    rewritten with explicit fragments
+    (`#pytorch-profiler-via-vllms-built-in-endpoints`,
+    `#debugging-foreground-vllm`).
+  - Last-updated dates bumped to 2026-04-28 in `docs/insomnia_runbook.md`,
+    `docs/runbook.md`, and `profiling/README.md`.
+
 ## 2026-04-27
 
 ### Config / Docs

--- a/docs/insomnia_runbook.md
+++ b/docs/insomnia_runbook.md
@@ -1,6 +1,6 @@
 # Insomnia Runbook
 
-*Last updated: 2026-04-24*
+*Last updated: 2026-04-28*
 *Owner: Aaron Fan (af3623)*
 
 Verified setup notes, gotchas, and debugging recipes for the Columbia Insomnia
@@ -19,6 +19,91 @@ setup, day-to-day cell submission, troubleshooting decision tree). This
 file (`insomnia_runbook.md`) is the cluster-specific gotcha reference that
 `runbook.md` links into. Start with `runbook.md` when onboarding;
 come back here when you hit a weird Slurm/CUDA/vLLM behavior.
+
+## Filesystem topology
+
+Everything Team 13 owns on Insomnia lives under a single shared parent directory.
+The canonical layout is:
+
+```
+/insomnia001/depts/edu/users/team13/
+├── hpml-assetopsbench-smart-grid-mcp/   # canonical team checkout (root worktree on main)
+│   ├── .venv-insomnia/                  # shared Python 3.11 env (uv-managed)
+│   ├── scripts/                         # run_experiment.sh, vllm_serve.sh, setup_insomnia.sh, ...
+│   ├── benchmarks/                      # Exp 1/2 capture trees (per-run JSONs, harness.log, vllm.log)
+│   ├── profiling/traces/                # Torch profiler outputs (per RUN_ID)
+│   └── logs/                            # exp_<jobid>.out Slurm output
+├── worktrees/<branch-slug>/             # per-branch git worktrees, sibling of canonical checkout
+└── AssetOpsBench/                       # upstream IBM clone (read-only, owner-only mode)
+```
+
+The parent directory is `drwxrws---` (`770 + setgid`) owned by `wax1:somedu`. The
+setgid bit makes new files inherit the `somedu` group; see "Group permissions"
+below for the `umask 002` convention that keeps everything group-writable.
+
+The upstream `AssetOpsBench/` clone is intentionally left at owner-only mode —
+do not chmod it. If you need a local change there, branch your own clone outside
+the team root rather than mutating the shared copy.
+
+To check your storage headroom on the edu scratch volume:
+
+```bash
+quota -s                                      # per-user usage and limits
+df -h /insomnia001/depts/edu/users/team13     # team scratch capacity
+```
+
+### Worktrees on Insomnia
+
+Per-branch work lives in `/insomnia001/depts/edu/users/team13/worktrees/<branch-slug>/`,
+**sibling of the canonical checkout, not nested under it**. Create a worktree from
+inside the canonical checkout:
+
+```bash
+cd /insomnia001/depts/edu/users/team13/hpml-assetopsbench-smart-grid-mcp
+git fetch team13
+
+# Local branch already exists:
+git worktree add ../worktrees/<slug> <local-branch>
+
+# Remote branch exists but no local branch yet — create the local branch in
+# the worktree so commits aren't detached:
+git worktree add -b <local-branch> ../worktrees/<slug> team13/<remote-branch>
+
+# Brand-new branch off team13/main:
+git worktree add -b <new-branch> ../worktrees/<slug> team13/main
+```
+
+**Do not pass a remote-tracking ref directly** (e.g.
+`git worktree add ../worktrees/<slug> team13/foo`). Git interprets that as a
+detached-HEAD checkout of the remote ref — commits land detached and `git push`
+targets get murky. Always either reference an existing local branch or use
+`-b <local-branch>` to create one.
+
+Worktrees share the canonical `.venv-insomnia/` (one venv, multiple working trees).
+`cd ../worktrees/<slug> && source ../../hpml-assetopsbench-smart-grid-mcp/.venv-insomnia/bin/activate`
+works fine; do not create a per-worktree venv.
+
+**Perms gotcha:** the `worktrees/` parent itself must be `drwxrws---` (group-writable
++ setgid), or teammates cannot create new worktrees under it. If `git worktree add`
+fails with "Permission denied" on the parent, ask the directory owner to fix:
+
+```bash
+chmod g+rwxs /insomnia001/depts/edu/users/team13/worktrees
+```
+
+Submodules don't auto-populate in new worktrees. If the project pulls in submodules
+(none today, but applies if added), run `git submodule update --init` after
+`git worktree add`.
+
+When done with a worktree, remove it from the canonical checkout:
+
+```bash
+cd /insomnia001/depts/edu/users/team13/hpml-assetopsbench-smart-grid-mcp
+git worktree remove ../worktrees/<slug>
+```
+
+`git worktree remove --force` deletes untracked files inside the worktree without
+warning; copy out anything you want to keep first.
 
 ## Slurm: account, partition, QoS
 
@@ -274,13 +359,55 @@ That base now also carries the portable AssetOpsBench PE-client slice used by
 our repo-local Self-Ask PE / Verified PE runners:
 
 - `litellm==1.81.13`
-- `mcp[cli]>=1.26.0`
+- `mcp[cli]==1.27.0`
+- `openai-agents==0.14.5`
+
+`requirements-insomnia.txt` overlays the cluster-only stack on top of the base
+file via `-r requirements.txt` at its head, so a single
+`uv pip install -r requirements-insomnia.txt` resolves both layers together.
 
 So if an Insomnia proof run dies with `ModuleNotFoundError: litellm` or
 `ModuleNotFoundError: mcp`, the fix is usually not a bespoke `pip install` in
 the moment — it is to refresh the shared env against
 `requirements-insomnia.txt`. The matching model/runtime contract is now also
 captured in [governance/model_registry.yaml](governance/model_registry.yaml).
+
+### Trial output contract (PR #143)
+
+`scripts/run_experiment.sh` post-processes every per-trial JSON to inject two
+canonical fields:
+
+- `data["scenario"]` — the **full source scenario JSON object** (with
+  `scenario.id` as the key Notebook 03 consumes), copied from the scenario
+  file referenced in `latencies.jsonl`. Already-populated objects with an
+  `id` key are left alone (idempotent).
+- `data["success"]` — boolean or `None`. If the runner already wrote a bool,
+  it is preserved as-is. Otherwise `_derive_success` walks `history` first
+  (falls back to `trajectory`); any failed step → `False`; if neither
+  history/trajectory nor an answer exists → `None`; otherwise → `bool(answer)`.
+  **Not** derived from harness exit status or judge pass rate.
+
+Default `TRIALS=3`. Older captures predating PR #143 are missing these fields
+and get classified as `legacy` by Notebook 03's `canonical_rows` gate. Retrofit
+from the repo root:
+
+```bash
+# Dry-run sweep across all cells:
+python3 scripts/backfill_canonical_scenario.py
+
+# Apply to all cells:
+python3 scripts/backfill_canonical_scenario.py --apply
+
+# Apply to one cell only (A/B/C/Y/Z):
+python3 scripts/backfill_canonical_scenario.py --apply --cell B
+
+# Apply to a subset (--cell is repeatable via argparse action="append"):
+python3 scripts/backfill_canonical_scenario.py --apply --cell B --cell Y
+```
+
+The script has no positional capture-dir argument — it walks
+`benchmarks/cell_<X>/raw/<run_id>/` from the repo root for each selected cell.
+Pass `--repo-root <path>` to point at a non-default checkout.
 
 The repo-standard local Llama checkpoint revision is:
 
@@ -349,11 +476,75 @@ export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 # Quick sanity check (should print version, not crash)
 python -c "import vllm; print(vllm.__version__)"
 
-# Foreground vLLM
+# Completions-only sanity serve (raw /v1/completions smoke tests only — do NOT
+# use this as the basis for any captured benchmark / AaT / PE run):
 python -u -m vllm.entrypoints.openai.api_server \
     --model models/Llama-3.1-8B-Instruct \
+    --served-model-name Llama-3.1-8B-Instruct \
     --port 8000 --max-model-len 8192 --dtype float16
 ```
+
+**Use the tool-call serve for any benchmark / AaT / PE reproduction.** As of
+PR #144, `scripts/run_experiment.sh` defaults `VLLM_ENABLE_AUTO_TOOL_CHOICE=1`
+and selects a model-family parser automatically (`llama3_json` for the team's
+pinned Llama-3.1-8B-Instruct; see `run_experiment.sh:90-104`). The top-level
+Cell A / Cell B configs (`configs/aat_direct.env`, `configs/aat_mcp_baseline.env`,
+their `_smoke` and `_upstream_smoke` siblings) pin the values explicitly;
+`configs/experiment2/*.env`, `configs/aat_mcp_optimized.env`, and the example
+configs inherit the defaults. The wired flags become
+`--enable-auto-tool-choice --tool-call-parser <parser>` (see
+`run_experiment.sh:759-776`). Reproducing the serve manually without these
+flags hits `tool_choice=auto requires --enable-auto-tool-choice` the moment
+the harness makes its first tool-call request, regardless of cell.
+
+The matching manual recipe — **source the target config first** so
+`MAX_MODEL_LEN` matches what the harness expects (`32768` for Cell Y/Z PE
+configs; `8192` for current Cell A/B AaT configs). Many configs intentionally
+omit `VLLM_SERVED_MODEL_NAME`, `VLLM_ENABLE_AUTO_TOOL_CHOICE`, and
+`VLLM_TOOL_CALL_PARSER` because they inherit defaults from
+`scripts/run_experiment.sh:90-104`. Apply those defaults yourself before
+launching:
+
+```bash
+# Pull MAX_MODEL_LEN, VLLM_MODEL_PATH, etc. from the cell's config.
+set -a; source configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env; set +a
+
+# Apply the same defaults run_experiment.sh would. Adjust the parser case
+# block if you point at a non-Llama-3 model.
+VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_MODEL_PATH="${VLLM_MODEL_PATH:-models/Llama-3.1-8B-Instruct}"
+VLLM_SERVED_MODEL_NAME="${VLLM_SERVED_MODEL_NAME:-$(basename "$VLLM_MODEL_PATH")}"
+VLLM_ENABLE_AUTO_TOOL_CHOICE="${VLLM_ENABLE_AUTO_TOOL_CHOICE:-1}"
+case "${MODEL_ID:-}" in
+  *llama-3*|*Llama-3*|*llama3*|*Llama3*) _DEFAULT_PARSER=llama3_json ;;
+  *qwen*|*Qwen*) _DEFAULT_PARSER=hermes ;;
+  *mistral*|*Mistral*) _DEFAULT_PARSER=mistral ;;
+  *) _DEFAULT_PARSER=llama3_json ;;
+esac
+VLLM_TOOL_CALL_PARSER="${VLLM_TOOL_CALL_PARSER:-$_DEFAULT_PARSER}"
+
+python -u -m vllm.entrypoints.openai.api_server \
+    --model "$VLLM_MODEL_PATH" \
+    --served-model-name "$VLLM_SERVED_MODEL_NAME" \
+    --port "$VLLM_PORT" --max-model-len "$MAX_MODEL_LEN" --dtype float16 \
+    --enable-auto-tool-choice --tool-call-parser "$VLLM_TOOL_CALL_PARSER"
+```
+
+Hard-coding `--max-model-len 8192` here is a known gotcha: a Cell Y/Z replay
+will overflow the 8192 context window and either truncate or crash partway
+through (see `docs/validation_log.md` for prior occurrences).
+
+**Torch profiler flag changed.** vLLM 0.19.0 dropped the
+`VLLM_TORCH_PROFILER_DIR` env var. Profiling is now enabled via a CLI flag with
+an absolute path:
+
+```bash
+--profiler-config '{"profiler":"torch","torch_profiler_dir":"/abs/path/to/profiling/traces/<run-id>_torch"}'
+```
+
+`run_experiment.sh:783-785` builds this automatically when `TORCH_PROFILE=1`;
+manual reproductions need to construct it explicitly. Output traces land under
+`profiling/traces/${RUN_ID}_torch/`.
 
 Expect 1-3 minutes to "Uvicorn running on http://0.0.0.0:8000" — Python
 imports take ~30 seconds, model load to GPU another minute, CUDA graph capture
@@ -390,7 +581,16 @@ If you're SSHing from Ghostty, either start the SSH session with
 launching `tmux`.
 
 To test inference, open a second SSH session and `curl` against the compute
-node hostname (visible in your interactive shell prompt, e.g. `ins080`):
+node hostname. GPU compute nodes follow the `ins0XX` pattern (e.g. `ins080`,
+`ins082`, `ins103`). Read your assigned node from the interactive shell prompt,
+or programmatically:
+
+```bash
+hostname              # e.g. ins080
+echo "$SLURMD_NODENAME"   # same, set inside Slurm jobs
+```
+
+Then from a second login session:
 
 ```bash
 ssh <UNI>@insomnia.rcs.columbia.edu
@@ -401,34 +601,62 @@ curl http://ins080:8000/v1/completions \
 
 ## Email notifications on job state
 
-Queue waits can be hours, so always attach mail flags when you submit. Pattern:
+Queue waits can be hours. **Always attach mail flags when you submit** — the
+default invocation pattern across the team is:
 
 ```bash
-sbatch \
-    --mail-type=BEGIN,END,FAIL \
-    --mail-user=<UNI>@columbia.edu \
-    scripts/vllm_serve.sh
+# One-time setup in ~/.bashrc on Insomnia:
+export MAIL_USER="${USER}@columbia.edu"
+```
+
+Then every submit looks like:
+
+```bash
+sbatch --mail-type=BEGIN,END,FAIL --mail-user="$MAIL_USER" \
+    scripts/run_experiment.sh configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env
 ```
 
 For interactive `srun` sessions:
 
 ```bash
-srun \
-    -A edu -p short --qos=short \
-    --gres=gpu:A6000:1 \
-    --time=00:30:00 \
-    --mail-type=BEGIN,END,FAIL \
-    --mail-user=<UNI>@columbia.edu \
+srun -A edu -p short --qos=short \
+    --gres=gpu:A6000:1 --time=00:30:00 \
+    --mail-type=BEGIN,END,FAIL --mail-user="$MAIL_USER" \
     --pty bash
 ```
-
-Convenience: `export MAIL_USER=<UNI>@columbia.edu` in your shell profile
-(`~/.bashrc` on Insomnia), then `sbatch --mail-type=BEGIN,END,FAIL --mail-user="$MAIL_USER" ...`.
 
 The committed scripts (`scripts/vllm_serve.sh`, `scripts/run_experiment.sh`)
 deliberately omit `#SBATCH --mail-user` so teammates running shared scripts
 don't get spammed with each other's job notifications. Pass the mail flags
 on the `sbatch` CLI per invocation instead.
+
+## Excluding bad nodes
+
+Individual GPU nodes occasionally land in a bad state where vLLM/PyTorch can't
+see the GPU, even though `sinfo` reports the node as Idle. Symptom in
+`logs/exp_<jobid>.out` or `vllm.log`:
+
+```
+RuntimeError: CUDA unknown error - this may be due to an incorrectly set up environment ...
+Setting the available devices to be zero.
+```
+
+When you hit this, identify the offending node from your job's
+`$SLURMD_NODENAME` (or the prompt in an interactive shell — e.g. `ins082`) and
+**re-submit with `--exclude=<node>`** so the scheduler routes around it:
+
+```bash
+sbatch --exclude=ins082 \
+    --mail-type=BEGIN,END,FAIL --mail-user="$MAIL_USER" \
+    scripts/run_experiment.sh "$cfg"
+```
+
+Multiple bad nodes: `--exclude=ins082,ins091`. The exclusion only affects this
+submission; subsequent submits without the flag remain eligible for the node.
+
+If a node stays bad across multiple submits over a day or more, file a ticket
+with RCS (`rcs-support@columbia.edu`) — they can drain and reboot it. A node
+that recovers on its own (typical) needs no follow-up.
 
 ## Queue waits
 
@@ -443,9 +671,15 @@ expect queue waits during weekday business hours. Some heuristics:
 - **`Priority`** just means you're in line; check estimated start with
   `squeue -u <UNI> --start`
 
-Llama-3.1-8B at FP16 fits on every GPU type Insomnia has (A6000 48 GB, L40/L40S
-48 GB, H100 80 GB), so `--gres=gpu:1` is the fastest path to a slot when the
-A6000 nodes are saturated.
+Llama-3.1-8B at FP16 fits on every GPU type Insomnia exposes to the `edu`
+account today (A6000 48 GB, L40/L40S 48 GB, H100 80 GB), so `--gres=gpu:1` is
+the fastest path to a slot when the A6000 nodes are saturated. For the
+authoritative live menu of partitions and GPU types:
+
+```bash
+sinfo -o '%P %.6D %.20G %N'      # partitions, node count, gres, nodelist
+sinfo -p short --Format='Gres'   # just the gres column
+```
 
 ## SSH multiplexing (avoid repeated Duo 2FA)
 
@@ -466,7 +700,14 @@ feature — it has nothing to do with login-node policy or job execution.
 
 ## See also
 
+- [runbook.md](runbook.md) — top-level reproducibility doc, including the
+  WandB setup section (`wandb login` once per node, `WANDB_API_KEY` /
+  `ENABLE_WANDB=1` / `WANDB_PROJECT` / `WANDB_ENTITY` / `WANDB_MODE` env vars
+  honored by `run_experiment.sh`)
 - [compute_plan.md](compute_plan.md) — phase-by-phase GPU allocation strategy
 - [slurm_cheatsheet.md](slurm_cheatsheet.md) — quick command reference for submit/status/logging/cancel flows
+- [governance/model_registry.yaml](governance/model_registry.yaml) — canonical model IDs, runtime pins, judge contract
 - [scripts/setup_insomnia.sh](../scripts/setup_insomnia.sh) — one-shot env setup with pinned versions
 - [scripts/vllm_serve.sh](../scripts/vllm_serve.sh) — Slurm job script for serving Llama-3.1-8B-Instruct
+- [scripts/run_experiment.sh](../scripts/run_experiment.sh) — benchmark wrapper (vLLM serve + harness + WandB + canonical scenario contract)
+- [scripts/backfill_canonical_scenario.py](../scripts/backfill_canonical_scenario.py) — retrofit pre-PR-#143 captures to canonical scenario/success contract

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,6 +1,6 @@
 # Runbook
 
-*Last updated: 2026-04-24*
+*Last updated: 2026-04-28*
 *Infra owner: Aaron Fan (af3623) — eval-harness owner: Akshat Bhandari (ab6174)*
 
 Canonical reproducibility runbook. A teammate following this from scratch
@@ -86,13 +86,11 @@ cd /insomnia001/depts/edu/users/team13/hpml-assetopsbench-smart-grid-mcp
 git pull
 ```
 
-If you need a personal worktree for experimental branches:
-
-```bash
-git worktree add ../hpml-worktree-<branch> <branch>
-```
-
-Run jobs from the main checkout; worktrees are for editing only.
+For per-branch worktrees on Insomnia, see
+[insomnia_runbook.md § Worktrees on Insomnia](insomnia_runbook.md#worktrees-on-insomnia)
+— worktrees go in the shared `/insomnia001/depts/edu/users/team13/worktrees/<slug>/`
+sibling, with explicit guidance on avoiding detached-HEAD checkouts. Run jobs
+from the main checkout; worktrees are for editing.
 
 ### 2.2 Verify the venv
 
@@ -122,7 +120,7 @@ python -c "import vllm; print(vllm.__version__)"
 
 **If the venv is missing or broken, coordinate with the owner before
 recreating.** Recreation steps live in
-[insomnia_runbook.md](insomnia_runbook.md) under "If you need a newer vLLM".
+[insomnia_runbook.md § Recreate the shared env when needed](insomnia_runbook.md#recreate-the-shared-env-when-needed).
 
 ### 2.3 Verify the model
 
@@ -290,10 +288,21 @@ host instead of the compute node. The wrapper should run inside the allocation.
 
 ### 4.3 PyTorch Profiler via vLLM
 
-vLLM has built-in `torch.profiler` support gated on the `VLLM_TORCH_PROFILER_DIR`
-env var. Start vLLM with the env var set, then drive capture with
-`run_vllm_torch_profile.sh`. Full recipe in
-[profiling/README.md#pytorch-profiler-via-vllms-built-in-endpoints](../profiling/README.md).
+vLLM has built-in `torch.profiler` support. **As of vLLM 0.19.0 the
+`VLLM_TORCH_PROFILER_DIR` env var was dropped** and replaced by a
+`--profiler-config` CLI flag taking JSON with an absolute path:
+
+```bash
+--profiler-config '{"profiler":"torch","torch_profiler_dir":"/abs/path/to/profiling/traces/<run-id>_torch"}'
+```
+
+`scripts/run_experiment.sh:783-785` builds this automatically when
+`TORCH_PROFILE=1` — the canonical capture route is
+`TORCH_PROFILE=1 bash scripts/run_experiment.sh <config>`. For manual
+debugging, drive capture with `run_vllm_torch_profile.sh`. Full recipe in
+[profiling/README.md#pytorch-profiler-via-vllms-built-in-endpoints](../profiling/README.md#pytorch-profiler-via-vllms-built-in-endpoints);
+operational notes in
+[insomnia_runbook.md § Debugging: foreground vLLM](insomnia_runbook.md#debugging-foreground-vllm).
 
 ### 4.4 Linking profiling outputs to the benchmark's WandB run
 

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -1,14 +1,14 @@
 # profiling/
 
-*Last updated: 2026-04-21*
+*Last updated: 2026-04-28*
 
-PyTorch Profiler / NVIDIA Nsight / `nvidia-smi` wrappers and captured traces. Traces are large binary files and are **gitignored by default** (`profiling/traces/` and `*.pt.trace.json` are excluded via `.gitignore`). Only the wrapper scripts and this README are tracked here.
+PyTorch Profiler / NVIDIA Nsight / `nvidia-smi` wrappers and captured traces. Traces are large binary files and are **gitignored by default** (`profiling/traces/`, `*.pt.trace.json`, and `*.pt.trace.json.gz` are excluded via `.gitignore`; vLLM 0.19 emits gzipped `*.pt.trace.json.gz`). Only the wrapper scripts and this README are tracked here.
 
 ## Structure
 
 ```
 profiling/
-├── traces/                  # GITIGNORED — actual .pt.trace.json / nsys reports / nvidia_smi.csv
+├── traces/                  # GITIGNORED — actual *.pt.trace.json.gz (vLLM 0.19) / nsys reports / nvidia_smi.csv
 ├── scripts/                 # wrapper scripts experimenters invoke
 │   ├── sample_nvidia_smi.sh        # background GPU utilization sampler (CSV)
 │   ├── run_nsight.sh               # `nsys profile` wrapper with stats post-proc
@@ -85,29 +85,101 @@ CAPTURE_NSYS=1 bash profiling/scripts/capture_around.sh profiling/traces/pe_base
 ### PyTorch Profiler via vLLM's built-in endpoints
 
 vLLM exposes `/start_profile` and `/stop_profile` HTTP routes that internally
-drive `torch.profiler`. They're only available if vLLM was launched with
-`VLLM_TORCH_PROFILER_DIR` pointing at a writable directory.
+drive `torch.profiler`. **As of vLLM 0.19.0 the `VLLM_TORCH_PROFILER_DIR` env
+var was dropped** — these endpoints are now only available if vLLM was
+launched with the `--profiler-config` CLI flag pointing at a writable
+absolute path:
 
-Start vLLM with profiling enabled:
-
-```bash
-export VLLM_TORCH_PROFILER_DIR=$PWD/profiling/traces/pt_$(date +%s)
-mkdir -p "$VLLM_TORCH_PROFILER_DIR"
-# --export=ALL ensures Slurm forwards the env var to the job
-sbatch --export=ALL scripts/vllm_serve.sh
+```
+--profiler-config '{"profiler":"torch","torch_profiler_dir":"/abs/path/to/profiling/traces/<run-id>_torch"}'
 ```
 
-Then, from the same compute node (via `srun --jobid=<id> --overlap --pty bash`)
-or over an SSH tunnel:
+The canonical end-to-end capture route is `TORCH_PROFILE=1` plus the normal
+benchmark wrapper, which builds the flag automatically (see
+`scripts/run_experiment.sh:783-785`):
 
 ```bash
-bash profiling/scripts/run_vllm_torch_profile.sh "$VLLM_TORCH_PROFILER_DIR" \
-    -- bash scripts/run_experiment.sh configs/pe_mcp_baseline.env
+TORCH_PROFILE=1 bash scripts/run_experiment.sh configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env
 ```
+
+Output traces land under `profiling/traces/${RUN_ID}_torch/` alongside the
+benchmark capture.
+
+For manual ad-hoc debugging, start vLLM in the foreground with the flag set
+explicitly, then drive the wrapper:
+
+```bash
+TRACE_DIR="$PWD/profiling/traces/pt_$(date +%s)_torch"
+mkdir -p "$TRACE_DIR"
+
+# Foreground vLLM with profiling enabled (compute node):
+python -u -m vllm.entrypoints.openai.api_server \
+    --model models/Llama-3.1-8B-Instruct \
+    --served-model-name Llama-3.1-8B-Instruct \
+    --port 8000 --max-model-len 32768 --dtype float16 \
+    --enable-auto-tool-choice --tool-call-parser llama3_json \
+    --profiler-config "{\"profiler\":\"torch\",\"torch_profiler_dir\":\"$TRACE_DIR\"}"
+```
+
+Then from a second shell on the same compute node (via `srun --jobid=<id>
+--overlap --pty bash`) or over an SSH tunnel, drive the wrapper against a
+target that does NOT spawn its own vLLM. The right target is
+`scripts/replay_scenarios.sh` (uses the existing `LITELLM_BASE_URL`) or a
+direct `curl` against the foreground server — never `bash
+scripts/run_experiment.sh <cell-config>`, because the cell configs assign
+`LAUNCH_VLLM=1` unconditionally and override any `LAUNCH_VLLM=0` env prefix
+when the script sources them. That assignment-not-default form clobbers env
+values, so the harness would launch a second vLLM and collide on
+`VLLM_PORT=8000`.
+
+```bash
+# Recommended: replay scenarios from an existing benchmark run dir against the
+# already-running foreground vLLM. No new server is launched; the harness just
+# replays prompts.
+LITELLM_BASE_URL="http://127.0.0.1:8000/v1" \
+LITELLM_API_KEY="dummy-vllm-not-checked" \
+bash profiling/scripts/run_vllm_torch_profile.sh "$TRACE_DIR" \
+    -- bash scripts/replay_scenarios.sh \
+        benchmarks/cell_Y_plan_execute/raw/<run-id> direct
+```
+
+For an even smaller probe (skip the harness, just generate inference traffic):
+
+```bash
+bash profiling/scripts/run_vllm_torch_profile.sh "$TRACE_DIR" \
+    -- curl -s http://127.0.0.1:8000/v1/chat/completions \
+            -H 'Content-Type: application/json' \
+            -d '{"model":"Llama-3.1-8B-Instruct","messages":[{"role":"user","content":"ping"}]}'
+```
+
+If you really need to drive a full cell config under the foreground server,
+make a temp config that overrides `LAUNCH_VLLM`:
+
+```bash
+TMPCFG=/tmp/exp2_cell_Y_external_vllm.env
+cp configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env "$TMPCFG"
+printf '\nLAUNCH_VLLM=0\nTORCH_PROFILE=0\n' >> "$TMPCFG"
+
+LITELLM_BASE_URL="http://127.0.0.1:8000/v1" \
+LITELLM_API_KEY="dummy-vllm-not-checked" \
+bash profiling/scripts/run_vllm_torch_profile.sh "$TRACE_DIR" \
+    -- bash scripts/run_experiment.sh "$TMPCFG"
+```
+
+Trailing assignments override the original `LAUNCH_VLLM=1` because shell
+sourcing is order-sensitive — last assignment wins.
 
 The wrapper hits `/start_profile` before the command and `/stop_profile` after.
-Open the emitted `pt.trace.json` in `chrome://tracing` or
-<https://ui.perfetto.dev>.
+vLLM 0.19 emits the trace as a gzipped `*.pt.trace.json.gz` under the configured
+`torch_profiler_dir`. Open by either gunzipping first
+(`gunzip -k <file>.pt.trace.json.gz`) and loading the resulting `.pt.trace.json`
+in `chrome://tracing`, or upload the `.gz` directly to
+<https://ui.perfetto.dev> (which decompresses transparently).
+
+`scripts/vllm_serve.sh` does **not** currently inject `--profiler-config`, so
+launching the serve job and then expecting `/start_profile` to work will fail
+on vLLM 0.19. Either use the `TORCH_PROFILE=1` wrapper above, or extend
+`scripts/vllm_serve.sh` before driving the endpoints by hand.
 
 ### Nsight Systems
 
@@ -206,8 +278,11 @@ WANDB_MODE=offline python3 profiling/scripts/log_profiling_to_wandb.py \
     --benchmark-run-dir "$BENCH" --profiling-dir "$OUT"
 ```
 
-## Status (Apr 14, 2026)
+## Status
 
-- `sample_nvidia_smi.sh`, `run_nsight.sh`, `run_vllm_torch_profile.sh`, `capture_around.sh` landed Apr 14.
-- First profiling runs against the Plan-Execute smoke (`benchmarks/cell_Y_plan_execute/raw/...`) scheduled for W3 once the shared vLLM endpoint stabilizes on Insomnia.
-- Analysis notebooks (`notebooks/02_mcp_latency.ipynb`, etc.) owned by Alex; will consume `benchmarks/cell_<X>/raw/<run-id>/latencies.jsonl` + `profiling/traces/<run-id>/nvidia_smi.csv`.
+For current proof runs and capture provenance, see
+[docs/validation_log.md](../docs/validation_log.md). Operational notes live in
+[docs/insomnia_runbook.md](../docs/insomnia_runbook.md). Analysis notebooks
+(`notebooks/02_mcp_latency.ipynb`, `notebooks/03_orchestration_comparison.ipynb`)
+consume `benchmarks/cell_<X>/raw/<run-id>/latencies.jsonl` +
+`profiling/traces/<run-id>/nvidia_smi.csv` as their inputs.

--- a/profiling/scripts/run_vllm_torch_profile.sh
+++ b/profiling/scripts/run_vllm_torch_profile.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 # PyTorch Profiler wrapper for vLLM-backed benchmark runs.
 #
-# vLLM ships with built-in torch.profiler support that activates when the env
-# var VLLM_TORCH_PROFILER_DIR points at a writable directory. When set, vLLM
-# exposes /start_profile and /stop_profile HTTP endpoints on the serve process
-# and writes Chrome-trace-compatible JSON files into the dir.
+# vLLM ships with built-in torch.profiler support that activates when the
+# server is launched with --profiler-config (vLLM >= 0.19.0; the older
+# VLLM_TORCH_PROFILER_DIR env-var path was removed). When the flag is set,
+# vLLM exposes /start_profile and /stop_profile HTTP endpoints on the serve
+# process and writes Chrome-trace-compatible JSON files into the configured
+# torch_profiler_dir.
 #
-# This script:
-#   1. Prepares the profiler output dir
-#   2. Launches vLLM with the env var set (reuses scripts/vllm_serve.sh logic
-#      via re-export — the serve script itself already inherits the environment)
-#   3. Waits for the server to become ready
-#   4. Hits /start_profile, runs the target command, hits /stop_profile
-#   5. Returns the exit code of the target command
+# This wrapper:
+#   1. Confirms the already-running vLLM server is reachable
+#   2. Hits /start_profile, runs the target command, hits /stop_profile
+#   3. Writes profile_meta.json alongside the trace
+#   4. Returns the exit code of the target command
+#
+# It does NOT launch vLLM. The canonical capture route is the benchmark
+# wrapper (TORCH_PROFILE=1 bash scripts/run_experiment.sh <config>), which
+# constructs the --profiler-config flag automatically. Use this script only
+# for ad-hoc / debugging captures against a manually-launched vLLM serve.
 #
 # Usage:
 #   bash profiling/scripts/run_vllm_torch_profile.sh <output_dir> \
@@ -27,18 +32,32 @@
 # IMPORTANT — ordering:
 #
 #   This wrapper assumes a vLLM server is ALREADY running in a separate
-#   Slurm allocation (or srun --pty shell) with VLLM_TORCH_PROFILER_DIR
-#   exported when the server was started. If vLLM wasn't started with the
-#   env var set, /start_profile returns an error and this script aborts.
+#   Slurm allocation (or srun --pty shell) and was launched with
+#   --profiler-config pointing at a writable absolute path. If vLLM wasn't
+#   started with the flag, /start_profile returns an error and this script
+#   aborts.
 #
-#   To start vLLM with profiling enabled:
-#     export VLLM_TORCH_PROFILER_DIR=/path/to/profiling/traces/<runid>
-#     sbatch --export=ALL scripts/vllm_serve.sh
+#   To start vLLM with profiling enabled (manual recipe):
+#     TRACE_DIR="$PWD/profiling/traces/<runid>_torch"
+#     mkdir -p "$TRACE_DIR"
+#     python -u -m vllm.entrypoints.openai.api_server \
+#         --model models/Llama-3.1-8B-Instruct \
+#         --served-model-name Llama-3.1-8B-Instruct \
+#         --port 8000 --max-model-len 32768 --dtype float16 \
+#         --enable-auto-tool-choice --tool-call-parser llama3_json \
+#         --profiler-config "{\"profiler\":\"torch\",\"torch_profiler_dir\":\"$TRACE_DIR\"}"
+#
+#   Or, more typically, use the benchmark wrapper:
+#     TORCH_PROFILE=1 bash scripts/run_experiment.sh <config>
+#   which handles the flag construction in run_experiment.sh:783-785.
 #
 # Output:
-#   $OUTPUT_DIR/pt.trace.json (Chrome trace, viewable in chrome://tracing
-#                              or https://ui.perfetto.dev)
-#   $OUTPUT_DIR/profile_meta.json (runid, timestamps, target command)
+#   $OUTPUT_DIR/*.pt.trace.json.gz (Chrome trace; vLLM 0.19 emits gzipped form.
+#                                   Open via https://ui.perfetto.dev directly,
+#                                   or `gunzip -k <file>.pt.trace.json.gz` and
+#                                   load the resulting .pt.trace.json in
+#                                   chrome://tracing)
+#   $OUTPUT_DIR/profile_meta.json  (runid, timestamps, target command)
 
 set -euo pipefail
 
@@ -66,7 +85,7 @@ mkdir -p "$OUTPUT_DIR"
 # Confirm vLLM is reachable and has profiling endpoints
 if ! curl -s "$BASE_URL/health" > /dev/null 2>&1; then
     echo "ERROR: vLLM not reachable at $BASE_URL/health" >&2
-    echo "       Start vLLM with VLLM_TORCH_PROFILER_DIR set before running this wrapper." >&2
+    echo "       Start vLLM with --profiler-config '{\"profiler\":\"torch\",\"torch_profiler_dir\":\"<abs-path>\"}' before running this wrapper." >&2
     exit 1
 fi
 
@@ -77,7 +96,7 @@ if [ "$START_RESP" != "200" ]; then
     echo "Response body:" >&2
     cat /tmp/start_profile.out >&2 || true
     echo "" >&2
-    echo "Most common cause: vLLM was not started with VLLM_TORCH_PROFILER_DIR set." >&2
+    echo "Most common cause: vLLM was not started with --profiler-config (vLLM >= 0.19.0)." >&2
     exit 1
 fi
 
@@ -116,9 +135,12 @@ meta = {
     "stop_ts": stop_ts,
     "target_command": cmd,
     "target_exit_code": cmd_rc,
-    "notes": "Chrome trace written by vLLM into the directory pointed at by "
-             "VLLM_TORCH_PROFILER_DIR. Open with chrome://tracing or "
-             "https://ui.perfetto.dev.",
+    "notes": "Chrome trace written by vLLM into the directory configured via "
+             "--profiler-config (vLLM >= 0.19.0). Emitted as gzipped "
+             "*.pt.trace.json.gz. Upload the .gz directly to "
+             "https://ui.perfetto.dev (handles gzip transparently), or "
+             "`gunzip -k <file>.pt.trace.json.gz` first and load the resulting "
+             ".pt.trace.json in chrome://tracing.",
 }
 with open(meta_path, "w") as f:
     json.dump(meta, f, indent=2)

--- a/scripts/run_exp1_ab_capture.sh
+++ b/scripts/run_exp1_ab_capture.sh
@@ -23,7 +23,9 @@
 # benchmark's WandB run.
 #
 # Usage:
-#   sbatch --mail-type=BEGIN,END,FAIL --mail-user=$USER \
+#   # Set MAIL_USER once (e.g. in ~/.bashrc on Insomnia):
+#   #   export MAIL_USER="${USER}@columbia.edu"
+#   sbatch --mail-type=BEGIN,END,FAIL --mail-user="$MAIL_USER" \
 #       scripts/run_exp1_ab_capture.sh
 #
 # After the job completes, find artifacts at:

--- a/scripts/run_exp1_ab_capture.sh
+++ b/scripts/run_exp1_ab_capture.sh
@@ -31,7 +31,7 @@
 #   benchmarks/cell_B_mcp_baseline/raw/<SLURM_JOB_ID>_aat_mcp_baseline/
 #   profiling/traces/<SLURM_JOB_ID>_cell_a/        (nvidia_smi.csv, capture_meta.json)
 #   profiling/traces/<SLURM_JOB_ID>_cell_b/
-#   profiling/traces/<SLURM_JOB_ID>_aat_direct_torch/     (pt.trace.json, if profiler ran)
+#   profiling/traces/<SLURM_JOB_ID>_aat_direct_torch/     (*.pt.trace.json.gz, if profiler ran)
 #   profiling/traces/<SLURM_JOB_ID>_aat_mcp_baseline_torch/
 #
 # To disable the torch-profiler replay for a faster run:
@@ -125,5 +125,6 @@ echo "       $CELL_B_BENCH/latencies.jsonl"
 echo "  5. Check torch profiler traces (if TORCH_PROFILE=1 was set in the configs):"
 echo "       profiling/traces/${JOB}_aat_direct_torch/"
 echo "       profiling/traces/${JOB}_aat_mcp_baseline_torch/"
-echo "     Open pt.trace.json in chrome://tracing or https://ui.perfetto.dev"
+echo "     vLLM 0.19 emits *.pt.trace.json.gz; open via https://ui.perfetto.dev (handles .gz)"
+echo "     or 'gunzip -k <file>.pt.trace.json.gz' first then chrome://tracing"
 echo "Finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary

Doc-only cascade reconciling Insomnia operational gaps surfaced after Apr 27 PR #143 / #144 landings + the Apr 26 worktree-perms incident, plus user-driven additions (`MAIL_USER` default, `--exclude=<node>` mitigation for "CUDA unknown error" node failures).

- **docs/insomnia_runbook.md (+283/−24)** — new "Filesystem topology" section (ASCII tree of /insomnia001/depts/edu/users/team13/); new "Worktrees on Insomnia" subsection (three-flavor git worktree add recipe with explicit detached-HEAD warning, perms gotcha, --force data-loss warning); foreground vLLM serve split into completions-only sanity vs tool-call benchmark/AaT/PE serve (sources cell config + applies ${VAR:-default} defaults from run_experiment.sh:90-104); new "Trial output contract (PR #143)" subsection (data["scenario"] full source object, data["success"] derivation rules, backfill_canonical_scenario.py actual CLI); new "Excluding bad nodes" section (--exclude=ins082 for CUDA unknown error); compute-node hostname pattern + live sinfo GPU menu + `quota -s` storage-headroom; `MAIL_USER="${USER}@columbia.edu"` as default; `requirements-insomnia.txt` overlay relationship explained; pin updates (`mcp[cli]==1.27.0`, `openai-agents==0.14.5`); cross-links to `runbook.md` § WandB, `model_registry.yaml`, `run_experiment.sh`, `backfill_canonical_scenario.py`.
- **`docs/runbook.md` (+12/−)?** — § 4.3 PyTorch profiler rewritten for vLLM 0.19.0 `--profiler-config` flag; § 2.2 venv-recovery anchor fix (`#recreate-the-shared-env-when-needed`); § 2.x stale `../hpml-worktree-<branch>` snippet replaced with cross-link; profiling cross-links given explicit fragments.
- **`profiling/README.md` (+96/−18)** — PyTorch-Profiler-via-vLLM section rewritten for `--profiler-config`; manual ad-hoc recipe rewritten to avoid `LAUNCH_VLLM=1` config-clobber footgun (recommends `replay_scenarios.sh` / direct `curl` / temp-config copy); `.gitignore` claim aligned with reality; "Status (Apr 14, 2026)" stale stub replaced with cross-link to `validation_log.md`.
- **`profiling/scripts/run_vllm_torch_profile.sh` (+45/−27)** — header rewritten for vLLM 0.19.0 `--profiler-config` flag; error messages updated; `profile_meta.json` "notes" field now describes gzipped `*.pt.trace.json.gz` form with perfetto/gunzip guidance.
- **`scripts/run_exp1_ab_capture.sh` (+3/−2)** — stale `pt.trace.json` references (`:34`, `:128`) → `*.pt.trace.json.gz`.
- **`.gitignore` (+1)** — added `*.pt.trace.json.gz` next to `*.pt.trace.json` under profiling block.
- **`CHANGELOG.md` (+117)** — single 2026-04-28 Documentation entry covering the cascade.

Cumulative: 7 files, +547 / −81. Doc-only — no behavior change.

## Cross-agent review

Reviewed by Codex via persistent file-based inbox over 6 iterations; v6 verdict **LGTM — approve, merge blocker: none**. Trajectory below; v6's 1 Medium + 2 Low were addressed in the final amend for audit cleanliness.

| Pass | Critical | High | Medium | Low | Verdict |
|------|----------|------|--------|-----|---------|
| v1 | 0 | 3 | 2 | 0 | findings remain |
| v2 | 0 | 2 | 2 | 3 | findings remain |
| v3 | 0 | 1 | 0 | 2 | findings remain |
| v4 | 0 | 1 | 1 | 1 | findings remain |
| v5 | 0 | 1 | 1 | 0 | findings remain |
| v6 | 0 | **0** | 1 | 2 | **LGTM** |

Notable bugs caught and fixed during review:
- **v1 H1**: worktree recipe could create detached HEAD when passed remote-tracking ref directly. Fixed by splitting into three explicit cases.
- **v1 H2**: documented `backfill_canonical_scenario.py --apply <capture-dir>` invocation didn't match actual CLI (no positional). Fixed.
- **v1 H3**: claim that Cell A/B "direct" runs work without tool-call flags was wrong (configs all set `VLLM_ENABLE_AUTO_TOOL_CHOICE=1`). Fixed by removing exception.
- **v2 H1**: hard-coded `--max-model-len 8192` in benchmark serve recipe would overflow Cell Y/Z (`MAX_MODEL_LEN=32768`). Fixed by sourcing config.
- **v2 H2**: `profiling/README.md` + `run_vllm_torch_profile.sh` still on `VLLM_TORCH_PROFILER_DIR` env var (dropped in vLLM 0.19.0). Cascade-fixed to `--profiler-config` CLI flag.
- **v3 H1**: config-source recipe didn't apply `${VAR:-default}` shell defaults; sourcing Cell Y config left `VLLM_SERVED_MODEL_NAME`/`VLLM_TOOL_CALL_PARSER` empty. Fixed.
- **v4 H1**: ad-hoc profiler wrapper invocation collided with `LAUNCH_VLLM=1` config (would launch second vLLM). Tried env-prefix override.
- **v5 H1**: env-prefix `LAUNCH_VLLM=0` clobbered by config sourcing (cell configs assign unconditionally). Fixed by switching to `replay_scenarios.sh` / `curl` / temp-config-copy targets.

Full review packets in `review/codex-prompts/20260428_*_ADHOC_insomnia_runbook_clarity-v{1..6}*.md` (gitignored).

## Test plan

- [x] Doc-only patch — no scripts execute. Markdown links verified locally.
- [x] `bash -n profiling/scripts/run_vllm_torch_profile.sh` → syntax OK.
- [x] `bash -n scripts/run_exp1_ab_capture.sh` → syntax OK.
- [x] `bash -n scripts/run_experiment.sh` → syntax OK.
- [x] `python3 -m py_compile scripts/backfill_canonical_scenario.py` → OK.
- [x] Reviewer reproduced the `LAUNCH_VLLM` config-clobber behavior and the temp-config workaround in a fresh shell.
- [x] Reviewer reproduced the `set -a; source <cell-config>; set +a` defaults block to confirm output values match what the harness uses.
- [x] `git grep -n "pt\.trace\.json"` confirms only intentional post-gunzip filename refs remain after the migration.
- [ ] Aaron Fan (runbook owner) review.

## Out-of-scope

- `scripts/vllm_serve.sh` does not currently inject `--profiler-config`. Flagged in `profiling/README.md` as a future patch — behavior change rather than doc fix.