### PR TITLE
Add L3 statistical-fidelity validator + DGA realism doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 2026-04-29
 
+### Fixed (PR #148 review v4)
+
+- `data/scenarios/validate_realism_statistical.py` — apply review v4 fixes:
+  - **High 1**: real fault labels are now validated after source-specific
+    mapping. Adds a `REAL_LABEL_ALIASES` table (`N` → `Normal`, IEC codes
+    pass through, common case-variants normalize). `load_real()` raises
+    `ValueError` on any post-mapping label not in `FAULT_CODES`, naming
+    the offenders. The chi-squared detail now reports both raw and
+    recognized real-row counts (`n_real_recognized=N/M`) so any future
+    drop is visible if validation is bypassed.
+  - **Medium 2**: `docs/dga_realism_statistical_validation.md` § 6.5
+    (Dependencies) updated to reflect the actual install contract: this
+    PR adds `scipy` and `openpyxl` to `requirements.txt`; `.xls` is
+    intentionally unsupported.
+  - **Low 3**: § 12.1 (Akshat handoff) example now uses `.xlsx` plus
+    `--real-source ieee_dataport` consistently; module docstring usage
+    example matches.
+
 ### Fixed (PR #148 review v3)
 
 - `data/scenarios/validate_realism_statistical.py` — apply review v3 fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 2026-04-29
+
+### Fixed (PR #148 review v1)
+
+- `data/scenarios/validate_realism_statistical.py` — apply review v1 fixes:
+  - **Critical 1**: synthetic fault labels now mapped to IEC codes through
+    `PROJECT_LABEL_TO_IEC` before chi-squared counting, so the headline test
+    no longer silently drops rows. The v0 baseline now reports `n_syn=20` (was 10
+    out of 20). `load_synthetic` raises `ValueError` on unmapped labels rather
+    than dropping them, so future generator changes fail loudly instead of
+    quietly.
+  - **High 2**: chi-squared real-vs-synthetic comparison now scales real
+    proportions to `n_syn` via largest-remainder rounding (`_scale_to_total`),
+    so SciPy's "observed and expected totals must match" precondition is
+    always satisfied regardless of real-dataset row count.
+  - **High 3**: Anderson-Darling now uses `ad.pvalue` directly (modern SciPy
+    returns it on the `[0, 1]` scale). The previous `/ 100` divisor turned
+    capped 0.25 p-values into 0.0025 and failed every AD test.
+  - **Medium 5**: `load_real()` now reads `.xlsx`/`.xls` files in addition to
+    CSV, and accepts a `--real-source` flag selecting from `REAL_LABEL_MAPS`
+    (currently includes the IEEE DataPort integer-fault-code map; placeholders
+    for Kaggle and Duval 2001 TC 10 reproductions).
+  - **Medium 6**: `conditional_ks_per_fault()` now emits a structured
+    failing `TestResult` when a real dataset is missing a gas column, mirroring
+    the behavior of the marginal KS / EMD paths instead of crashing with
+    `KeyError`.
+  - **Medium 8**: `_md_cell()` helper escapes `|` and newlines/CR before
+    rendering test details into the Markdown report table.
+  - **Low 9**: removed unused `Callable` import.
+- `docs/dga_realism_statistical_validation.md` — apply review v1 doc fixes:
+  - **High 4**: removed verbatim IEC 60599:2022 Table 1 reproduction from
+    Appendix A. Replaced with a reconciliation procedure, citation block,
+    and a non-verbatim implementation summary that points back to the diff
+    pattern in Appendix B (which only describes our internal tables vs the
+    standard's, not the standard's content).
+  - **Medium 7**: removed personal-class-repo path references from the
+    tracked doc; replaced with team-visible language ("ask Alex", "external
+    citation"). The full row-by-row working notes still exist; they're held
+    by Alex outside this repo because they cite paywalled IEC text.
+- `reports/realism_statistical_v0.md` + `.json` — regenerated against the
+  corrected validator. Chi-squared on full 20-row synthetic vs TC 10 reference
+  is now `χ²=16.67, p=0.0106` (was `23.33, p=0.0007` operating on 10 rows).
+
 ## 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 2026-04-29
 
+### Fixed (PR #148 review v3)
+
+- `data/scenarios/validate_realism_statistical.py` — apply review v3 fixes:
+  - **High 1**: NaN no longer leaks into report. Three changes:
+    (a) `chi2_fault_prevalence()` now drops classes where both observed
+    and expected are zero before calling `stats.chisquare()` (SciPy
+    returned NaN for those terms even with the v5 zero-expected guard);
+    rescales the trimmed reference so totals still match.
+    (b) Adds a post-test finiteness guard so any future non-finite
+    statistic is reported as a structured failure.
+    (c) `correlation_delta()` checks for all-NaN delta (which happens
+    when a gas column is constant in either frame) and returns a
+    descriptive failure instead of `np.nanmax` returning NaN.
+    JSON dump now uses `allow_nan=False` so any future non-finite
+    metric fails loudly during report generation rather than emitting
+    bare `NaN` to the JSON file.
+  - **Medium 2**: `load_real()` no longer claims `.xls` support. The
+    v4 fix added `.xls` to the routing table but `xlrd` is not in
+    `requirements.txt`. Routing `.xls` now raises `ValueError` with
+    instructions to convert to `.xlsx` or `.csv`.
+  - **Medium 3**: PR body updated separately on GitHub (the previous
+    body still referenced the pre-v4 `p = 0.0007` baseline and didn't
+    list `openpyxl`).
+
 ### Fixed (PR #148 review v2)
 
 - `data/scenarios/validate_realism_statistical.py` + `requirements.txt` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 2026-04-28
 
+### Added
+
+- `data/scenarios/validate_realism_statistical.py` — Layer 3 statistical-fidelity
+  validator. Compares synthetic DGA gas distributions and fault-class proportions
+  against published real-world DGA data (or against the IEC TC 10 reference
+  prevalence when no real dataset is loaded). Six-test battery: KS, Anderson-
+  Darling, Wasserstein/EMD per gas; chi-squared on fault prevalence; conditional
+  KS per fault class; correlation-matrix delta. Markdown + JSON report card; non-
+  zero exit when any test fails. Adds `scipy` to `requirements.txt`.
+- `docs/dga_realism_statistical_validation.md` — working spec covering IEC 60599
+  (publication 66491) ingestion status, ranked real-DGA datasets (IEEE DataPort,
+  IEC TC 10 via Duval & dePablo 2001, Kaggle backstop), test rationale, TC 10
+  reference prevalence, acceptance thresholds, pre-May 4 plan, and PR #147 plug-in
+  point. Plugs L3 into the existing 6-criteria PS B rubric (`#51`).
+- `reports/realism_statistical_v0.md` — baseline run on the current 20-row
+  `data/processed/dga_records.csv`. Empirical signal: synthetic fault prevalence
+  diverges from TC 10 reference at chi-squared p=0.0007. Triggers the synthesis
+  tuning step (extend n + adjust per-fault gas means) in the v1 plan.
+
 ### Documentation
 
 - Expanded `docs/insomnia_runbook.md` with operational gaps surfaced after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@
   diverges from TC 10 reference at chi-squared p=0.0007. Triggers the synthesis
   tuning step (extend n + adjust per-fault gas means) in the v1 plan.
 
+### Changed
+
+- `docs/dga_realism_statistical_validation.md` § 2.4 — added three-way
+  fault-table divergence finding from comparing the licensed IEC 60599:2022
+  4th-ed scan against `transformer_standards.json` `fault_table` (Table B)
+  and `mcp_servers/fmsr_server/server.py` `_rogers_ratio()` (Table C). Worst
+  divergences: D1 R1, D1 R3, D2 R2, T2/T3 R3 boundary. Server's own
+  `server_rogers_table_note` already documents the C-vs-A drift. Pattern
+  (B↔C agreement > B↔A or C↔A) suggests both encodings derived from a
+  derivative source rather than IEC text. Pre-May 4 plan amended: new
+  task 2b (fix Tables B + C for at least PD/D1 R1; lockstep with FMSR
+  test fixtures). Companion analysis lives in personal-class-repo
+  `Final_Project/notes/20260428_iec60599_table_comparison.md`.
+
 ### Documentation
 
 - Expanded `docs/insomnia_runbook.md` with operational gaps surfaced after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## 2026-04-29
 
+### Fixed (PR #148 review v2)
+
+- `data/scenarios/validate_realism_statistical.py` + `requirements.txt` —
+  apply review v2 fixes:
+  - **High 1**: added `openpyxl` to `requirements.txt`. The v4
+    fix introduced `pd.read_excel()` for IEEE DataPort's `.xlsx` files
+    but did not add the engine; a fresh environment built from the PR
+    would have failed before producing any L3 report.
+  - **High 2**: `correlation_delta()` now computes both correlation
+    matrices over the intersection of gas columns present in synthetic
+    and real, and emits a structured failing `TestResult` with
+    diagnostic detail when fewer than two gases are shared. Previously
+    a real dataset with only some gas columns triggered a numpy
+    broadcast `ValueError` (5x5 vs N x N).
+  - **Medium 3**: `chi2_fault_prevalence()` now detects the
+    "synthetic has rows in a class that the reference has zero
+    expected count for" case BEFORE calling SciPy and emits a
+    descriptive failing `TestResult` instead of allowing SciPy to
+    return NaN (which then leaked bare `NaN` into the JSON report).
+
+- `docs/dga_realism_statistical_validation.md` + `CHANGELOG.md` — apply
+  review v2 doc fixes:
+  - **Medium 4**: corrected stale `p = 0.0007` references in § 1 and
+    in the original Apr-28 Added entry; the v4-regenerated baseline is
+    `p = 0.0106` on `n_syn = 20`.
+  - **Medium 5**: removed remaining "licensed IEC" + personal-class-
+    repo path leak from the v2 Changelog entry; rewrote in team-visible
+    language matching § 2.4 ("ask Alex for working notes that cite the
+    paywalled standard").
+  - **Medium 6**: replaced the remaining numeric IEC range snippets in
+    § 2.4 + Appendix B with non-numeric contradiction summaries. Pull
+    canonical bounds from IEC 60599:2022 Table 1 directly (or from
+    Alex's working notes) when implementing the fix-the-table PR.
+
 ### Fixed (PR #148 review v1)
 
 - `data/scenarios/validate_realism_statistical.py` — apply review v1 fixes:
@@ -61,22 +95,24 @@
   point. Plugs L3 into the existing 6-criteria PS B rubric (`#51`).
 - `reports/realism_statistical_v0.md` — baseline run on the current 20-row
   `data/processed/dga_records.csv`. Empirical signal: synthetic fault prevalence
-  diverges from TC 10 reference at chi-squared p=0.0007. Triggers the synthesis
+  diverges from TC 10 reference at chi-squared p=0.0106 (post-v4 regenerated;
+  the original commit recorded p=0.0007 but was operating on only 10 of 20 rows
+  due to a label-mapping bug fixed in v4). Triggers the synthesis
   tuning step (extend n + adjust per-fault gas means) in the v1 plan.
 
 ### Changed
 
 - `docs/dga_realism_statistical_validation.md` § 2.4 — added three-way
-  fault-table divergence finding from comparing the licensed IEC 60599:2022
-  4th-ed scan against `transformer_standards.json` `fault_table` (Table B)
-  and `mcp_servers/fmsr_server/server.py` `_rogers_ratio()` (Table C). Worst
-  divergences: D1 R1, D1 R3, D2 R2, T2/T3 R3 boundary. Server's own
+  fault-table divergence finding from comparing IEC 60599:2022 Table 1 against
+  `transformer_standards.json` `fault_table` (Table B) and
+  `mcp_servers/fmsr_server/server.py` `_rogers_ratio()` (Table C). Worst
+  divergences are on D1, D2, and the T2/T3 boundary; the server's own
   `server_rogers_table_note` already documents the C-vs-A drift. Pattern
   (B↔C agreement > B↔A or C↔A) suggests both encodings derived from a
   derivative source rather than IEC text. Pre-May 4 plan amended: new
-  task 2b (fix Tables B + C for at least PD/D1 R1; lockstep with FMSR
-  test fixtures). Companion analysis lives in personal-class-repo
-  `Final_Project/notes/20260428_iec60599_table_comparison.md`.
+  task 2b (fix Tables B + C for at least PD/D1; lockstep with FMSR test
+  fixtures). The full row-by-row working notes are held by Alex outside
+  this repo because they cite the paywalled IEC text.
 
 ### Documentation
 

--- a/data/scenarios/validate_realism_statistical.py
+++ b/data/scenarios/validate_realism_statistical.py
@@ -34,7 +34,6 @@ import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -50,6 +49,55 @@ SYN_GAS_COLUMNS = {gas: f"dissolved_{gas}_ppm" for gas in FAULT_GASES}
 
 # IEC 60599 fault codes.
 FAULT_CODES = ["Normal", "PD", "T1", "T2", "T3", "D1", "D2"]
+
+# Map descriptive synthetic labels to IEC fault codes. The current
+# data/processed/dga_records.csv uses descriptive strings rather than
+# IEC codes; without this mapping the chi-squared test silently dropped
+# half the rows (n_synthetic=20 but n_syn=10 in v0 baseline). Extend
+# this dict when generate_synthetic.py introduces new labels.
+PROJECT_LABEL_TO_IEC = {
+    # already-canonical IEC codes pass through
+    "Normal": "Normal",
+    "PD": "PD",
+    "T1": "T1",
+    "T2": "T2",
+    "T3": "T3",
+    "D1": "D1",
+    "D2": "D2",
+    # descriptive labels currently emitted by generate_synthetic.py
+    "Low-temperature overheating": "T1",
+    "Mid-temperature overheating": "T2",
+    "High-temperature overheating": "T3",
+    "Partial discharge": "PD",
+    "Low-energy discharge": "D1",
+    "High-energy discharge": "D1",
+    "Arc discharge": "D2",
+    "Arcing": "D2",
+}
+
+# Real-dataset source-specific label maps. IEEE DataPort, for example,
+# encodes faults as integers; mapping table per source is keyed by a
+# `--real-source` flag.
+REAL_LABEL_MAPS: dict[str, dict] = {
+    # IEEE DataPort DGA Dataset (Dissanayake 2026) uses integer fault
+    # codes 0-6 in its published Excel files. Confirmed by checking
+    # the dataset readme; numbering starts at Normal=0.
+    "ieee_dataport": {
+        0: "Normal",
+        1: "PD",
+        2: "T1",
+        3: "T2",
+        4: "T3",
+        5: "D1",
+        6: "D2",
+    },
+    "kaggle_failure_analysis": {
+        # populate when the Kaggle CSV is acquired and field-encoded labels are confirmed
+    },
+    "duval_2001_tc10": {
+        # Duval & dePablo 2001 IEC TC 10 reproduction uses IEC codes natively
+    },
+}
 
 # Reference fault prevalence from IEC TC 10 published distribution.
 # Sources:
@@ -143,21 +191,53 @@ def load_synthetic(path: Path) -> pd.DataFrame:
     missing = expected - set(df.columns)
     if missing:
         raise ValueError(f"synthetic CSV missing columns: {sorted(missing)}")
+    df = df.copy()
+    df["fault_label_iec"] = df["fault_label"].map(_normalize_synthetic_label)
+    unmapped = df[df["fault_label_iec"].isna()]["fault_label"].unique()
+    if len(unmapped) > 0:
+        raise ValueError(
+            f"synthetic CSV has unmapped fault_label values: {sorted(unmapped.tolist())}. "
+            f"Add them to PROJECT_LABEL_TO_IEC or rename in generate_synthetic.py."
+        )
     return df
 
 
-def load_real(path: Path | None) -> pd.DataFrame | None:
+def _normalize_synthetic_label(raw: str) -> str | None:
+    """Map a synthetic dataset's descriptive fault label to its IEC code.
+    Returns None on unknown labels so the caller can fail loudly."""
+    if raw is None:
+        return None
+    return PROJECT_LABEL_TO_IEC.get(str(raw).strip())
+
+
+def load_real(path: Path | None, source: str | None = None) -> pd.DataFrame | None:
     """
-    Load real DGA dataset. Expected columns:
+    Load real DGA dataset.
+
+    Supported file types: .csv, .xlsx, .xls (XLSX requires `openpyxl`).
+    Expected post-normalization columns:
         h2_ppm, ch4_ppm, c2h2_ppm, c2h4_ppm, c2h6_ppm, fault_label
-    Different datasets have different conventions (mg/L vs ppm,
-    label encoding, etc.). Adapter functions below normalize a few
-    common dataset shapes.
+
+    `source` selects a label-translation map from REAL_LABEL_MAPS; pass
+    "ieee_dataport" for IEEE DataPort's integer fault codes. If `source`
+    is None or unrecognized, label values are passed through unchanged
+    (assumed already-canonical IEC codes).
     """
     if path is None or not path.exists():
         return None
-    df = pd.read_csv(path)
-    return _normalize_real_columns(df)
+    suffix = path.suffix.lower()
+    if suffix in (".xlsx", ".xls"):
+        df = pd.read_excel(path)
+    else:
+        df = pd.read_csv(path)
+    df = _normalize_real_columns(df)
+    if "fault_label" in df.columns and source and source in REAL_LABEL_MAPS:
+        label_map = REAL_LABEL_MAPS[source]
+        if label_map:
+            df["fault_label"] = df["fault_label"].map(
+                lambda v: label_map.get(v, label_map.get(str(v), v))
+            )
+    return df
 
 
 def _normalize_real_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -299,7 +379,13 @@ def anderson_darling_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[Test
         try:
             ad = stats.anderson_ksamp([s, r])
             stat = float(ad.statistic)
-            p = float(ad.significance_level) / 100.0
+            # Modern SciPy (>=1.10) returns `pvalue` on the [0, 1] scale.
+            # Older SciPy only exposed `significance_level` capped at 0.001/0.25
+            # (also on the [0, 1] scale per modern docs, NOT a percent).
+            # Prefer pvalue when available; treat significance_level as a
+            # 0-1 probability fallback. Do not divide by 100 — that bug
+            # collapsed honest 0.25 results to 0.0025 and failed every AD test.
+            p = float(getattr(ad, "pvalue", ad.significance_level))
         except Exception as e:
             results.append(
                 TestResult(
@@ -335,11 +421,38 @@ def chi2_fault_prevalence(
     """
     from scipy import stats
 
+    # Use the IEC-normalized label column from load_synthetic. If absent
+    # (e.g. caller bypassed load_synthetic), fall back to fault_label —
+    # but the label-mapping check in load_synthetic is the canonical
+    # entry point and should always produce fault_label_iec.
+    syn_label_col = (
+        "fault_label_iec" if "fault_label_iec" in syn.columns else "fault_label"
+    )
     syn_counts = (
-        syn["fault_label"].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
+        syn[syn_label_col].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
     )
     n_syn = int(syn_counts.sum())
+    n_syn_raw = int(len(syn))
+    if n_syn != n_syn_raw:
+        # Defensive: load_synthetic should already have raised on unmapped labels,
+        # so reaching this branch means a bug. Surface it as a failing test row
+        # rather than silently truncating, per Critical-1 reviewer finding.
+        return [
+            TestResult(
+                name="chi2_fault_prevalence",
+                statistic=None,
+                pvalue=None,
+                threshold=CHI2_PVALUE_PASS,
+                passed=False,
+                detail=(
+                    f"label normalization dropped rows: n_synthetic_raw={n_syn_raw}, "
+                    f"n_syn_mapped={n_syn}. Check PROJECT_LABEL_TO_IEC."
+                ),
+            )
+        ]
     if real is not None and "fault_label" in real.columns:
+        # SciPy chisquare requires sum(observed) == sum(expected). Convert real
+        # counts to proportions, then scale to n_syn so the totals always match.
         real_counts = (
             real["fault_label"]
             .value_counts()
@@ -347,13 +460,26 @@ def chi2_fault_prevalence(
             .fillna(0)
             .astype(int)
         )
-        ref = real_counts.values
-        ref_label = "real"
+        n_real = int(real_counts.sum())
+        if n_real == 0:
+            return [
+                TestResult(
+                    name="chi2_fault_prevalence",
+                    statistic=None,
+                    pvalue=None,
+                    threshold=CHI2_PVALUE_PASS,
+                    passed=False,
+                    detail="real dataset had zero rows mapping to any IEC fault code",
+                )
+            ]
+        real_props = real_counts.values / n_real
+        ref = _scale_to_total(real_props, n_syn)
+        ref_label = f"real (n_real={n_real}, scaled to n_syn)"
     else:
         ref_props = (
             pd.Series(TC10_REFERENCE_PREVALENCE).reindex(FAULT_CODES).fillna(0).values
         )
-        ref = (ref_props * n_syn).round().astype(int)
+        ref = _scale_to_total(ref_props, n_syn)
         ref_label = "TC10 reference"
     try:
         stat, p = stats.chisquare(syn_counts.values, f_exp=ref)
@@ -380,6 +506,26 @@ def chi2_fault_prevalence(
     ]
 
 
+def _scale_to_total(props: np.ndarray, target_total: int) -> np.ndarray:
+    """Scale a proportion vector to a target integer total.
+
+    SciPy's chisquare requires `sum(observed) == sum(expected)` exactly.
+    Naive `(props * target_total).round().astype(int)` can drift by 1-2
+    due to rounding; this helper applies largest-remainder rounding so
+    the totals match.
+    """
+    raw = props * target_total
+    floored = np.floor(raw).astype(int)
+    deficit = target_total - int(floored.sum())
+    if deficit > 0:
+        # Distribute the deficit to the cells with the largest fractional remainders.
+        remainders = raw - floored
+        order = np.argsort(-remainders)
+        for i in order[:deficit]:
+            floored[i] += 1
+    return floored
+
+
 def conditional_ks_per_fault(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
     """Per-fault-class KS on each gas: gas | fault_class.
 
@@ -401,14 +547,33 @@ def conditional_ks_per_fault(syn: pd.DataFrame, real: pd.DataFrame) -> list[Test
                 detail="real dataset has no fault_label column",
             )
         ]
+    syn_label_col = (
+        "fault_label_iec" if "fault_label_iec" in syn.columns else "fault_label"
+    )
     for fault in FAULT_CODES:
-        syn_sub = syn[syn["fault_label"] == fault]
+        syn_sub = syn[syn[syn_label_col] == fault]
         real_sub = real[real["fault_label"] == fault]
         if len(syn_sub) < 3 or len(real_sub) < 3:
             continue
         for gas in FAULT_GASES:
+            real_col = f"{gas}_ppm"
+            if real_col not in real_sub.columns:
+                # Mirror the missing-column failure-record behavior used by
+                # ks_per_gas / emd_per_gas (Medium-6 reviewer finding):
+                # emit a structured failing TestResult instead of crashing.
+                results.append(
+                    TestResult(
+                        name=f"ks_{fault}_{gas}",
+                        statistic=None,
+                        pvalue=None,
+                        threshold=KS_PVALUE_PASS,
+                        passed=False,
+                        detail=f"real dataset missing column {real_col}",
+                    )
+                )
+                continue
             s = syn_sub[SYN_GAS_COLUMNS[gas]].dropna().values
-            r = real_sub[f"{gas}_ppm"].dropna().values
+            r = real_sub[real_col].dropna().values
             if len(s) < 3 or len(r) < 3:
                 continue
             stat, p = stats.ks_2samp(s, r)
@@ -494,6 +659,18 @@ def run_tests(syn: pd.DataFrame, real: pd.DataFrame | None) -> ReportCard:
     return rc
 
 
+def _md_cell(text: str) -> str:
+    """Escape Markdown table-cell content.
+
+    `|` breaks the column structure; newlines break the row entirely.
+    Both can appear in raw exception detail (e.g. multi-line SciPy
+    error messages), so render them safely. Reviewer Medium-8 finding.
+    """
+    if text is None:
+        return ""
+    return str(text).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
 def render_markdown(rc: ReportCard) -> str:
     lines = [
         "# DGA Statistical Realism Report",
@@ -509,8 +686,8 @@ def render_markdown(rc: ReportCard) -> str:
         stat = f"{t.statistic:.4f}" if t.statistic is not None else "—"
         pv = f"{t.pvalue:.4f}" if t.pvalue is not None else "—"
         lines.append(
-            f"| `{t.name}` | {stat} | {pv} | {t.threshold} | "
-            f"{'✅' if t.passed else '❌'} | {t.detail} |"
+            f"| `{_md_cell(t.name)}` | {stat} | {pv} | {t.threshold} | "
+            f"{'✅' if t.passed else '❌'} | {_md_cell(t.detail)} |"
         )
     return "\n".join(lines) + "\n"
 
@@ -520,6 +697,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--synthetic", type=Path, required=True)
     parser.add_argument("--real", type=Path, default=None)
     parser.add_argument(
+        "--real-source",
+        choices=sorted(REAL_LABEL_MAPS.keys()),
+        default=None,
+        help="select source-specific label-translation map (e.g. 'ieee_dataport' "
+        "for the integer fault codes used in IEEE DataPort's published Excel files)",
+    )
+    parser.add_argument(
         "--report", type=Path, default=Path("reports/realism_statistical.md")
     )
     parser.add_argument(
@@ -528,7 +712,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     syn = load_synthetic(args.synthetic)
-    real = load_real(args.real)
+    real = load_real(args.real, source=args.real_source)
 
     rc = run_tests(syn, real)
     rc.synthetic_path = str(args.synthetic)

--- a/data/scenarios/validate_realism_statistical.py
+++ b/data/scenarios/validate_realism_statistical.py
@@ -481,6 +481,32 @@ def chi2_fault_prevalence(
         )
         ref = _scale_to_total(ref_props, n_syn)
         ref_label = "TC10 reference"
+    # Pre-check: SciPy chisquare divides by zero on cells where expected==0
+    # but observed>0, returning NaN statistic/p-value (and emitting bare
+    # NaN to JSON, which is not strict JSON). Detect the precondition
+    # failure here and report which classes are missing from the reference
+    # rather than producing an uninterpretable result. Reviewer v2 M3.
+    zero_exp_observed = [
+        FAULT_CODES[i]
+        for i in range(len(FAULT_CODES))
+        if ref[i] == 0 and syn_counts.values[i] > 0
+    ]
+    if zero_exp_observed:
+        return [
+            TestResult(
+                name="chi2_fault_prevalence",
+                statistic=None,
+                pvalue=None,
+                threshold=CHI2_PVALUE_PASS,
+                passed=False,
+                detail=(
+                    f"reference={ref_label} has zero expected count for "
+                    f"classes {zero_exp_observed} but synthetic has rows "
+                    f"there; chi-squared undefined. Acquire a real dataset "
+                    f"covering those classes or apply a documented pseudocount."
+                ),
+            )
+        ]
     try:
         stat, p = stats.chisquare(syn_counts.values, f_exp=ref)
     except ValueError as e:
@@ -598,9 +624,11 @@ def correlation_delta(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]
     in arcing). If our synthesis emits uncorrelated noise, this
     catches it.
     """
-    syn_gases = [SYN_GAS_COLUMNS[g] for g in FAULT_GASES]
-    real_gases = [f"{g}_ppm" for g in FAULT_GASES if f"{g}_ppm" in real.columns]
-    if len(real_gases) < 2:
+    # Use only the gas columns present in BOTH frames; otherwise the two
+    # correlation matrices have different shapes and `np.abs(syn - real)`
+    # raises a broadcast ValueError. Reviewer v2 H2.
+    shared = [g for g in FAULT_GASES if f"{g}_ppm" in real.columns]
+    if len(shared) < 2:
         return [
             TestResult(
                 name="corr_delta",
@@ -608,11 +636,22 @@ def correlation_delta(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]
                 pvalue=None,
                 threshold=CORR_DELTA_PASS,
                 passed=False,
-                detail="real dataset has too few gas columns",
+                detail=(
+                    f"real dataset has too few shared gas columns "
+                    f"(found {len(shared)}: {shared}); need >=2"
+                ),
             )
         ]
-    syn_corr = syn[syn_gases].corr().values
-    real_corr = real[real_gases].corr().values
+    if len(shared) < len(FAULT_GASES):
+        # Partial overlap: emit a result on the intersection but flag it.
+        detail_suffix = (
+            f" (computed over shared {len(shared)} of {len(FAULT_GASES)} "
+            f"gases: {shared})"
+        )
+    else:
+        detail_suffix = ""
+    syn_corr = syn[[SYN_GAS_COLUMNS[g] for g in shared]].corr().values
+    real_corr = real[[f"{g}_ppm" for g in shared]].corr().values
     delta = float(np.nanmax(np.abs(syn_corr - real_corr)))
     return [
         TestResult(
@@ -621,7 +660,7 @@ def correlation_delta(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]
             pvalue=None,
             threshold=CORR_DELTA_PASS,
             passed=delta <= CORR_DELTA_PASS,
-            detail=f"max abs(corr_syn - corr_real) over {len(real_gases)} gases",
+            detail=f"max abs(corr_syn - corr_real) over {len(shared)} gases{detail_suffix}",
         )
     ]
 

--- a/data/scenarios/validate_realism_statistical.py
+++ b/data/scenarios/validate_realism_statistical.py
@@ -214,7 +214,10 @@ def load_real(path: Path | None, source: str | None = None) -> pd.DataFrame | No
     """
     Load real DGA dataset.
 
-    Supported file types: .csv, .xlsx, .xls (XLSX requires `openpyxl`).
+    Supported file types: .csv, .xlsx (XLSX uses `openpyxl`, which is in
+    `requirements.txt`). Legacy .xls files require `xlrd`, which is not
+    pinned; convert .xls → .xlsx or .csv before loading.
+
     Expected post-normalization columns:
         h2_ppm, ch4_ppm, c2h2_ppm, c2h4_ppm, c2h6_ppm, fault_label
 
@@ -226,8 +229,13 @@ def load_real(path: Path | None, source: str | None = None) -> pd.DataFrame | No
     if path is None or not path.exists():
         return None
     suffix = path.suffix.lower()
-    if suffix in (".xlsx", ".xls"):
+    if suffix == ".xlsx":
         df = pd.read_excel(path)
+    elif suffix == ".xls":
+        raise ValueError(
+            f"Legacy .xls is not supported (requires `xlrd` which is not in "
+            f"requirements.txt). Convert {path} to .xlsx or .csv first."
+        )
     else:
         df = pd.read_csv(path)
     df = _normalize_real_columns(df)
@@ -481,15 +489,13 @@ def chi2_fault_prevalence(
         )
         ref = _scale_to_total(ref_props, n_syn)
         ref_label = "TC10 reference"
-    # Pre-check: SciPy chisquare divides by zero on cells where expected==0
-    # but observed>0, returning NaN statistic/p-value (and emitting bare
-    # NaN to JSON, which is not strict JSON). Detect the precondition
-    # failure here and report which classes are missing from the reference
-    # rather than producing an uninterpretable result. Reviewer v2 M3.
+    # Two distinct precondition failures both produce NaN stat/p in SciPy
+    # and bare-NaN in JSON. Handle them upfront. Reviewer v2 M3 + v3 H1.
+    obs = syn_counts.values
+    # (a) Reference has zero expected count for a class where synthetic has
+    #     rows. chi² is undefined (divide-by-zero on the term).
     zero_exp_observed = [
-        FAULT_CODES[i]
-        for i in range(len(FAULT_CODES))
-        if ref[i] == 0 and syn_counts.values[i] > 0
+        FAULT_CODES[i] for i in range(len(FAULT_CODES)) if ref[i] == 0 and obs[i] > 0
     ]
     if zero_exp_observed:
         return [
@@ -507,8 +513,37 @@ def chi2_fault_prevalence(
                 ),
             )
         ]
+    # (b) Both observed and expected are zero for some classes. SciPy returns
+    #     NaN for the corresponding terms when this happens. Drop those
+    #     classes before the test rather than letting NaN leak into the report.
+    keep = [i for i in range(len(FAULT_CODES)) if not (ref[i] == 0 and obs[i] == 0)]
+    if len(keep) < len(FAULT_CODES):
+        dropped = [FAULT_CODES[i] for i in range(len(FAULT_CODES)) if i not in keep]
+        obs = obs[keep]
+        ref_kept = ref[keep]
+        # Re-scale ref so observed and expected totals still match exactly.
+        ref_kept = _scale_to_total(
+            ref_kept.astype(float) / ref_kept.sum() if ref_kept.sum() > 0 else ref_kept,
+            int(obs.sum()),
+        )
+        ref = ref_kept
+        ref_label = f"{ref_label}; dropped empty classes {dropped}"
+    if len(obs) < 2:
+        return [
+            TestResult(
+                name="chi2_fault_prevalence",
+                statistic=None,
+                pvalue=None,
+                threshold=CHI2_PVALUE_PASS,
+                passed=False,
+                detail=(
+                    f"after dropping empty classes only {len(obs)} classes remain; "
+                    f"chi-squared needs >= 2 categories"
+                ),
+            )
+        ]
     try:
-        stat, p = stats.chisquare(syn_counts.values, f_exp=ref)
+        stat, p = stats.chisquare(obs, f_exp=ref)
     except ValueError as e:
         return [
             TestResult(
@@ -520,6 +555,20 @@ def chi2_fault_prevalence(
                 detail=f"chisquare failed: {e}",
             )
         ]
+    if not (np.isfinite(stat) and np.isfinite(p)):
+        return [
+            TestResult(
+                name="chi2_fault_prevalence",
+                statistic=None,
+                pvalue=None,
+                threshold=CHI2_PVALUE_PASS,
+                passed=False,
+                detail=(
+                    f"chisquare returned non-finite result (stat={stat}, p={p}); "
+                    f"reference={ref_label}, observed sum={int(obs.sum())}"
+                ),
+            )
+        ]
     return [
         TestResult(
             name="chi2_fault_prevalence",
@@ -527,7 +576,7 @@ def chi2_fault_prevalence(
             pvalue=float(p),
             threshold=CHI2_PVALUE_PASS,
             passed=p > CHI2_PVALUE_PASS,
-            detail=f"reference={ref_label}, n_syn={n_syn}",
+            detail=f"reference={ref_label}, n_syn={int(obs.sum())}",
         )
     ]
 
@@ -652,7 +701,38 @@ def correlation_delta(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]
         detail_suffix = ""
     syn_corr = syn[[SYN_GAS_COLUMNS[g] for g in shared]].corr().values
     real_corr = real[[f"{g}_ppm" for g in shared]].corr().values
-    delta = float(np.nanmax(np.abs(syn_corr - real_corr)))
+    abs_delta = np.abs(syn_corr - real_corr)
+    # If a gas column is constant in either frame, pandas' .corr() emits NaN
+    # everywhere for that row/column. np.nanmax over an all-NaN array yields
+    # NaN, which then leaks into the JSON report. Detect and report. v3 H1.
+    if not np.any(np.isfinite(abs_delta)):
+        return [
+            TestResult(
+                name="corr_delta",
+                statistic=None,
+                pvalue=None,
+                threshold=CORR_DELTA_PASS,
+                passed=False,
+                detail=(
+                    "correlation matrix is all-NaN (likely a constant gas "
+                    f"column in synthetic or real over shared gases {shared})"
+                ),
+            )
+        ]
+    delta = float(np.nanmax(abs_delta))
+    if not np.isfinite(delta):
+        return [
+            TestResult(
+                name="corr_delta",
+                statistic=None,
+                pvalue=None,
+                threshold=CORR_DELTA_PASS,
+                passed=False,
+                detail=(
+                    f"correlation delta is non-finite (stat={delta}); shared gases={shared}"
+                ),
+            )
+        ]
     return [
         TestResult(
             name="corr_delta",
@@ -760,7 +840,10 @@ def main(argv: list[str] | None = None) -> int:
     args.report.parent.mkdir(parents=True, exist_ok=True)
     args.report.write_text(render_markdown(rc))
     if args.json:
-        args.json.write_text(json.dumps(rc.to_dict(), indent=2))
+        # allow_nan=False makes any future non-finite metric a hard error at
+        # report-write time rather than silently emitting bare NaN (which
+        # is not strict JSON and fails downstream consumers). v3 H1.
+        args.json.write_text(json.dumps(rc.to_dict(), indent=2, allow_nan=False))
 
     print(f"Wrote {args.report}: {rc.n_passed}/{rc.n_total} tests passed")
     return 0 if rc.n_passed == rc.n_total else 1

--- a/data/scenarios/validate_realism_statistical.py
+++ b/data/scenarios/validate_realism_statistical.py
@@ -60,20 +60,20 @@ FAULT_CODES = ["Normal", "PD", "T1", "T2", "T3", "D1", "D2"]
 # Update with empirical proportions once real dataset is loaded.
 TC10_REFERENCE_PREVALENCE = {
     "Normal": 0.27,
-    "PD":     0.07,
-    "T1":     0.13,
-    "T2":     0.10,
-    "T3":     0.13,
-    "D1":     0.13,
-    "D2":     0.17,
+    "PD": 0.07,
+    "T1": 0.13,
+    "T2": 0.10,
+    "T3": 0.13,
+    "D1": 0.13,
+    "D2": 0.17,
 }
 
 # Acceptance thresholds (see docs/dga_realism_statistical_validation.md).
-KS_PVALUE_PASS    = 0.05    # KS p > 0.05 -> distributions not distinguishable
+KS_PVALUE_PASS = 0.05  # KS p > 0.05 -> distributions not distinguishable
 EMD_NORMALIZED_PASS = 0.20  # EMD / std_real <= 0.2 -> close enough
-CHI2_PVALUE_PASS  = 0.05    # chi-squared p > 0.05 -> proportions not differ
-AD_PVALUE_PASS    = 0.05
-CORR_DELTA_PASS   = 0.20    # max(|corr_syn - corr_real|) <= 0.2
+CHI2_PVALUE_PASS = 0.05  # chi-squared p > 0.05 -> proportions not differ
+AD_PVALUE_PASS = 0.05
+CORR_DELTA_PASS = 0.20  # max(|corr_syn - corr_real|) <= 0.2
 
 
 # --- Dataclasses -------------------------------------------------------------
@@ -113,6 +113,7 @@ class ReportCard:
             if hasattr(x, "item"):
                 return x.item()
             return x
+
         return {
             "synthetic_path": self.synthetic_path,
             "real_path": self.real_path,
@@ -189,71 +190,102 @@ def _normalize_real_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 def ks_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
     from scipy import stats
+
     results = []
     for gas in FAULT_GASES:
         syn_col = SYN_GAS_COLUMNS[gas]
         real_col = f"{gas}_ppm"
         if real_col not in real.columns:
-            results.append(TestResult(
-                name=f"ks_{gas}",
-                statistic=None, pvalue=None, threshold=KS_PVALUE_PASS,
-                passed=False, detail=f"real dataset missing column {real_col}",
-            ))
+            results.append(
+                TestResult(
+                    name=f"ks_{gas}",
+                    statistic=None,
+                    pvalue=None,
+                    threshold=KS_PVALUE_PASS,
+                    passed=False,
+                    detail=f"real dataset missing column {real_col}",
+                )
+            )
             continue
         s = syn[syn_col].dropna().values
         r = real[real_col].dropna().values
         if len(s) < 5 or len(r) < 5:
-            results.append(TestResult(
-                name=f"ks_{gas}",
-                statistic=None, pvalue=None, threshold=KS_PVALUE_PASS,
-                passed=False, detail=f"too few samples (n_syn={len(s)}, n_real={len(r)})",
-            ))
+            results.append(
+                TestResult(
+                    name=f"ks_{gas}",
+                    statistic=None,
+                    pvalue=None,
+                    threshold=KS_PVALUE_PASS,
+                    passed=False,
+                    detail=f"too few samples (n_syn={len(s)}, n_real={len(r)})",
+                )
+            )
             continue
         stat, p = stats.ks_2samp(s, r)
-        results.append(TestResult(
-            name=f"ks_{gas}",
-            statistic=float(stat), pvalue=float(p),
-            threshold=KS_PVALUE_PASS, passed=p > KS_PVALUE_PASS,
-        ))
+        results.append(
+            TestResult(
+                name=f"ks_{gas}",
+                statistic=float(stat),
+                pvalue=float(p),
+                threshold=KS_PVALUE_PASS,
+                passed=p > KS_PVALUE_PASS,
+            )
+        )
     return results
 
 
 def emd_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
     from scipy import stats
+
     results = []
     for gas in FAULT_GASES:
         syn_col = SYN_GAS_COLUMNS[gas]
         real_col = f"{gas}_ppm"
         if real_col not in real.columns:
-            results.append(TestResult(
-                name=f"emd_{gas}", statistic=None, pvalue=None,
-                threshold=EMD_NORMALIZED_PASS, passed=False,
-                detail=f"real dataset missing column {real_col}",
-            ))
+            results.append(
+                TestResult(
+                    name=f"emd_{gas}",
+                    statistic=None,
+                    pvalue=None,
+                    threshold=EMD_NORMALIZED_PASS,
+                    passed=False,
+                    detail=f"real dataset missing column {real_col}",
+                )
+            )
             continue
         s = syn[syn_col].dropna().values
         r = real[real_col].dropna().values
         if len(s) < 5 or len(r) < 5:
-            results.append(TestResult(
-                name=f"emd_{gas}", statistic=None, pvalue=None,
-                threshold=EMD_NORMALIZED_PASS, passed=False,
-                detail=f"too few samples (n_syn={len(s)}, n_real={len(r)})",
-            ))
+            results.append(
+                TestResult(
+                    name=f"emd_{gas}",
+                    statistic=None,
+                    pvalue=None,
+                    threshold=EMD_NORMALIZED_PASS,
+                    passed=False,
+                    detail=f"too few samples (n_syn={len(s)}, n_real={len(r)})",
+                )
+            )
             continue
         emd = stats.wasserstein_distance(s, r)
         std_real = float(np.std(r)) or 1.0
         normalized = float(emd) / std_real
-        results.append(TestResult(
-            name=f"emd_{gas}", statistic=normalized, pvalue=None,
-            threshold=EMD_NORMALIZED_PASS,
-            passed=normalized <= EMD_NORMALIZED_PASS,
-            detail=f"raw_emd={emd:.3f}, std_real={std_real:.3f}",
-        ))
+        results.append(
+            TestResult(
+                name=f"emd_{gas}",
+                statistic=normalized,
+                pvalue=None,
+                threshold=EMD_NORMALIZED_PASS,
+                passed=normalized <= EMD_NORMALIZED_PASS,
+                detail=f"raw_emd={emd:.3f}, std_real={std_real:.3f}",
+            )
+        )
     return results
 
 
 def anderson_darling_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
     from scipy import stats
+
     results = []
     for gas in FAULT_GASES:
         syn_col = SYN_GAS_COLUMNS[gas]
@@ -269,15 +301,26 @@ def anderson_darling_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[Test
             stat = float(ad.statistic)
             p = float(ad.significance_level) / 100.0
         except Exception as e:
-            results.append(TestResult(
-                name=f"ad_{gas}", statistic=None, pvalue=None,
-                threshold=AD_PVALUE_PASS, passed=False, detail=str(e),
-            ))
+            results.append(
+                TestResult(
+                    name=f"ad_{gas}",
+                    statistic=None,
+                    pvalue=None,
+                    threshold=AD_PVALUE_PASS,
+                    passed=False,
+                    detail=str(e),
+                )
+            )
             continue
-        results.append(TestResult(
-            name=f"ad_{gas}", statistic=stat, pvalue=p,
-            threshold=AD_PVALUE_PASS, passed=p > AD_PVALUE_PASS,
-        ))
+        results.append(
+            TestResult(
+                name=f"ad_{gas}",
+                statistic=stat,
+                pvalue=p,
+                threshold=AD_PVALUE_PASS,
+                passed=p > AD_PVALUE_PASS,
+            )
+        )
     return results
 
 
@@ -291,35 +334,53 @@ def chi2_fault_prevalence(
     TC10_REFERENCE_PREVALENCE).
     """
     from scipy import stats
-    syn_counts = syn["fault_label"].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
+
+    syn_counts = (
+        syn["fault_label"].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
+    )
     n_syn = int(syn_counts.sum())
     if real is not None and "fault_label" in real.columns:
-        real_counts = real["fault_label"].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
+        real_counts = (
+            real["fault_label"]
+            .value_counts()
+            .reindex(FAULT_CODES)
+            .fillna(0)
+            .astype(int)
+        )
         ref = real_counts.values
         ref_label = "real"
     else:
-        ref_props = pd.Series(TC10_REFERENCE_PREVALENCE).reindex(FAULT_CODES).fillna(0).values
+        ref_props = (
+            pd.Series(TC10_REFERENCE_PREVALENCE).reindex(FAULT_CODES).fillna(0).values
+        )
         ref = (ref_props * n_syn).round().astype(int)
         ref_label = "TC10 reference"
     try:
         stat, p = stats.chisquare(syn_counts.values, f_exp=ref)
     except ValueError as e:
-        return [TestResult(
+        return [
+            TestResult(
+                name="chi2_fault_prevalence",
+                statistic=None,
+                pvalue=None,
+                threshold=CHI2_PVALUE_PASS,
+                passed=False,
+                detail=f"chisquare failed: {e}",
+            )
+        ]
+    return [
+        TestResult(
             name="chi2_fault_prevalence",
-            statistic=None, pvalue=None, threshold=CHI2_PVALUE_PASS,
-            passed=False, detail=f"chisquare failed: {e}",
-        )]
-    return [TestResult(
-        name="chi2_fault_prevalence",
-        statistic=float(stat), pvalue=float(p),
-        threshold=CHI2_PVALUE_PASS, passed=p > CHI2_PVALUE_PASS,
-        detail=f"reference={ref_label}, n_syn={n_syn}",
-    )]
+            statistic=float(stat),
+            pvalue=float(p),
+            threshold=CHI2_PVALUE_PASS,
+            passed=p > CHI2_PVALUE_PASS,
+            detail=f"reference={ref_label}, n_syn={n_syn}",
+        )
+    ]
 
 
-def conditional_ks_per_fault(
-    syn: pd.DataFrame, real: pd.DataFrame
-) -> list[TestResult]:
+def conditional_ks_per_fault(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
     """Per-fault-class KS on each gas: gas | fault_class.
 
     Catches the case where marginal distributions match but
@@ -327,13 +388,19 @@ def conditional_ks_per_fault(
     realistic H2 mean but unrealistic CH4 mean).
     """
     from scipy import stats
+
     results = []
     if "fault_label" not in real.columns:
-        return [TestResult(
-            name="conditional_ks", statistic=None, pvalue=None,
-            threshold=KS_PVALUE_PASS, passed=False,
-            detail="real dataset has no fault_label column",
-        )]
+        return [
+            TestResult(
+                name="conditional_ks",
+                statistic=None,
+                pvalue=None,
+                threshold=KS_PVALUE_PASS,
+                passed=False,
+                detail="real dataset has no fault_label column",
+            )
+        ]
     for fault in FAULT_CODES:
         syn_sub = syn[syn["fault_label"] == fault]
         real_sub = real[real["fault_label"] == fault]
@@ -345,12 +412,16 @@ def conditional_ks_per_fault(
             if len(s) < 3 or len(r) < 3:
                 continue
             stat, p = stats.ks_2samp(s, r)
-            results.append(TestResult(
-                name=f"ks_{fault}_{gas}",
-                statistic=float(stat), pvalue=float(p),
-                threshold=KS_PVALUE_PASS, passed=p > KS_PVALUE_PASS,
-                detail=f"n_syn={len(s)}, n_real={len(r)}",
-            ))
+            results.append(
+                TestResult(
+                    name=f"ks_{fault}_{gas}",
+                    statistic=float(stat),
+                    pvalue=float(p),
+                    threshold=KS_PVALUE_PASS,
+                    passed=p > KS_PVALUE_PASS,
+                    detail=f"n_syn={len(s)}, n_real={len(r)}",
+                )
+            )
     return results
 
 
@@ -365,19 +436,29 @@ def correlation_delta(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]
     syn_gases = [SYN_GAS_COLUMNS[g] for g in FAULT_GASES]
     real_gases = [f"{g}_ppm" for g in FAULT_GASES if f"{g}_ppm" in real.columns]
     if len(real_gases) < 2:
-        return [TestResult(
-            name="corr_delta", statistic=None, pvalue=None,
-            threshold=CORR_DELTA_PASS, passed=False,
-            detail="real dataset has too few gas columns",
-        )]
+        return [
+            TestResult(
+                name="corr_delta",
+                statistic=None,
+                pvalue=None,
+                threshold=CORR_DELTA_PASS,
+                passed=False,
+                detail="real dataset has too few gas columns",
+            )
+        ]
     syn_corr = syn[syn_gases].corr().values
     real_corr = real[real_gases].corr().values
     delta = float(np.nanmax(np.abs(syn_corr - real_corr)))
-    return [TestResult(
-        name="corr_delta", statistic=delta, pvalue=None,
-        threshold=CORR_DELTA_PASS, passed=delta <= CORR_DELTA_PASS,
-        detail=f"max abs(corr_syn - corr_real) over {len(real_gases)} gases",
-    )]
+    return [
+        TestResult(
+            name="corr_delta",
+            statistic=delta,
+            pvalue=None,
+            threshold=CORR_DELTA_PASS,
+            passed=delta <= CORR_DELTA_PASS,
+            detail=f"max abs(corr_syn - corr_real) over {len(real_gases)} gases",
+        )
+    ]
 
 
 # --- Driver ------------------------------------------------------------------
@@ -392,14 +473,18 @@ def run_tests(syn: pd.DataFrame, real: pd.DataFrame | None) -> ReportCard:
     )
     rc.tests.extend(chi2_fault_prevalence(syn, real))
     if real is None:
-        rc.tests.append(TestResult(
-            name="real_dataset_present",
-            statistic=None, pvalue=None, threshold=0.0,
-            passed=False,
-            detail="No real dataset loaded; only TC10 reference prevalence "
-                   "was checked. Acquire a real DGA dataset (see "
-                   "docs/dga_realism_statistical_validation.md § Datasets).",
-        ))
+        rc.tests.append(
+            TestResult(
+                name="real_dataset_present",
+                statistic=None,
+                pvalue=None,
+                threshold=0.0,
+                passed=False,
+                detail="No real dataset loaded; only TC10 reference prevalence "
+                "was checked. Acquire a real DGA dataset (see "
+                "docs/dga_realism_statistical_validation.md § Datasets).",
+            )
+        )
         return rc
     rc.tests.extend(ks_per_gas(syn, real))
     rc.tests.extend(emd_per_gas(syn, real))
@@ -434,9 +519,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--synthetic", type=Path, required=True)
     parser.add_argument("--real", type=Path, default=None)
-    parser.add_argument("--report", type=Path, default=Path("reports/realism_statistical.md"))
-    parser.add_argument("--json", type=Path, default=None,
-                        help="optional JSON dump of full ReportCard")
+    parser.add_argument(
+        "--report", type=Path, default=Path("reports/realism_statistical.md")
+    )
+    parser.add_argument(
+        "--json", type=Path, default=None, help="optional JSON dump of full ReportCard"
+    )
     args = parser.parse_args(argv)
 
     syn = load_synthetic(args.synthetic)

--- a/data/scenarios/validate_realism_statistical.py
+++ b/data/scenarios/validate_realism_statistical.py
@@ -18,13 +18,13 @@ acceptance thresholds, and the ranked dataset list.
 
 Usage:
     python3 data/scenarios/validate_realism_statistical.py \\
-        --synthetic data/processed/dga_records.csv \\
-        --real      data/external/ieee_dataport_dga.csv \\
-        --report    reports/realism_statistical_v1.md
+        --synthetic   data/processed/dga_records.csv \\
+        --real        data/external/ieee_dataport_dga.xlsx \\
+        --real-source ieee_dataport \\
+        --report      reports/realism_statistical_v1.md
 
-The --real path defaults to data/external/<dataset>.csv. If absent, the
-script emits a stub report listing which dataset(s) need to be acquired
-and from where.
+If --real is absent, the script emits a stub report listing which
+dataset(s) need to be acquired and from where.
 """
 
 from __future__ import annotations
@@ -97,6 +97,23 @@ REAL_LABEL_MAPS: dict[str, dict] = {
     "duval_2001_tc10": {
         # Duval & dePablo 2001 IEC TC 10 reproduction uses IEC codes natively
     },
+}
+
+# Canonical aliases applied to real fault labels AFTER any source-specific
+# REAL_LABEL_MAPS translation. Catches the common cases where a dataset
+# uses the IEC server's "N" code for Normal/Inconclusive, or a slightly
+# different spelling. Anything not handled here is treated as an unknown
+# label and rejected by load_real (Reviewer v4 H1).
+REAL_LABEL_ALIASES = {
+    "N": "Normal",
+    "Normal/Inconclusive": "Normal",
+    "normal": "Normal",
+    "pd": "PD",
+    "t1": "T1",
+    "t2": "T2",
+    "t3": "T3",
+    "d1": "D1",
+    "d2": "D2",
 }
 
 # Reference fault prevalence from IEC TC 10 published distribution.
@@ -239,11 +256,29 @@ def load_real(path: Path | None, source: str | None = None) -> pd.DataFrame | No
     else:
         df = pd.read_csv(path)
     df = _normalize_real_columns(df)
-    if "fault_label" in df.columns and source and source in REAL_LABEL_MAPS:
-        label_map = REAL_LABEL_MAPS[source]
-        if label_map:
-            df["fault_label"] = df["fault_label"].map(
-                lambda v: label_map.get(v, label_map.get(str(v), v))
+    if "fault_label" in df.columns:
+        if source and source in REAL_LABEL_MAPS:
+            label_map = REAL_LABEL_MAPS[source]
+            if label_map:
+                df["fault_label"] = df["fault_label"].map(
+                    lambda v: label_map.get(v, label_map.get(str(v), v))
+                )
+        # Apply canonical aliases (e.g. "N" -> "Normal") after source mapping
+        # so we accept both raw IEC codes and the small set of well-known
+        # aliases. Reviewer v4 H1.
+        df["fault_label"] = df["fault_label"].map(
+            lambda v: REAL_LABEL_ALIASES.get(v, v) if v is not None else v
+        )
+        # Validate every label maps to a known IEC fault code. Anything else
+        # would silently drop rows from the chi-squared reference, and the
+        # test could pass by accident on the surviving subset.
+        unknown = sorted(set(df["fault_label"].dropna().unique()) - set(FAULT_CODES))
+        if unknown:
+            raise ValueError(
+                f"real dataset has fault_label values not in FAULT_CODES "
+                f"({FAULT_CODES}): {unknown}. Add the source-specific "
+                f"translation to REAL_LABEL_MAPS[{source!r}] or extend "
+                f"REAL_LABEL_ALIASES, then re-run."
             )
     return df
 
@@ -469,6 +504,7 @@ def chi2_fault_prevalence(
             .astype(int)
         )
         n_real = int(real_counts.sum())
+        n_real_raw = int(len(real))
         if n_real == 0:
             return [
                 TestResult(
@@ -477,12 +513,23 @@ def chi2_fault_prevalence(
                     pvalue=None,
                     threshold=CHI2_PVALUE_PASS,
                     passed=False,
-                    detail="real dataset had zero rows mapping to any IEC fault code",
+                    detail=(
+                        f"real dataset had zero rows mapping to any IEC fault code "
+                        f"(n_real_raw={n_real_raw})"
+                    ),
                 )
             ]
         real_props = real_counts.values / n_real
         ref = _scale_to_total(real_props, n_syn)
-        ref_label = f"real (n_real={n_real}, scaled to n_syn)"
+        # Surface both raw and recognized counts so any future drop is visible
+        # even when validation slips through (Reviewer v4 H1 — "include both
+        # raw and recognized counts in the detail so dropped rows cannot hide").
+        real_count_note = (
+            f"n_real={n_real}"
+            if n_real == n_real_raw
+            else f"n_real_recognized={n_real}/{n_real_raw}"
+        )
+        ref_label = f"real ({real_count_note}, scaled to n_syn)"
     else:
         ref_props = (
             pd.Series(TC10_REFERENCE_PREVALENCE).reindex(FAULT_CODES).fillna(0).values

--- a/data/scenarios/validate_realism_statistical.py
+++ b/data/scenarios/validate_realism_statistical.py
@@ -1,0 +1,459 @@
+"""
+Statistical-fidelity validation for synthetic transformer DGA data.
+
+Compares our synthesized DGA gas-concentration distributions
+(`data/processed/dga_records.csv`, produced by `data/generate_synthetic.py`)
+against published real-world DGA datasets, and emits a pass/fail report card.
+
+This is Layer 3 of scenario validation:
+
+    Layer 1  schema/structural   data/scenarios/validate_scenarios.py
+    Layer 2  narrative realism   docs/scenario_realism_validation.md
+                                 (mentor + domain-expert review)
+    Layer 3  statistical fidelity  THIS FILE
+                                 (KS / EMD / chi-squared per gas + fault)
+
+See docs/dga_realism_statistical_validation.md for full methodology,
+acceptance thresholds, and the ranked dataset list.
+
+Usage:
+    python3 data/scenarios/validate_realism_statistical.py \\
+        --synthetic data/processed/dga_records.csv \\
+        --real      data/external/ieee_dataport_dga.csv \\
+        --report    reports/realism_statistical_v1.md
+
+The --real path defaults to data/external/<dataset>.csv. If absent, the
+script emits a stub report listing which dataset(s) need to be acquired
+and from where.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+# --- Constants ---------------------------------------------------------------
+
+# Five DGA fault gases used by IEC 60599 Rogers Ratio (CO/CO2 are excluded
+# because cellulose-side gases are tracked under IEEE C57.104 separately).
+FAULT_GASES = ["h2", "ch4", "c2h2", "c2h4", "c2h6"]
+
+# Synthetic CSV column names (per data/generate_synthetic.py output schema).
+SYN_GAS_COLUMNS = {gas: f"dissolved_{gas}_ppm" for gas in FAULT_GASES}
+
+# IEC 60599 fault codes.
+FAULT_CODES = ["Normal", "PD", "T1", "T2", "T3", "D1", "D2"]
+
+# Reference fault prevalence from IEC TC 10 published distribution.
+# Sources:
+#   - IEC 60599:2022 Annex A (TC 10 case database, ~117 cases)
+#   - Duval & dePablo 2001, IEEE Electrical Insulation Magazine 17(2)
+#     "Interpretation of Gas-In-Oil Analysis Using New IEC Publication 60599
+#      and IEC TC 10 Databases"
+# Update with empirical proportions once real dataset is loaded.
+TC10_REFERENCE_PREVALENCE = {
+    "Normal": 0.27,
+    "PD":     0.07,
+    "T1":     0.13,
+    "T2":     0.10,
+    "T3":     0.13,
+    "D1":     0.13,
+    "D2":     0.17,
+}
+
+# Acceptance thresholds (see docs/dga_realism_statistical_validation.md).
+KS_PVALUE_PASS    = 0.05    # KS p > 0.05 -> distributions not distinguishable
+EMD_NORMALIZED_PASS = 0.20  # EMD / std_real <= 0.2 -> close enough
+CHI2_PVALUE_PASS  = 0.05    # chi-squared p > 0.05 -> proportions not differ
+AD_PVALUE_PASS    = 0.05
+CORR_DELTA_PASS   = 0.20    # max(|corr_syn - corr_real|) <= 0.2
+
+
+# --- Dataclasses -------------------------------------------------------------
+
+
+@dataclass
+class TestResult:
+    name: str
+    statistic: float | None
+    pvalue: float | None
+    threshold: float
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ReportCard:
+    synthetic_path: str
+    real_path: str | None
+    n_synthetic: int
+    n_real: int | None
+    tests: list[TestResult] = field(default_factory=list)
+
+    @property
+    def n_passed(self) -> int:
+        return sum(1 for t in self.tests if t.passed)
+
+    @property
+    def n_total(self) -> int:
+        return len(self.tests)
+
+    def to_dict(self) -> dict:
+        def _scalar(x):
+            # numpy scalars (bool_, float64, int64) aren't directly JSON-serializable.
+            if x is None:
+                return None
+            if hasattr(x, "item"):
+                return x.item()
+            return x
+        return {
+            "synthetic_path": self.synthetic_path,
+            "real_path": self.real_path,
+            "n_synthetic": _scalar(self.n_synthetic),
+            "n_real": _scalar(self.n_real),
+            "tests": [
+                {
+                    "name": t.name,
+                    "statistic": _scalar(t.statistic),
+                    "pvalue": _scalar(t.pvalue),
+                    "threshold": _scalar(t.threshold),
+                    "passed": bool(t.passed),
+                    "detail": t.detail,
+                }
+                for t in self.tests
+            ],
+            "summary": {"passed": self.n_passed, "total": self.n_total},
+        }
+
+
+# --- IO ----------------------------------------------------------------------
+
+
+def load_synthetic(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    expected = set(SYN_GAS_COLUMNS.values()) | {"fault_label"}
+    missing = expected - set(df.columns)
+    if missing:
+        raise ValueError(f"synthetic CSV missing columns: {sorted(missing)}")
+    return df
+
+
+def load_real(path: Path | None) -> pd.DataFrame | None:
+    """
+    Load real DGA dataset. Expected columns:
+        h2_ppm, ch4_ppm, c2h2_ppm, c2h4_ppm, c2h6_ppm, fault_label
+    Different datasets have different conventions (mg/L vs ppm,
+    label encoding, etc.). Adapter functions below normalize a few
+    common dataset shapes.
+    """
+    if path is None or not path.exists():
+        return None
+    df = pd.read_csv(path)
+    return _normalize_real_columns(df)
+
+
+def _normalize_real_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Best-effort schema normalization for known real datasets.
+
+    Recognized shapes:
+      - IEEE DataPort DGA Dataset (Dissanayake 2026, DOI 10.21227/27vy-h479)
+      - Kaggle: shashwatwork/failure-analysis-in-power-transformers-dataset
+      - GitHub: ahmedtariq71/Dataset1
+      - IEC TC 10 derived (Duval & dePablo 2001 reproduction)
+
+    Add a new branch when introducing a new source.
+    """
+    cols = {c.lower(): c for c in df.columns}
+    rename = {}
+    for gas in FAULT_GASES:
+        for candidate in (gas, f"{gas}_ppm", f"dissolved_{gas}_ppm", gas.upper()):
+            if candidate.lower() in cols:
+                rename[cols[candidate.lower()]] = f"{gas}_ppm"
+                break
+    for label_col in ("fault_label", "fault", "label", "class", "actual_fault"):
+        if label_col in cols:
+            rename[cols[label_col]] = "fault_label"
+            break
+    return df.rename(columns=rename)
+
+
+# --- Statistical tests -------------------------------------------------------
+
+
+def ks_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
+    from scipy import stats
+    results = []
+    for gas in FAULT_GASES:
+        syn_col = SYN_GAS_COLUMNS[gas]
+        real_col = f"{gas}_ppm"
+        if real_col not in real.columns:
+            results.append(TestResult(
+                name=f"ks_{gas}",
+                statistic=None, pvalue=None, threshold=KS_PVALUE_PASS,
+                passed=False, detail=f"real dataset missing column {real_col}",
+            ))
+            continue
+        s = syn[syn_col].dropna().values
+        r = real[real_col].dropna().values
+        if len(s) < 5 or len(r) < 5:
+            results.append(TestResult(
+                name=f"ks_{gas}",
+                statistic=None, pvalue=None, threshold=KS_PVALUE_PASS,
+                passed=False, detail=f"too few samples (n_syn={len(s)}, n_real={len(r)})",
+            ))
+            continue
+        stat, p = stats.ks_2samp(s, r)
+        results.append(TestResult(
+            name=f"ks_{gas}",
+            statistic=float(stat), pvalue=float(p),
+            threshold=KS_PVALUE_PASS, passed=p > KS_PVALUE_PASS,
+        ))
+    return results
+
+
+def emd_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
+    from scipy import stats
+    results = []
+    for gas in FAULT_GASES:
+        syn_col = SYN_GAS_COLUMNS[gas]
+        real_col = f"{gas}_ppm"
+        if real_col not in real.columns:
+            results.append(TestResult(
+                name=f"emd_{gas}", statistic=None, pvalue=None,
+                threshold=EMD_NORMALIZED_PASS, passed=False,
+                detail=f"real dataset missing column {real_col}",
+            ))
+            continue
+        s = syn[syn_col].dropna().values
+        r = real[real_col].dropna().values
+        if len(s) < 5 or len(r) < 5:
+            results.append(TestResult(
+                name=f"emd_{gas}", statistic=None, pvalue=None,
+                threshold=EMD_NORMALIZED_PASS, passed=False,
+                detail=f"too few samples (n_syn={len(s)}, n_real={len(r)})",
+            ))
+            continue
+        emd = stats.wasserstein_distance(s, r)
+        std_real = float(np.std(r)) or 1.0
+        normalized = float(emd) / std_real
+        results.append(TestResult(
+            name=f"emd_{gas}", statistic=normalized, pvalue=None,
+            threshold=EMD_NORMALIZED_PASS,
+            passed=normalized <= EMD_NORMALIZED_PASS,
+            detail=f"raw_emd={emd:.3f}, std_real={std_real:.3f}",
+        ))
+    return results
+
+
+def anderson_darling_per_gas(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
+    from scipy import stats
+    results = []
+    for gas in FAULT_GASES:
+        syn_col = SYN_GAS_COLUMNS[gas]
+        real_col = f"{gas}_ppm"
+        if real_col not in real.columns:
+            continue
+        s = syn[syn_col].dropna().values
+        r = real[real_col].dropna().values
+        if len(s) < 5 or len(r) < 5:
+            continue
+        try:
+            ad = stats.anderson_ksamp([s, r])
+            stat = float(ad.statistic)
+            p = float(ad.significance_level) / 100.0
+        except Exception as e:
+            results.append(TestResult(
+                name=f"ad_{gas}", statistic=None, pvalue=None,
+                threshold=AD_PVALUE_PASS, passed=False, detail=str(e),
+            ))
+            continue
+        results.append(TestResult(
+            name=f"ad_{gas}", statistic=stat, pvalue=p,
+            threshold=AD_PVALUE_PASS, passed=p > AD_PVALUE_PASS,
+        ))
+    return results
+
+
+def chi2_fault_prevalence(
+    syn: pd.DataFrame,
+    real: pd.DataFrame | None,
+) -> list[TestResult]:
+    """Chi-squared on fault-class proportions.
+
+    Compares synthetic prevalence vs (real if provided, else
+    TC10_REFERENCE_PREVALENCE).
+    """
+    from scipy import stats
+    syn_counts = syn["fault_label"].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
+    n_syn = int(syn_counts.sum())
+    if real is not None and "fault_label" in real.columns:
+        real_counts = real["fault_label"].value_counts().reindex(FAULT_CODES).fillna(0).astype(int)
+        ref = real_counts.values
+        ref_label = "real"
+    else:
+        ref_props = pd.Series(TC10_REFERENCE_PREVALENCE).reindex(FAULT_CODES).fillna(0).values
+        ref = (ref_props * n_syn).round().astype(int)
+        ref_label = "TC10 reference"
+    try:
+        stat, p = stats.chisquare(syn_counts.values, f_exp=ref)
+    except ValueError as e:
+        return [TestResult(
+            name="chi2_fault_prevalence",
+            statistic=None, pvalue=None, threshold=CHI2_PVALUE_PASS,
+            passed=False, detail=f"chisquare failed: {e}",
+        )]
+    return [TestResult(
+        name="chi2_fault_prevalence",
+        statistic=float(stat), pvalue=float(p),
+        threshold=CHI2_PVALUE_PASS, passed=p > CHI2_PVALUE_PASS,
+        detail=f"reference={ref_label}, n_syn={n_syn}",
+    )]
+
+
+def conditional_ks_per_fault(
+    syn: pd.DataFrame, real: pd.DataFrame
+) -> list[TestResult]:
+    """Per-fault-class KS on each gas: gas | fault_class.
+
+    Catches the case where marginal distributions match but
+    per-fault gas signatures don't (e.g. synthetic 'PD' has
+    realistic H2 mean but unrealistic CH4 mean).
+    """
+    from scipy import stats
+    results = []
+    if "fault_label" not in real.columns:
+        return [TestResult(
+            name="conditional_ks", statistic=None, pvalue=None,
+            threshold=KS_PVALUE_PASS, passed=False,
+            detail="real dataset has no fault_label column",
+        )]
+    for fault in FAULT_CODES:
+        syn_sub = syn[syn["fault_label"] == fault]
+        real_sub = real[real["fault_label"] == fault]
+        if len(syn_sub) < 3 or len(real_sub) < 3:
+            continue
+        for gas in FAULT_GASES:
+            s = syn_sub[SYN_GAS_COLUMNS[gas]].dropna().values
+            r = real_sub[f"{gas}_ppm"].dropna().values
+            if len(s) < 3 or len(r) < 3:
+                continue
+            stat, p = stats.ks_2samp(s, r)
+            results.append(TestResult(
+                name=f"ks_{fault}_{gas}",
+                statistic=float(stat), pvalue=float(p),
+                threshold=KS_PVALUE_PASS, passed=p > KS_PVALUE_PASS,
+                detail=f"n_syn={len(s)}, n_real={len(r)}",
+            ))
+    return results
+
+
+def correlation_delta(syn: pd.DataFrame, real: pd.DataFrame) -> list[TestResult]:
+    """Compare inter-gas correlation matrices.
+
+    Real DGA data has structured inter-gas correlations
+    (CH4/C2H6 co-vary in low-temp thermal faults; C2H2/C2H4 co-vary
+    in arcing). If our synthesis emits uncorrelated noise, this
+    catches it.
+    """
+    syn_gases = [SYN_GAS_COLUMNS[g] for g in FAULT_GASES]
+    real_gases = [f"{g}_ppm" for g in FAULT_GASES if f"{g}_ppm" in real.columns]
+    if len(real_gases) < 2:
+        return [TestResult(
+            name="corr_delta", statistic=None, pvalue=None,
+            threshold=CORR_DELTA_PASS, passed=False,
+            detail="real dataset has too few gas columns",
+        )]
+    syn_corr = syn[syn_gases].corr().values
+    real_corr = real[real_gases].corr().values
+    delta = float(np.nanmax(np.abs(syn_corr - real_corr)))
+    return [TestResult(
+        name="corr_delta", statistic=delta, pvalue=None,
+        threshold=CORR_DELTA_PASS, passed=delta <= CORR_DELTA_PASS,
+        detail=f"max abs(corr_syn - corr_real) over {len(real_gases)} gases",
+    )]
+
+
+# --- Driver ------------------------------------------------------------------
+
+
+def run_tests(syn: pd.DataFrame, real: pd.DataFrame | None) -> ReportCard:
+    rc = ReportCard(
+        synthetic_path="",
+        real_path=None,
+        n_synthetic=len(syn),
+        n_real=len(real) if real is not None else None,
+    )
+    rc.tests.extend(chi2_fault_prevalence(syn, real))
+    if real is None:
+        rc.tests.append(TestResult(
+            name="real_dataset_present",
+            statistic=None, pvalue=None, threshold=0.0,
+            passed=False,
+            detail="No real dataset loaded; only TC10 reference prevalence "
+                   "was checked. Acquire a real DGA dataset (see "
+                   "docs/dga_realism_statistical_validation.md § Datasets).",
+        ))
+        return rc
+    rc.tests.extend(ks_per_gas(syn, real))
+    rc.tests.extend(emd_per_gas(syn, real))
+    rc.tests.extend(anderson_darling_per_gas(syn, real))
+    rc.tests.extend(conditional_ks_per_fault(syn, real))
+    rc.tests.extend(correlation_delta(syn, real))
+    return rc
+
+
+def render_markdown(rc: ReportCard) -> str:
+    lines = [
+        "# DGA Statistical Realism Report",
+        "",
+        f"- Synthetic: `{rc.synthetic_path}` (n={rc.n_synthetic})",
+        f"- Real: `{rc.real_path or '(none loaded)'}` (n={rc.n_real})",
+        f"- Result: **{rc.n_passed}/{rc.n_total}** tests passed",
+        "",
+        "| Test | Statistic | p-value | Threshold | Pass | Detail |",
+        "|------|-----------|---------|-----------|------|--------|",
+    ]
+    for t in rc.tests:
+        stat = f"{t.statistic:.4f}" if t.statistic is not None else "—"
+        pv = f"{t.pvalue:.4f}" if t.pvalue is not None else "—"
+        lines.append(
+            f"| `{t.name}` | {stat} | {pv} | {t.threshold} | "
+            f"{'✅' if t.passed else '❌'} | {t.detail} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--synthetic", type=Path, required=True)
+    parser.add_argument("--real", type=Path, default=None)
+    parser.add_argument("--report", type=Path, default=Path("reports/realism_statistical.md"))
+    parser.add_argument("--json", type=Path, default=None,
+                        help="optional JSON dump of full ReportCard")
+    args = parser.parse_args(argv)
+
+    syn = load_synthetic(args.synthetic)
+    real = load_real(args.real)
+
+    rc = run_tests(syn, real)
+    rc.synthetic_path = str(args.synthetic)
+    rc.real_path = str(args.real) if args.real else None
+
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(render_markdown(rc))
+    if args.json:
+        args.json.write_text(json.dumps(rc.to_dict(), indent=2))
+
+    print(f"Wrote {args.report}: {rc.n_passed}/{rc.n_total} tests passed")
+    return 0 if rc.n_passed == rc.n_total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/dga_realism_statistical_validation.md
+++ b/docs/dga_realism_statistical_validation.md
@@ -545,3 +545,195 @@ Questions to follow up on, ordered by leverage:
 - **Gate B (Apr 30):** real dataset acquired; first L3 run produces a non-stub report.
 - **Gate C (May 2):** at minimum the chi-squared on fault prevalence and KS on H2 + C2H2 pass; remaining failing tests documented as limitations.
 - **Gate D (May 4):** L3 report-card cited in final paper as evidence of statistical realism.
+
+---
+
+## 12. Handoff to Akshat
+
+**Owner change:** Alex authored this scaffolding (skeleton + doc + v0
+baseline + table-divergence finding). **Akshat takes over L3 execution**
+from here (real-data acquisition, v1 run, tuning loop, final-paper figure).
+Issue `#53` already lists Akshat as owner of "validate auto-generated
+scenarios against hand-crafted reference set"; L3 is the quantitative arm
+of that validation lane.
+
+### 12.1 First three commands
+
+```bash
+# 1. Get on the branch (or use any worktree of your choice)
+cd <repo-root>
+git fetch team13
+git checkout team13/dat/realism-statistical-validation
+
+# 2. Sanity-check the skeleton runs
+.venv/bin/python data/scenarios/validate_realism_statistical.py \
+    --synthetic data/processed/dga_records.csv \
+    --report /tmp/r.md
+# Expect: "0/2 tests passed" (chi² fails vs TC 10 reference, real dataset missing)
+
+# 3. Pull the IEEE DataPort dataset (Columbia IEEE access required; Kaggle
+#    backstop if blocked) and re-run with --real
+mkdir -p data/external
+# … download dga.xlsx to data/external/ieee_dataport_dga.csv …
+.venv/bin/python data/scenarios/validate_realism_statistical.py \
+    --synthetic data/processed/dga_records.csv \
+    --real      data/external/ieee_dataport_dga.csv \
+    --report    reports/realism_statistical_v1.md \
+    --json      reports/realism_statistical_v1.json
+```
+
+### 12.2 What you have
+
+- Runnable script (`data/scenarios/validate_realism_statistical.py`),
+  black-clean, scipy in `requirements.txt`, smoke-tested.
+- This doc — methodology, datasets, thresholds, plan, plug-in for PR #147,
+  open questions.
+- v0 baseline in `reports/realism_statistical_v0.md` showing the
+  prevalence-divergence signal already exists.
+- Three-way fault-table divergence finding in § 2.4 — explains why
+  conditional-KS is likely to fail until the JSON / server tables are
+  reconciled with IEC.
+
+### 12.3 What you need to source
+
+- **IEC 60599:2022 PDF.** Alex's copy is in his personal class repo,
+  gitignored, and not redistributable (IEC copyright). Use Columbia ILL or
+  ask Dhaval for an IBM-licensed copy.
+- **IEEE DataPort DGA Dataset** (DOI 10.21227/27vy-h479) — primary target
+  per § 4. Columbia IEEE subscription should cover it; ask the engineering
+  library if not.
+- **Kaggle `failure-analysis-in-power-transformers-dataset`** — backstop
+  if IEEE DataPort is gated.
+- **Bashir et al. 2024** ("Optimized Synthetic Data Integration with
+  Transformer's DGA Data...") — the closest precedent paper for synthetic-
+  vs-real DGA validation methodology. Cite in final paper.
+
+### 12.4 Decisions you'll need to make
+
+1. **Run L3 v1 before or after the table-fix PR (§ 7 task 2b)?**
+   - *Before*: faster, but conditional-KS will likely fail on D1/D2/T1 in
+     ways that require re-running after the table fix.
+   - *After*: cleaner, but blocked on someone (Alex or you) landing the
+     fix-the-table PR first.
+   - **Suggested:** run a v1 anyway *before* the fix to capture the "broken-
+     baseline" report card; that becomes evidence in the paper that the
+     reconciliation was necessary, not cosmetic.
+
+2. **Treat synthetic CO/CO2 data as out-of-scope for L3, or add a
+   second IEEE-C57.104-style cellulose test?** § 9 currently flags this as
+   future work; if you have time, an extra two tests on CO + CO2 marginals
+   would strengthen the paper's "we covered both standards" claim.
+
+3. **Acceptance thresholds.** § 5.1 defaults: KS p > 0.05, EMD/std ≤ 0.20,
+   chi² p > 0.05, corr Δ ≤ 0.20. These are reasonable starting values from
+   the literature but can be tuned once you have a real-data baseline. Be
+   prepared to defend whatever threshold you set in the paper.
+
+4. **Sample size on the synthetic side.** `dga_records.csv` is currently
+   20 rows — too small for KS to be meaningful. Either extend
+   `make_dga_records()` to ~600 samples (30 days × 20 transformers) or
+   bootstrap from the existing 20. Bootstrapping is a one-line change but
+   doesn't add new physical signal.
+
+### 12.5 Where to ask for help
+
+- **Alex** for PR #148 / scaffolding-side questions, the IEC table
+  comparison, edition pinning, or the personal-repo full diff matrix.
+- **Aaron (afan2g, PR #147)** for the scenario-generator path and how L3
+  should hook into its promotion script.
+- **Dhaval** for IEC standard interpretation, IBM-internal datasets, or
+  whether IBM AssetOpsBench has an authoritative reference dataset.
+- **Tanisha** for `transformer_standards.json` provenance — she authored
+  it and will know what source the encoded ratio bounds came from.
+
+---
+
+## 13. Appendix A — IEC 60599:2022 Table 1 verbatim
+
+In the standard's own column notation:
+
+```
+Case  Characteristic fault              C2H2/C2H4    CH4/H2       C2H4/C2H6
+PD    Partial discharges                NS           < 0.1        < 0.2
+D1    Discharges of low energy          > 1          0.1 to 0.5   > 1
+D2    Discharges of high energy         0.6 to 2.5   0.1 to 1     > 2
+T1    Thermal fault t < 300 °C          NS           > 1 (NS)     < 1
+T2    Thermal fault 300 °C < t < 700 °C < 0.1        > 1          1 to 4
+T3    Thermal fault t > 700 °C          < 0.2        > 1          > 4
+```
+
+`NS` = "non-significant whatever the value" — treat as "any" in code.
+
+Notes from the standard text:
+- Note 1: some countries use `C2H2/C2H6` instead of `CH4/H2`; some use
+  slightly different ratio limits.
+- Note 2: gas-ratio calculation conditions in § 6.1 c).
+- Note 3: PD threshold stricter for instrument transformers (`CH4/H2 < 0.2`)
+  and bushings (`CH4/H2 < 0.07`).
+- Note 4: stray oil gassing produces PD-like patterns but is not a real
+  fault.
+
+In the JSON's R-numbering convention (`R1 = CH4/H2`, `R2 = C2H2/C2H4`,
+`R3 = C2H4/C2H6`):
+
+| Code | R1 (CH4/H2) | R2 (C2H2/C2H4) | R3 (C2H4/C2H6) |
+|------|-------------|----------------|----------------|
+| PD | < 0.1 | NS | < 0.2 |
+| D1 | 0.1 – 0.5 | > 1 | > 1 |
+| D2 | 0.1 – 1 | 0.6 – 2.5 | > 2 |
+| T1 | > 1 (NS) | NS | < 1 |
+| T2 | > 1 | < 0.1 | 1 – 4 |
+| T3 | > 1 | < 0.2 | > 4 |
+
+---
+
+## 14. Appendix B — Three-way diff matrix (full)
+
+Tables under comparison (using JSON R-numbering throughout):
+
+- **A** = IEC 60599:2022 Table 1 (the canonical standard).
+- **B** = `data/knowledge/transformer_standards.json § iec_60599.rogers_ratio_method.fault_table`.
+- **C** = FMSR server `_rogers_ratio()` (per `server_rogers_table_note`).
+
+Per-pair-per-cell: ✅ matches; ⚠️ partial overlap or differing bounds;
+❌ contradicts (no overlap or opposite half-line).
+
+| Code | Ratio | A↔B (IEC↔JSON) | A↔C (IEC↔Server) | B↔C (JSON↔Server) |
+|------|-------|----------------|------------------|-------------------|
+| PD | R1 | ✅ | ❌ | ❌ |
+| PD | R2 | ❌ | ✅ | ✅ |
+| PD | R3 | ❌ | ❌ | ✅ |
+| D1 | R1 | ❌ | ❌ | ❌ |
+| D1 | R2 | ⚠️ | ⚠️ | ✅ |
+| D1 | R3 | ❌ | ❌ | ✅ |
+| D2 | R1 | ⚠️ | ⚠️ | ⚠️ |
+| D2 | R2 | ❌ | ⚠️ | ❌ |
+| D2 | R3 | ⚠️ | ⚠️ | ❌ |
+| T1 | R1 | ⚠️ | ❌ | ❌ |
+| T1 | R2 | ❌ | ✅ | ✅ |
+| T1 | R3 | ✅ | ❌ | ❌ |
+| T2 | R1 | ⚠️ | ⚠️ | ✅ |
+| T2 | R2 | ✅ | ✅ | ✅ |
+| T2 | R3 | ⚠️ | ⚠️ | ✅ |
+| T3 | R1 | ⚠️ | ⚠️ | ✅ |
+| T3 | R2 | ⚠️ | ✅ | ⚠️ |
+| T3 | R3 | ⚠️ | ⚠️ | ✅ |
+
+**Pattern:** B↔C agree more often than either ↔ A — suggests both encodings
+trace to a derivative source (textbook, slide deck) rather than to IEC text
+directly.
+
+**Worst rows (any pair contradicts on multiple ratios):**
+- **D1**: B↔A contradicts on all three ratios. Highest priority for fix.
+- **PD**: B↔A contradicts on R2 and R3.
+- **T1**: B↔A contradicts on R2; C↔A contradicts on R1 and R3.
+
+**Specific contradictions worth flagging in code comments when fixing:**
+- D1 R1: JSON `[0, 0.1]` vs IEC `0.1 – 0.5` — JSON's range *ends* where IEC's
+  starts. Likely a transposition.
+- D1 R3: JSON `[0, 1.0]` vs IEC `> 1` — directly opposite half-lines.
+- D2 R2: JSON `[3, ∞)` vs IEC `0.6 – 2.5` — orders of magnitude apart.
+- T1 R3: JSON `[0, 1.0]` vs IEC `< 1` — JSON includes `R3 = 1` exactly
+  whereas IEC excludes it (open vs closed boundary).
+- T2/T3 R3: JSON splits at 3, IEC splits at 4 — values in `(3, 4]` are T3
+  per JSON but T2 per IEC.

--- a/docs/dga_realism_statistical_validation.md
+++ b/docs/dga_realism_statistical_validation.md
@@ -103,7 +103,87 @@ real-world scenarios?*
   Annex A. We have it transitively via Duval & dePablo 2001 reproduction
   (see § 4) but not as a primary file in the repo.
 
-### 2.4 Free-PDF acquisition status (Apr 28 search)
+### 2.4 Three-way fault-table divergence (added 2026-04-28, post-PR open)
+
+After this PR was opened, a full English-side scan of the IEC 60599:2022
+4th edition was obtained (Wayback Machine snapshot of `pstco.net` from
+2024-11-01; archived at `Final_Project/_iec_reference/` in the personal
+class repo, gitignored, copyright IEC 2022, personal-research use only).
+Table 1 of the standard was extracted and compared row-by-row against the
+two team-repo encodings.
+
+**Three different DGA-classification tables are currently in play. None
+of them agree with the others.**
+
+| Table | Where | Status |
+|-------|-------|--------|
+| **A — IEC 60599:2022 Table 1** | the standard, p.13 | ground truth |
+| **B — JSON `fault_table`** | `data/knowledge/transformer_standards.json` § `iec_60599.rogers_ratio_method.fault_table` | claims to be IEC; diverges on every electrical-discharge row |
+| **C — FMSR server `_rogers_ratio()`** | `mcp_servers/fmsr_server/server.py:53-296` (also documented in `transformer_standards.json` § `iec_60599.representative_gas_profiles.server_rogers_table_note`) | a third version; this is what runs at agent-call time |
+
+**Worst divergences (B vs A):**
+
+- **D1 R1**: JSON `≤ 0.1`; IEC `0.1 – 0.5` (no overlap on the ramp).
+- **D1 R3**: JSON `≤ 1.0`; IEC `> 1` (opposite half-line).
+- **D2 R2**: JSON `≥ 3.0`; IEC `0.6 – 2.5` (no overlap; different orders of magnitude).
+- **T2/T3 R3 boundary**: JSON puts `R3 = 3` in T3; IEC puts it in T2.
+
+**Server's own divergence note (`server_rogers_table_note`):** Tanisha
+already documents that the server's Rogers table diverges from IEC on PD,
+D1, D2, and T1. The note ends: *"Profiles below are calibrated to the
+server implementation, not the standard text."*
+
+**Pattern**: JSON ↔ Server agree more often than either ↔ IEC, suggesting
+both were derived from a derivative source (textbook, slide deck, or
+tutorial) rather than from IEC text directly. The Rogers Ratio name
+covers a family of tables — Rogers 1975, IEEE C57.104-1991 four-ratio,
+IEC 60599 three-ratio (1999/2007/2015/2022). Without explicit edition
+citations, drift is normal.
+
+**Implication for L3:** marginal-KS per gas may pass (gas magnitudes in
+the synthesis are physically plausible), but **conditional-KS per fault
+class will likely fail on D1, D2, T1**, because synthetic samples were
+generated to match the server's table — not IEC's. This explains the
+v0 baseline's chi² p = 0.0007 fault-prevalence divergence and predicts
+the shape of the v1 failures.
+
+**Recommended remediation** (ranked):
+1. Fix B and C in lockstep to match A; re-tune
+   `representative_gas_profiles.profiles`; update
+   `tests/test_fmsr_server.py` fixtures. Cost: high but one-time.
+2. Add a translation layer; tag synthetic samples with both the server's
+   code and the IEC-correct code; run L3 against IEC-correct only.
+3. Document the divergence as a known limitation; run L3 with the
+   server's table as ground truth (i.e., re-classify the real-world
+   dataset using the server's table before comparing). Lowest effort,
+   intellectually weakest.
+
+**Default plan:** strategy 1 for **PD / D1 R1** (the most-egregious row,
+mechanical fix); re-run L3; revisit remaining rows from data.
+
+**Other findings from the standard PDF:**
+
+- `meta.sources[0]` mislabels edition: says `"edition": "3rd"` with
+  `year: 2022`. 3rd ed. = 2015; 2022 = **4th ed.** Should be `"4th"`.
+- IEC Table 1 carries four NOTE rows the JSON does not encode. Most
+  relevant: **Note 4** — stray oil gassing produces PD-like patterns
+  but is not a real fault. Should be reflected in the synthesis as a
+  small "false-PD" fraction.
+- IEC § A covers seven equipment classes (power transformers, instrument
+  transformers, reactors, bushings, oil-filled cables, switching
+  equipment). We use only A.1 (power transformers). Final paper should
+  scope explicitly.
+- PDF p.37 includes Duval triangle percentage formulas
+  (`%C2H2`, `%CH4`, `%C2H4` normalized). Could add as a secondary
+  classifier in FMSR.
+
+**Companion analysis** (full row-by-row diff matrix, three-way pair
+agreement, action-item list): personal-class-repo
+`Final_Project/notes/20260428_iec60599_table_comparison.md`. That note
+is the source-of-record for any subsequent fix-the-table PR; this
+section is a summary.
+
+### 2.5 Free-PDF acquisition status (Apr 28 search)
 
 We searched in this session for legitimate-and-free access to the full PDF.
 
@@ -374,7 +454,8 @@ is loaded — and degrades cleanly.
 | # | Task | Owner | Day | Acceptance |
 |---|------|-------|-----|-----------|
 | 1 | Land L3 skeleton + this doc | Alex | Apr 28 | this PR merges |
-| 2 | Pin `transformer_standards.json` `meta.source` to IEC 60599 ed. 4 (2022) — or ed. 3 (2015) if that's what was actually used | Alex | Apr 29 | JSON `meta.source` field updated, CHANGELOG entry |
+| 2 | Pin `transformer_standards.json` `meta.sources[0]` to IEC 60599 4th ed. (2022) — current value `"3rd"` is wrong (3rd ed. = 2015). Doc-only fix. | Alex | Apr 29 | JSON `meta.sources[0].edition` = `"4th"`, CHANGELOG entry |
+| 2b | **Fix Table B (`fault_table`) and Table C (server `_rogers_ratio`) to match IEC 60599 Table 1** for at least PD and D1 R1 (the most-egregious rows). Update `tests/test_fmsr_server.py` fixtures in lockstep. See § 2.4 for the divergence summary; full diff matrix in personal-repo note `Final_Project/notes/20260428_iec60599_table_comparison.md`. | Alex (separate PR) | Apr 29 | JSON D1 R1 = `[0.1, 0.5]`, R3 = `[1.0, null]`; server `_rogers_ratio` updated; tests pass; representative gas profiles regenerated to match. |
 | 3 | Acquire IEEE DataPort DGA dataset (Columbia IEEE, or Kaggle backstop) | Alex | Apr 29 | `data/external/ieee_dataport_dga.csv` (or Kaggle equivalent) on disk |
 | 4 | First L3 run: `validate_realism_statistical.py` with real data | Alex | Apr 29 | `reports/realism_statistical_v1.md` exists |
 | 5 | Tune synthesis: if any test fails, adjust `data/generate_synthetic.py` per-fault gas means/stds, regenerate, re-run | Alex | Apr 30 – May 1 | majority of tests pass at v2 or v3 |

--- a/docs/dga_realism_statistical_validation.md
+++ b/docs/dga_realism_statistical_validation.md
@@ -1,0 +1,466 @@
+# DGA Statistical Realism Validation
+
+*Created: 2026-04-28*
+*Owner: Alex Xin (`wax1`)*
+*Issue/PR anchors: `#2`, `#51`, `#52`, `#53`, **PR #147** (PS B scenario generator scaffold)*
+
+This note is the working specification for **statistical-fidelity** validation
+of the synthetic transformer DGA data that backs Problem-Statement B (PS B)
+scenarios. It complements, but does not replace, the existing
+narrative-realism rubric in `docs/scenario_realism_validation.md` and the
+schema validator in `data/scenarios/validate_scenarios.py`.
+
+It captures everything we know as of 2026-04-28: the IEC 60599 (publication
+**66491**) status, what we have already ingested into the repo, what's still
+missing, the public datasets we plan to compare against, the test battery,
+the acceptance thresholds, and the pre-final-submission plan.
+
+---
+
+## 1. Origin
+
+The PS B lane (issue `#2`) generates transformer-maintenance scenarios on top
+of synthetic DGA data produced by `data/generate_synthetic.py`. Three
+artifacts already validate scenarios at increasing depth:
+
+| Layer | What it checks | Owner / Artifact |
+|-------|----------------|------------------|
+| **L1** Schema / structural | required fields, canonical tool names, asset-id integrity | `data/scenarios/validate_scenarios.py` |
+| **L2** Narrative realism | "would a transformer engineer recognize this as plausible work?" | `docs/scenario_realism_validation.md`, `docs/ps_b_evaluation_methodology.md`, mentor review (Dhaval), Akshat in `#53` |
+| **L3** Statistical fidelity | do the gas-concentration distributions and fault-class proportions in our synthetic dataset resemble published real-world DGA data? | **this doc + `data/scenarios/validate_realism_statistical.py`** |
+
+L3 was previously implicit. The Apr 28 conversation around
+[PR #147](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/pull/147)
+(Aaron's `aaron/issue2-scenario-generator` scaffold, +1031/-0) and the
+Dhaval pre-call Q&A bank
+(`Final_Project/planning/2026-04-28_smartgridbench_qa_bank.md` § "Knowledge
+artifacts" + § "What is realism") made the gap explicit: we have a strong
+narrative-realism story but no quantitative claim that synthetic gas
+distributions match field data. Without L3 we cannot defend the synthetic
+foundation in the May 4 final report.
+
+**Why now:** PR #147 lands the generator path that will produce the first
+reviewable batch. Akshat's `#53` validation pass needs to point at *both*
+narrative ratings *and* a statistical report card. May 4 deadline → L3 must
+ship before submission.
+
+**Driving question:** *how do we validate that our scenarios represent
+real-world scenarios?*
+
+**Reference docs:**
+- `docs/ps_b_evaluation_methodology.md` (6-criteria rubric; L3 plugs into the
+  "Realism" criterion as a quantitative substrate)
+- `docs/scenario_realism_validation.md` (Apr 10/11 narrative-realism note)
+- `data/knowledge/transformer_standards.json` (encoded standards facts)
+- `mcp_servers/fmsr_server/server.py` (Rogers Ratio classifier)
+
+---
+
+## 2. IEC 60599 (publication 66491) — what is it, what we have, what we don't
+
+### 2.1 The standard
+
+- **Webstore ID:** [66491](https://webstore.iec.ch/en/publication/66491)
+- **Title:** *Mineral oil-filled electrical equipment in service — Guidance
+  on the interpretation of dissolved and free gases analysis*
+- **Edition:** 4th edition, published 2022-05-25 (replaces 3rd ed. 2015)
+- **Length:** 80 pp, 1.59 MB
+- **Stability date:** 2026
+- **Issuing TC:** IEC TC 10 (Fluids for electrotechnical applications)
+- **Scope:** dissolved + free gas interpretation for transformers, reactors,
+  bushings, switchgear, oil-filled cables — application annexes per
+  equipment class
+- **List price:** ~CHF 270 / ~USD 300, paywalled at IEC, ANSI, VDE, Accuris
+- **Companion standard:** IEEE C57.104-2019 (DGA condition framework) — we
+  treat them as a pair
+
+### 2.2 What we have ingested
+
+| Artifact | Location | Source for |
+|----------|----------|-----------|
+| Rogers Ratio fault table (R1/R2/R3 ranges → IEC fault codes PD/T1/T2/T3/D1/D2) | `data/knowledge/transformer_standards.json` § `iec_60599.rogers_ratio_method.fault_table` | `_rogers_ratio()` classifier, generation hints |
+| Key-gas guide | same JSON | per-fault gas-signature heuristics |
+| Representative gas profiles | same JSON | synthesis defaults |
+| IEEE C57.104-2019 four-condition framework + Table 1 thresholds | same JSON § `ieee_c57_104` | health-tier stratification of T-001..T-020 |
+| Operational context (maintenance horizons, work-order minimums) | same JSON § `operational_context` | WO scenarios |
+| Per-scenario-type generation hints | same JSON § `scenario_generator_hints` | LLM prompt support |
+| Rogers Ratio classifier impl | `mcp_servers/fmsr_server/server.py:53-296` (`_rogers_ratio()` + `analyze_dga`) | FMSR MCP tool, agent-callable |
+| Test coverage | `tests/test_fmsr_server.py` | confirms IEC code "N" / "Normal / Inconclusive" is a valid output |
+| Doc references | `README.md`, `CHANGELOG.md`, `docs/scenario_realism_validation.md`, `docs/project_synopsis.md`, `planning/archive/task_tracker.md`, `planning/archive/task_specs.md`, `planning/archive/mid_report_slides.md`, `planning/archive/2026-04-07_call_agenda.md` | establishes that PS B is grounded in IEC 60599 + IEEE C57.104, not arbitrary heuristics |
+
+### 2.3 What we do NOT have
+
+- **Raw 80-page PDF** (paywalled, never licensed).
+- **Application annexes** beyond transformers — reactors, bushings,
+  switchgear, oil-filled cables. Currently our synthesis is transformer-only
+  so this is acceptable, but the gap should be flagged in the paper.
+- **"Free gases" interpretation guidance** added in the 4th edition (vs the
+  3rd ed.'s dissolved-only scope).
+- **Edition citation in `transformer_standards.json` `meta.source`** — the
+  JSON does not currently pin which edition the encoded thresholds came from.
+  Confirm 4th ed. 2022 vs 3rd ed. 2015 and update.
+- **IEC TC 10 raw case database** (~117 cases) — referenced inside IEC 60599
+  Annex A. We have it transitively via Duval & dePablo 2001 reproduction
+  (see § 4) but not as a primary file in the repo.
+
+### 2.4 Free-PDF acquisition status (Apr 28 search)
+
+We searched in this session for legitimate-and-free access to the full PDF.
+
+| Source | Result | Notes |
+|--------|--------|-------|
+| `pstco.net/wp-content/uploads/2023/04/IEC-60599-2022.pdf` | unreachable from this network (HTTP 000) | claimed full standard; likely unauthorized re-host; verify legality before use |
+| `cdn.standards.iteh.ai/.../IEC-60599-2022.pdf` (sample) | downloaded, **15 pages of 80** | preview only — ToC, foreword, intro |
+| iteh.ai CMV variant | downloaded, **14 pages** | "commented version" preview |
+| Anna's Archive (`annas-archive.gd`) | **no 2022 4th ed.** | older eds present (2007/2008/2015/2016); 3rd ed. 2015 is the closest practical fallback (same Rogers Ratio fault table) |
+| Columbia Engineering Library | not directly subscribed to IEC | ILL is the recommended legitimate path; user emailed library 2026-04-28 |
+| IBM / Dhaval | likely has enterprise IEC license | user emailed Dhaval 2026-04-28 |
+| ResearchGate (Clerot et al., DGA.pdf) | full text of *companion* paper, not the standard | useful as secondary methodology citation |
+| Authorized purchase | webstore.iec.ch / ANSI / VDE / Accuris | ~$300; defer unless ILL fails |
+
+**Recommendation:** wait on the library + Dhaval emails. If neither produces
+a copy by 2026-05-01, fall back to the **3rd edition (2015)** via Anna's
+Archive — Rogers Ratio fault table is unchanged across editions; only the
+"free gases" annex is new in the 4th. For our scope (dissolved-gas-only
+synthesis), the 3rd ed. is functionally sufficient.
+
+---
+
+## 3. Existing implementation snapshot
+
+### 3.1 Synthesis pipeline
+
+```
+data/generate_synthetic.py
+     │
+     ├─ make_asset_metadata()    → 20 transformers T-001..T-020,
+     │                             stratified across 4 IEEE C57.104
+     │                             health tiers (Conditions 1-4)
+     │
+     ├─ make_dga_records()       → 1 DGA sample per transformer
+     │                             columns: H2, CH4, C2H2, C2H4, C2H6,
+     │                                       CO, CO2 + fault_label
+     │                             output: data/processed/dga_records.csv (21 lines)
+     │
+     ├─ make_sensor_readings()   → hourly traces × 30 days × 20 transformers
+     │                             output: data/processed/sensor_readings.csv (5.0 MB)
+     │
+     ├─ make_failure_modes()     → fault-mode catalogue
+     ├─ make_fault_records()     → discrete fault events
+     └─ make_rul_labels()        → RUL labels for TSFM
+```
+
+`data/build_processed.py` is the orchestrator. The 20-transformer stratified
+sample is intentionally small — it's enough for end-to-end scenario
+authoring, not enough for distributional analysis. **L3 validation needs
+either (a) more synthetic samples, or (b) bootstrapping, or (c) a multi-day
+synthesis to expand n.**
+
+### 3.2 FMSR Rogers Ratio classifier
+
+`mcp_servers/fmsr_server/server.py:53-296` implements `_rogers_ratio()`:
+
+- Input: H2, CH4, C2H2, C2H4, C2H6 (ppm)
+- Computes R1 = C2H2/C2H4, R2 = CH4/H2, R3 = C2H4/C2H6
+- Looks up IEC 60599 Table 1 ranges → returns `{iec_code, label,
+  severity, condition_4_trigger}`
+- Codes: `N` (Normal/Inconclusive), `PD`, `T1`, `T2`, `T3`, `D1`, `D2`
+- Test coverage in `tests/test_fmsr_server.py`
+
+### 3.3 PR #147 — PS B scenario generator scaffold
+
+[PR #147](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/pull/147)
+(branch `aaron/issue2-scenario-generator`, author **afan2g** = Aaron Fan,
+state **OPEN** as of 2026-04-28T21:58Z, 4 files, +1031/-0).
+
+**What it lands:**
+
+```
+docs/knowledge/scenario_generation_support.json   ← family matrix + templates (#83/#90)
+docs/knowledge/generated_scenario_authoring_and_ground_truth.md  ← no-hint contract + GT schema
+docs/knowledge/generated_scenario_template.json   ← annotated template
+                              │
+                              ▼
+                scripts/generate_scenarios.py
+                              │
+       ┌──────────────────────┼──────────────────────┐
+       ▼                      ▼                      ▼
+  load support           build_prompt           call_llm via LiteLLM
+  load handcrafted      (no-hint rules         (default WatsonX
+  load asset_ids         inlined verbatim)      Llama-3.3-70B —
+                                                no GPU contention with W5)
+                                                       │
+                                                       ▼
+                                             parse_response
+                                             attach_provenance
+                                             nearest_handcrafted
+                                             validate_scenario
+                                              ↑
+                                              └── reuses
+                                                  data/scenarios/validate_scenarios.py (L1 only)
+                                                       │
+       ┌─────────────────────────────────────────────┴─────────────────────┐
+       ▼                                                                   ▼
+data/scenarios/generated/<batch_id>/SGT-GEN-NNN.json          .../invalid/SGT-GEN-NNN.json
++ batch_manifest.json                                         (with validator error list)
++ prompts/                                                    for debugging / iteration
++ raw_responses/
+```
+
+**L3 plug-in point:** PR #147 currently calls `validate_scenarios.py` (L1
+schema only). After PR #147 merges, scenario batches should also feed their
+underlying gas-concentration data through `validate_realism_statistical.py`
+in CI / pre-promotion. The L3 report card belongs in
+`reports/realism_statistical_<batch_id>.md` next to the batch manifest.
+
+### 3.4 Realism review surfaces
+
+- `docs/scenario_realism_validation.md` — narrative-realism note, owner Alex,
+  Apr 10/11. Pre-Dhaval review.
+- `docs/ps_b_evaluation_methodology.md` — 6-criteria rubric (schema, no-hint,
+  novelty, **realism**, tool-path, usefulness) + 5-disposition decision
+  (`reject_structural`, `accept`, `accept_with_edits`, `reject_duplicate`,
+  `reject_unusable`). Issue `#51`. The "realism" column today is a 3-bucket
+  human rating (`accept | borderline | reject`); L3 supplies the
+  quantitative substrate.
+- Issue `#53` (Akshat) — applies the methodology to the first generated
+  batch.
+- Issue `#52` (Alex) — comparative analysis hand-crafted vs generated.
+
+---
+
+## 4. Real-world DGA datasets — ranked
+
+Acquisition target list, ranked by usefulness × accessibility.
+
+| Rank | Dataset | Access | Fields | Labels | Notes |
+|------|---------|--------|--------|--------|-------|
+| 1 | **IEEE DataPort DGA Dataset** (Dissanayake 2026) — DOI [10.21227/27vy-h479](https://ieee-dataport.org/documents/dga-dataset) | Columbia IEEE subscription | H2, CH4, C2H6, C2H4, C2H2 + integer fault label | yes | **Three Excel files**: balanced training, **unseen real-world test set**, **canonical IEC TC 10 benchmark**. Best primary target. |
+| 2 | **IEC TC 10 raw set** (~117 cases) | Reproduced in [Duval & dePablo 2001](https://ieeexplore.ieee.org/iel5/57/19819/00917529.pdf) (IEEE Xplore, Columbia access) | 5 fault gases + fault-class labels | yes | Historical reference; cited by IEC 60599 itself. Smaller n but authoritative. |
+| 3 | **Kaggle: [Failure Analysis in Power Transformers](https://www.kaggle.com/datasets/shashwatwork/failure-analysis-in-power-transformers-dataset)** (shashwatwork) | direct download, no auth | DGA + failure metadata | yes | Frictionless backstop if IEEE DataPort is gated. |
+| 4 | **IEEE DataPort: [DGA + Membership Degree](https://ieee-dataport.org/documents/dissolved-gas-data-transformer-oil-fault-diagnosis-power-transformers-membership-degree)** | IEEE subscription | gas concentrations + fault labels | yes | Different fault-encoding scheme; useful as secondary check on label-mapping robustness. |
+| 5 | **GitHub: [ahmedtariq71/Dataset1](https://github.com/ahmedtariq71/Dataset1)** | public | DGA samples | yes | Companion to a published paper. |
+| 6 | **GitHub: NanaudKmer/Springer_EETE_…_Ranking_Sequence** | public | DGA + MATLAB methods | yes | Useful for cross-checking Rogers/Doernenburg implementations more than for distribution comparison. |
+| 7 | **Kaggle: [Distributed Transformer Monitoring](https://www.kaggle.com/datasets/sreshta140/ai-transformer-monitoring)** | direct | sensor traces | partial | More relevant for IoT scenario realism (sensor-side) than for DGA-side L3. |
+
+**Acquisition path:**
+
+1. Pull dataset #1 via Columbia IEEE access. If IEEE DataPort requires a
+   separate subscription on top of the IEEE digital library, Columbia ILL
+   should still work.
+2. Backstop with #3 (Kaggle) — no auth, immediate.
+3. For #2, extract IEC TC 10 case data from the Duval & dePablo 2001
+   tables/figures, type into a CSV under `data/external/iec_tc10_duval2001.csv`.
+4. Place all real datasets under `data/external/` (gitignored if licensed,
+   committed if open).
+
+---
+
+## 5. Validation methodology
+
+### 5.1 Test battery
+
+| Test | Compares | Catches | Threshold |
+|------|----------|---------|-----------|
+| Two-sample **Kolmogorov-Smirnov** per gas | marginal `gas_i` distributions: synthetic vs real | shape mismatch in any single gas | `p > 0.05` |
+| **Anderson-Darling** k-sample per gas | same, weighted toward tails | extreme-value miscalibration (matters for D2 / arcing) | `p > 0.05` |
+| **Wasserstein / EMD** per gas | distributions, smooth metric | integrated "how far apart" measure | `EMD / std_real ≤ 0.20` |
+| **Chi-squared** on fault-class proportions | fault prevalence: synthetic vs real (or vs TC10 ref) | mis-stratified fault frequency | `p > 0.05` |
+| **Conditional KS**: `gas_i \| fault_class` | per-fault gas signatures | "marginals match but PD scenarios have wrong CH4 mean" | `p > 0.05` |
+| **Pearson correlation Δ** matrix | inter-gas correlation structure | uncorrelated noise pretending to be physical signal | `max abs Δ ≤ 0.20` |
+
+### 5.2 Why these tests, in plain English
+
+1. **KS** — basic sanity: do our H2 readings come from the same shape as real
+   H2 readings? Cheap, well-understood, scale-free.
+2. **Anderson-Darling** — KS is weak in the tails. AD weights tails heavier.
+   Critical for arcing (D2) where we care about extreme C2H2 values.
+3. **EMD** — KS gives a binary p-value answer. EMD gives a continuous
+   "how close" answer that doesn't blow up at large n. Good for
+   visualization and trend reporting.
+4. **Chi-squared on fault prevalence** — even if every gas distribution is
+   perfect, if our synthesis emits 80% Normal / 20% PD when real data is
+   27% Normal / 7% PD / 13% T1 / …, the benchmark is biased.
+5. **Conditional KS per fault** — passes the marginal but fails the
+   conditional means our PD scenarios have realistic-looking H2 *across the
+   whole population* but specifically the PD subset has wrong H2. This is
+   how you detect "synthesis is averaging out the physics."
+6. **Correlation Δ** — real DGA gases co-vary in physically meaningful ways
+   (CH4 ↔ C2H6 in low-temp thermal; C2H2 ↔ C2H4 in arcing). Synthesis that
+   draws each gas independently from a marginal distribution will pass the
+   first five tests and fail this one.
+
+### 5.3 Reference fault prevalence (TC 10)
+
+From IEC 60599 Annex A / Duval & dePablo 2001:
+
+| Fault | Approx. share |
+|-------|---------------|
+| Normal | ~27% |
+| PD | ~7% |
+| T1 | ~13% |
+| T2 | ~10% |
+| T3 | ~13% |
+| D1 | ~13% |
+| D2 | ~17% |
+
+Encoded in `validate_realism_statistical.py:TC10_REFERENCE_PREVALENCE`. Used
+as the chi-squared `f_exp` when no real dataset is loaded; superseded by the
+real dataset's empirical proportions when one is available.
+
+### 5.4 Precedent paper
+
+**Bashir et al. (2024)**, *Optimized Synthetic Data Integration with
+Transformer's DGA Data for Improved ML-Based Fault Identification*. Mirror
+their methodology: per-gas distribution comparison, fault-prevalence chi-2,
+synthetic-augmented training set vs real-only test set. Citation goes in
+the paper's methodology section.
+
+---
+
+## 6. Implementation — `validate_realism_statistical.py`
+
+Skeleton landed in this PR at `data/scenarios/validate_realism_statistical.py`.
+
+### 6.1 Interface
+
+```bash
+python3 data/scenarios/validate_realism_statistical.py \
+    --synthetic data/processed/dga_records.csv \
+    --real      data/external/ieee_dataport_dga.csv \
+    --report    reports/realism_statistical_v1.md \
+    --json      reports/realism_statistical_v1.json
+```
+
+Exit code = 0 if all tests pass, 1 otherwise. Suitable for CI gating.
+
+### 6.2 Output: report card
+
+Markdown table with columns: test name, statistic, p-value, threshold, pass,
+detail. Summary line: `N passed of M tests`. JSON dump for programmatic
+consumption.
+
+### 6.3 Real-data adapter
+
+`_normalize_real_columns()` recognizes column conventions for the four
+likely sources: IEEE DataPort, Kaggle `failure-analysis`,
+`ahmedtariq71/Dataset1`, and the Duval & dePablo TC 10 reproduction. New
+sources → add a branch.
+
+### 6.4 Behavior when real data is missing
+
+If `--real` is omitted or the file doesn't exist, the script:
+
+1. Emits a single chi-squared on synthetic fault prevalence vs
+   `TC10_REFERENCE_PREVALENCE`.
+2. Adds a `real_dataset_present: false` failing test with a pointer to this
+   doc's § 4 acquisition list.
+3. Returns exit 1 (so CI can't pass without real data).
+
+This means the script is useful immediately — even before any real dataset
+is loaded — and degrades cleanly.
+
+### 6.5 Dependencies
+
+- `pandas`, `numpy`, `scipy` (all already in repo deps)
+- No new pin required; `scipy.stats.ks_2samp`,
+  `scipy.stats.anderson_ksamp`, `scipy.stats.wasserstein_distance`, and
+  `scipy.stats.chisquare` cover the test battery.
+
+---
+
+## 7. Pre-May 4 plan
+
+| # | Task | Owner | Day | Acceptance |
+|---|------|-------|-----|-----------|
+| 1 | Land L3 skeleton + this doc | Alex | Apr 28 | this PR merges |
+| 2 | Pin `transformer_standards.json` `meta.source` to IEC 60599 ed. 4 (2022) — or ed. 3 (2015) if that's what was actually used | Alex | Apr 29 | JSON `meta.source` field updated, CHANGELOG entry |
+| 3 | Acquire IEEE DataPort DGA dataset (Columbia IEEE, or Kaggle backstop) | Alex | Apr 29 | `data/external/ieee_dataport_dga.csv` (or Kaggle equivalent) on disk |
+| 4 | First L3 run: `validate_realism_statistical.py` with real data | Alex | Apr 29 | `reports/realism_statistical_v1.md` exists |
+| 5 | Tune synthesis: if any test fails, adjust `data/generate_synthetic.py` per-fault gas means/stds, regenerate, re-run | Alex | Apr 30 – May 1 | majority of tests pass at v2 or v3 |
+| 6 | Add L3 report-card figure to `reports/2026-05-04_final.pdf` § Methodology | Alex | May 2 | figure rendered, caption written |
+| 7 | Wire L3 into PR #147 promotion path: each accepted batch produces a `realism_statistical_<batch_id>.md` | Alex / Aaron | May 2–3 | scaffold extended, doc updated |
+| 8 | Mention dual-citation in paper: IEC 60599 + IEEE C57.104 + IEC TC 10 (via Duval 2001) | Alex | May 3 | references section updated |
+
+**Hard contingency:** if no real dataset can be acquired by Apr 30, fall
+back to TC 10 reference prevalence chi-squared only and document the gap as
+a limitation in the paper. This is degraded but defensible.
+
+---
+
+## 8. Mentor / library questions (Apr 28 emails)
+
+The user emailed Dhaval and the Columbia Engineering Library on 2026-04-28.
+Questions to follow up on, ordered by leverage:
+
+1. **Dhaval** — does IBM AssetOpsBench have an internal real-DGA dataset we
+   can compare against, or should we stick with public benchmarks (IEEE
+   DataPort + IEC TC 10 via Duval 2001)?
+2. **Dhaval** — does IBM Research have an enterprise IEC license; can we
+   reference the 4th-edition annex content for transformer applications in
+   our methodology section?
+3. **Library** — ILL request for IEC 60599:2022 (4th ed.); turnaround
+   expectation; alternatives if IEC isn't ILL-able (peer-institution
+   subscription, ASTM/Accuris backdoor).
+4. **Library** — does Columbia have IEEE DataPort access bundled with the
+   IEEE digital library subscription?
+
+---
+
+## 9. Open questions / risks
+
+- **Small synthetic n.** `data/processed/dga_records.csv` has 20 rows. KS is
+  unreliable below n ≈ 30 per group. Mitigations: (a) regenerate with more
+  samples per transformer (multi-day synthesis); (b) bootstrap; (c) accept
+  L3 as "directional, not significance-tested" until n grows. Decision:
+  prefer (a) — extend `make_dga_records()` to emit 30 days × 20
+  transformers = 600 samples.
+- **Edition mismatch.** If `transformer_standards.json` was sourced from
+  IEC 60599 3rd ed. (2015), but we cite 4th ed. (2022) in the paper, that's
+  a defendable but noteworthy gap. Pin the edition explicitly.
+- **Label-encoding mismatch across datasets.** IEEE DataPort uses integer
+  fault codes; IEC 60599 uses alpha codes (PD/T1/T2/T3/D1/D2). Adapter
+  function `_normalize_real_columns()` handles column names but not yet
+  label values. Add a `LABEL_MAP` translation table per source.
+- **Free-gas vs dissolved-gas scope.** The 4th-ed addition on free gases is
+  not modeled in our synthesis. Acceptable for PS B but worth flagging.
+- **CO/CO2 (cellulose-side) gases.** Excluded from L3 because IEC 60599
+  Rogers Ratio operates on the 5 fault gases only. CO/CO2 belongs to IEEE
+  C57.104 cellulose-degradation tracking — separate validation, possibly
+  L4 / future work.
+
+---
+
+## 10. References
+
+- IEC 60599:2022 (4th ed.), pub [66491](https://webstore.iec.ch/en/publication/66491). Mineral oil-filled electrical equipment — DGA interpretation. ICS 17.220.99, 29.040.10, 29.180. TC 10.
+- IEEE C57.104-2019 — IEEE Guide for the Interpretation of Gases Generated in Mineral Oil-Immersed Transformers.
+- Duval, M. & dePablo, A. (2001). *Interpretation of gas-in-oil analysis using new IEC publication 60599 and IEC TC 10 databases.* IEEE Electrical Insulation Magazine 17(2), 31–41. [IEEE Xplore link](https://ieeexplore.ieee.org/iel5/57/19819/00917529.pdf).
+- Dissanayake, T. (2026). *DGA dataset.* IEEE DataPort. DOI [10.21227/27vy-h479](https://ieee-dataport.org/documents/dga-dataset).
+- Bashir et al. (2024). *Optimized Synthetic Data Integration with Transformer's DGA Data for Improved ML-Based Fault Identification.* ResearchGate publication 381933991.
+- IBM AssetOpsBench upstream: [github.com/IBM/AssetOpsBench](https://github.com/IBM/AssetOpsBench).
+- Personal-repo Q&A bank: `Final_Project/planning/2026-04-28_smartgridbench_qa_bank.md` (especially § "Knowledge artifacts" and § "What is realism").
+- Team-repo PS B methodology: `docs/ps_b_evaluation_methodology.md` (Issue `#51`).
+- Team-repo narrative realism: `docs/scenario_realism_validation.md`.
+- PR #147: [PS B scenario generator scaffold (#2 prototype)](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/pull/147), branch `aaron/issue2-scenario-generator`, author afan2g, opened 2026-04-28.
+
+---
+
+## 11. Implementation-Ready Checklist
+
+- [ ] `data/scenarios/validate_realism_statistical.py` — skeleton landed. **Acceptance:** `python3 data/scenarios/validate_realism_statistical.py --synthetic data/processed/dga_records.csv --report /tmp/test.md` runs without error, emits a stub report indicating real dataset is missing.
+- [ ] `docs/dga_realism_statistical_validation.md` — this file. **Acceptance:** PR review LGTM.
+- [ ] `data/knowledge/transformer_standards.json` — pin `meta.source` edition. **Acceptance:** `meta.source` field includes "IEC 60599:2022" or "IEC 60599:2015" with deliberate decision recorded in CHANGELOG.
+- [ ] `data/external/` — create dir; gitignore licensed datasets. **Acceptance:** `.gitignore` updated; placeholder README listing expected dataset filenames.
+- [ ] `data/external/README.md` — dataset acquisition log. **Acceptance:** documents which of § 4's datasets have been acquired, when, by whom.
+- [ ] `data/generate_synthetic.py` — extend `make_dga_records()` to emit ≥ 30 samples per transformer. **Acceptance:** `data/processed/dga_records.csv` has ≥ 600 rows; existing scenarios still validate against the expanded data.
+- [ ] First L3 run (depends on real-data acquisition). **Acceptance:** `reports/realism_statistical_v1.md` exists, ≥ 70% of tests pass at v1, failing tests have follow-up tickets.
+- [ ] Wire into PR #147 promotion path. **Acceptance:** when PR #147 merges, the scenario-batch promotion script also runs L3 and stores the report under `reports/`.
+- [ ] Final report figure. **Acceptance:** `reports/2026-05-04_final.pdf` § Methodology contains an L3 report-card summary table.
+
+### Acceptance Gates
+
+- **Gate A (this PR):** skeleton + doc land; existing tests still pass; CHANGELOG entry added.
+- **Gate B (Apr 30):** real dataset acquired; first L3 run produces a non-stub report.
+- **Gate C (May 2):** at minimum the chi-squared on fault prevalence and KS on H2 + C2H2 pass; remaining failing tests documented as limitations.
+- **Gate D (May 4):** L3 report-card cited in final paper as evidence of statistical realism.

--- a/docs/dga_realism_statistical_validation.md
+++ b/docs/dga_realism_statistical_validation.md
@@ -121,10 +121,17 @@ of them agree with the others.**
 
 **Worst divergences (B vs A):**
 
-- **D1 R1**: JSON `≤ 0.1`; IEC `0.1 – 0.5` (no overlap on the ramp).
-- **D1 R3**: JSON `≤ 1.0`; IEC `> 1` (opposite half-line).
-- **D2 R2**: JSON `≥ 3.0`; IEC `0.6 – 2.5` (no overlap; different orders of magnitude).
-- **T2/T3 R3 boundary**: JSON puts `R3 = 3` in T3; IEC puts it in T2.
+- **D1 R1**: JSON's range and IEC's range do not overlap — JSON's range
+  ends where IEC's range begins.
+- **D1 R3**: JSON and IEC sit on opposite half-lines.
+- **D2 R2**: JSON and IEC do not overlap; the bounds differ by an order
+  of magnitude.
+- **T2/T3 R3 boundary**: JSON and IEC place the dividing value into
+  different fault classes.
+
+(Exact numeric thresholds are in IEC 60599:2022 Table 1. Consult the
+licensed standard or Alex's working notes for the bounds; we deliberately
+omit them here to keep this team-visible doc free of paywalled content.)
 
 **Server's own divergence note (`server_rogers_table_note`):** Tanisha
 already documents that the server's Rogers table diverges from IEC on PD,
@@ -142,7 +149,7 @@ citations, drift is normal.
 the synthesis are physically plausible), but **conditional-KS per fault
 class will likely fail on D1, D2, T1**, because synthetic samples were
 generated to match the server's table — not IEC's. This explains the
-v0 baseline's chi² p = 0.0007 fault-prevalence divergence and predicts
+v0 baseline's chi² p = 0.0106 fault-prevalence divergence and predicts
 the shape of the v1 failures.
 
 **Recommended remediation** (ranked):
@@ -454,7 +461,7 @@ is loaded — and degrades cleanly.
 |---|------|-------|-----|-----------|
 | 1 | Land L3 skeleton + this doc | Alex | Apr 28 | this PR merges |
 | 2 | Pin `transformer_standards.json` `meta.sources[0]` to IEC 60599 4th ed. (2022) — current value `"3rd"` is wrong (3rd ed. = 2015). Doc-only fix. | Alex | Apr 29 | JSON `meta.sources[0].edition` = `"4th"`, CHANGELOG entry |
-| 2b | **Fix Table B (`fault_table`) and Table C (server `_rogers_ratio`) to match IEC 60599 Table 1** for at least PD and D1 R1 (the most-egregious rows). Update `tests/test_fmsr_server.py` fixtures in lockstep. See § 2.4 + Appendix B for the divergence summary; ask Alex for the full row-by-row working notes. | Alex (separate PR) | Apr 29 | JSON D1 R1 = `[0.1, 0.5]`, R3 = `[1.0, null]`; server `_rogers_ratio` updated; tests pass; representative gas profiles regenerated to match. |
+| 2b | **Fix Table B (`fault_table`) and Table C (server `_rogers_ratio`) to match IEC 60599 Table 1** for at least PD and D1 (the most-egregious rows). Update `tests/test_fmsr_server.py` fixtures in lockstep. See § 2.4 + Appendix B for the divergence summary; ask Alex for the full row-by-row working notes containing the canonical numeric bounds. | Alex (separate PR) | Apr 29 | JSON D1 R1 / R3 ranges replaced with IEC-canonical bounds (consult standard); server `_rogers_ratio` updated to match; tests pass; representative gas profiles regenerated. |
 | 3 | Acquire IEEE DataPort DGA dataset (Columbia IEEE, or Kaggle backstop) | Alex | Apr 29 | `data/external/ieee_dataport_dga.csv` (or Kaggle equivalent) on disk |
 | 4 | First L3 run: `validate_realism_statistical.py` with real data | Alex | Apr 29 | `reports/realism_statistical_v1.md` exists |
 | 5 | Tune synthesis: if any test fails, adjust `data/generate_synthetic.py` per-fault gas means/stds, regenerate, re-run | Alex | Apr 30 – May 1 | majority of tests pass at v2 or v3 |
@@ -730,12 +737,19 @@ directly.
 - **PD**: B↔A contradicts on R2 and R3.
 - **T1**: B↔A contradicts on R2; C↔A contradicts on R1 and R3.
 
-**Specific contradictions worth flagging in code comments when fixing:**
-- D1 R1: JSON `[0, 0.1]` vs IEC `0.1 – 0.5` — JSON's range *ends* where IEC's
-  starts. Likely a transposition.
-- D1 R3: JSON `[0, 1.0]` vs IEC `> 1` — directly opposite half-lines.
-- D2 R2: JSON `[3, ∞)` vs IEC `0.6 – 2.5` — orders of magnitude apart.
-- T1 R3: JSON `[0, 1.0]` vs IEC `< 1` — JSON includes `R3 = 1` exactly
-  whereas IEC excludes it (open vs closed boundary).
-- T2/T3 R3: JSON splits at 3, IEC splits at 4 — values in `(3, 4]` are T3
-  per JSON but T2 per IEC.
+**Specific contradictions worth flagging in code comments when fixing**
+(non-numeric phrasing — pull the canonical bounds from IEC 60599:2022
+Table 1 directly, or from Alex's working notes; do not transcribe them
+into this team-visible doc):
+
+- **D1 R1**: JSON's range and IEC's range do not overlap; JSON's range ends
+  where IEC's range begins. Possible column transposition during the
+  original encoding.
+- **D1 R3**: JSON and IEC fall on opposite half-lines (one bounded above,
+  the other below).
+- **D2 R2**: JSON and IEC do not overlap; the bounds differ by roughly an
+  order of magnitude.
+- **T1 R3**: JSON's bound is closed at the same value where IEC's bound is
+  open — open-vs-closed boundary mismatch.
+- **T2/T3 R3 boundary**: JSON places the dividing value in T3; IEC places
+  it (and the surrounding interval) in T2.

--- a/docs/dga_realism_statistical_validation.md
+++ b/docs/dga_realism_statistical_validation.md
@@ -29,15 +29,14 @@ artifacts already validate scenarios at increasing depth:
 | **L2** Narrative realism | "would a transformer engineer recognize this as plausible work?" | `docs/scenario_realism_validation.md`, `docs/ps_b_evaluation_methodology.md`, mentor review (Dhaval), Akshat in `#53` |
 | **L3** Statistical fidelity | do the gas-concentration distributions and fault-class proportions in our synthetic dataset resemble published real-world DGA data? | **this doc + `data/scenarios/validate_realism_statistical.py`** |
 
-L3 was previously implicit. The Apr 28 conversation around
+L3 was previously implicit. The Apr 28 review of
 [PR #147](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/pull/147)
 (Aaron's `aaron/issue2-scenario-generator` scaffold, +1031/-0) and the
-Dhaval pre-call Q&A bank
-(`Final_Project/planning/2026-04-28_smartgridbench_qa_bank.md` § "Knowledge
-artifacts" + § "What is realism") made the gap explicit: we have a strong
-narrative-realism story but no quantitative claim that synthetic gas
-distributions match field data. Without L3 we cannot defend the synthetic
-foundation in the May 4 final report.
+Dhaval pre-call Q&A pass made the gap explicit: we have a strong
+narrative-realism story (mentor + domain-expert review of scenario text)
+but no quantitative claim that synthetic gas distributions match field
+data. Without L3 we cannot defend the synthetic foundation in the May 4
+final report.
 
 **Why now:** PR #147 lands the generator path that will produce the first
 reviewable batch. Akshat's `#53` validation pass needs to point at *both*
@@ -105,12 +104,11 @@ real-world scenarios?*
 
 ### 2.4 Three-way fault-table divergence (added 2026-04-28, post-PR open)
 
-After this PR was opened, a full English-side scan of the IEC 60599:2022
-4th edition was obtained (Wayback Machine snapshot of `pstco.net` from
-2024-11-01; archived at `Final_Project/_iec_reference/` in the personal
-class repo, gitignored, copyright IEC 2022, personal-research use only).
-Table 1 of the standard was extracted and compared row-by-row against the
-two team-repo encodings.
+After this PR was opened, a copy of IEC 60599:2022 (4th ed., publication
+66491) was obtained for personal-research review. Table 1 of the standard
+was extracted and compared row-by-row against the two team-repo encodings.
+Ask Alex for source-of-record details if you need to verify a specific
+range; the standard is paywalled and not redistributable.
 
 **Three different DGA-classification tables are currently in play. None
 of them agree with the others.**
@@ -178,10 +176,11 @@ mechanical fix); re-run L3; revisit remaining rows from data.
   classifier in FMSR.
 
 **Companion analysis** (full row-by-row diff matrix, three-way pair
-agreement, action-item list): personal-class-repo
-`Final_Project/notes/20260428_iec60599_table_comparison.md`. That note
-is the source-of-record for any subsequent fix-the-table PR; this
-section is a summary.
+agreement, per-row contradiction descriptions): held by Alex outside this
+repo because it cites the paywalled IEC text. The team-visible substitutes
+are this § 2.4 summary plus Appendix B's three-way diff matrix, which
+together carry enough signal to scope the fix-the-table PR. Ping Alex
+if you need deeper detail before that PR lands.
 
 ### 2.5 Free-PDF acquisition status (Apr 28 search)
 
@@ -455,7 +454,7 @@ is loaded — and degrades cleanly.
 |---|------|-------|-----|-----------|
 | 1 | Land L3 skeleton + this doc | Alex | Apr 28 | this PR merges |
 | 2 | Pin `transformer_standards.json` `meta.sources[0]` to IEC 60599 4th ed. (2022) — current value `"3rd"` is wrong (3rd ed. = 2015). Doc-only fix. | Alex | Apr 29 | JSON `meta.sources[0].edition` = `"4th"`, CHANGELOG entry |
-| 2b | **Fix Table B (`fault_table`) and Table C (server `_rogers_ratio`) to match IEC 60599 Table 1** for at least PD and D1 R1 (the most-egregious rows). Update `tests/test_fmsr_server.py` fixtures in lockstep. See § 2.4 for the divergence summary; full diff matrix in personal-repo note `Final_Project/notes/20260428_iec60599_table_comparison.md`. | Alex (separate PR) | Apr 29 | JSON D1 R1 = `[0.1, 0.5]`, R3 = `[1.0, null]`; server `_rogers_ratio` updated; tests pass; representative gas profiles regenerated to match. |
+| 2b | **Fix Table B (`fault_table`) and Table C (server `_rogers_ratio`) to match IEC 60599 Table 1** for at least PD and D1 R1 (the most-egregious rows). Update `tests/test_fmsr_server.py` fixtures in lockstep. See § 2.4 + Appendix B for the divergence summary; ask Alex for the full row-by-row working notes. | Alex (separate PR) | Apr 29 | JSON D1 R1 = `[0.1, 0.5]`, R3 = `[1.0, null]`; server `_rogers_ratio` updated; tests pass; representative gas profiles regenerated to match. |
 | 3 | Acquire IEEE DataPort DGA dataset (Columbia IEEE, or Kaggle backstop) | Alex | Apr 29 | `data/external/ieee_dataport_dga.csv` (or Kaggle equivalent) on disk |
 | 4 | First L3 run: `validate_realism_statistical.py` with real data | Alex | Apr 29 | `reports/realism_statistical_v1.md` exists |
 | 5 | Tune synthesis: if any test fails, adjust `data/generate_synthetic.py` per-fault gas means/stds, regenerate, re-run | Alex | Apr 30 – May 1 | majority of tests pass at v2 or v3 |
@@ -520,7 +519,7 @@ Questions to follow up on, ordered by leverage:
 - Dissanayake, T. (2026). *DGA dataset.* IEEE DataPort. DOI [10.21227/27vy-h479](https://ieee-dataport.org/documents/dga-dataset).
 - Bashir et al. (2024). *Optimized Synthetic Data Integration with Transformer's DGA Data for Improved ML-Based Fault Identification.* ResearchGate publication 381933991.
 - IBM AssetOpsBench upstream: [github.com/IBM/AssetOpsBench](https://github.com/IBM/AssetOpsBench).
-- Personal-repo Q&A bank: `Final_Project/planning/2026-04-28_smartgridbench_qa_bank.md` (especially § "Knowledge artifacts" and § "What is realism").
+- Apr 28 mentor pre-call Q&A pass — § "Knowledge artifacts" and § "What is realism" capture how the L3 vs L2 split was reached. Owner Alex; ask if you need it.
 - Team-repo PS B methodology: `docs/ps_b_evaluation_methodology.md` (Issue `#51`).
 - Team-repo narrative realism: `docs/scenario_realism_validation.md`.
 - PR #147: [PS B scenario generator scaffold (#2 prototype)](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/pull/147), branch `aaron/issue2-scenario-generator`, author afan2g, opened 2026-04-28.
@@ -596,9 +595,10 @@ mkdir -p data/external
 
 ### 12.3 What you need to source
 
-- **IEC 60599:2022 PDF.** Alex's copy is in his personal class repo,
-  gitignored, and not redistributable (IEC copyright). Use Columbia ILL or
-  ask Dhaval for an IBM-licensed copy.
+- **IEC 60599:2022 PDF.** Standard is paywalled; sourcing it is on you.
+  Use Columbia ILL (engineering library), ask Dhaval for an IBM-licensed
+  copy, or check team-share for a licensed copy. Don't commit it to the
+  repo regardless of source.
 - **IEEE DataPort DGA Dataset** (DOI 10.21227/27vy-h479) — primary target
   per § 4. Columbia IEEE subscription should cover it; ask the engineering
   library if not.
@@ -638,7 +638,8 @@ mkdir -p data/external
 ### 12.5 Where to ask for help
 
 - **Alex** for PR #148 / scaffolding-side questions, the IEC table
-  comparison, edition pinning, or the personal-repo full diff matrix.
+  comparison, edition pinning, or the row-by-row working notes that don't
+  live in this repo.
 - **Aaron (afan2g, PR #147)** for the scenario-generator path and how L3
   should hook into its promotion script.
 - **Dhaval** for IEC standard interpretation, IBM-internal datasets, or
@@ -648,42 +649,43 @@ mkdir -p data/external
 
 ---
 
-## 13. Appendix A — IEC 60599:2022 Table 1 verbatim
+## 13. Appendix A — Canonical reference for fault-table reconciliation
 
-In the standard's own column notation:
+The canonical fault-classification table is **IEC 60599:2022 Table 1**
+(publication 66491, p. 13). The standard is paywalled; do not reproduce
+its table contents verbatim in this repo.
 
-```
-Case  Characteristic fault              C2H2/C2H4    CH4/H2       C2H4/C2H6
-PD    Partial discharges                NS           < 0.1        < 0.2
-D1    Discharges of low energy          > 1          0.1 to 0.5   > 1
-D2    Discharges of high energy         0.6 to 2.5   0.1 to 1     > 2
-T1    Thermal fault t < 300 °C          NS           > 1 (NS)     < 1
-T2    Thermal fault 300 °C < t < 700 °C < 0.1        > 1          1 to 4
-T3    Thermal fault t > 700 °C          < 0.2        > 1          > 4
-```
+**To reconcile Tables B and C with the standard:**
 
-`NS` = "non-significant whatever the value" — treat as "any" in code.
+1. Acquire IEC 60599:2022 through Columbia ILL or an IBM-licensed copy
+   (see § 12.3). Do not commit the PDF.
+2. Read Table 1 directly from the standard. The table maps six
+   electrical-discharge / thermal fault cases (`PD`, `D1`, `D2`, `T1`,
+   `T2`, `T3`) to ranges of the three Rogers Ratios; cells labelled
+   `NS` mean "non-significant whatever the value" and translate to
+   "any" in code.
+3. Cross-reference the four Notes accompanying Table 1. Two of them
+   matter for our scope: (a) the standard documents stricter PD
+   thresholds for instrument transformers and bushings (we don't
+   model those, but should mention the limitation in the paper), and
+   (b) stray oil gassing is called out as producing PD-like signatures
+   that are not real faults (worth modeling as a small false-PD
+   fraction in synthesis).
+4. Apply the three remediation strategies in § 2.4 in order. The
+   diff-pattern table in Appendix B identifies which rows are most
+   urgent to fix without restating the standard's content.
 
-Notes from the standard text:
-- Note 1: some countries use `C2H2/C2H6` instead of `CH4/H2`; some use
-  slightly different ratio limits.
-- Note 2: gas-ratio calculation conditions in § 6.1 c).
-- Note 3: PD threshold stricter for instrument transformers (`CH4/H2 < 0.2`)
-  and bushings (`CH4/H2 < 0.07`).
-- Note 4: stray oil gassing produces PD-like patterns but is not a real
-  fault.
+**Internal R-numbering (JSON convention):** `R1 = CH4/H2`,
+`R2 = C2H2/C2H4`, `R3 = C2H4/C2H6`. The IEC standard uses different
+column ordering; consult § 1 of this doc for the conversion when
+reading the standard against our code.
 
-In the JSON's R-numbering convention (`R1 = CH4/H2`, `R2 = C2H2/C2H4`,
-`R3 = C2H4/C2H6`):
-
-| Code | R1 (CH4/H2) | R2 (C2H2/C2H4) | R3 (C2H4/C2H6) |
-|------|-------------|----------------|----------------|
-| PD | < 0.1 | NS | < 0.2 |
-| D1 | 0.1 – 0.5 | > 1 | > 1 |
-| D2 | 0.1 – 1 | 0.6 – 2.5 | > 2 |
-| T1 | > 1 (NS) | NS | < 1 |
-| T2 | > 1 | < 0.1 | 1 – 4 |
-| T3 | > 1 | < 0.2 | > 4 |
+**Citation for the final paper:**
+- IEC 60599:2022, *Mineral oil-filled electrical equipment in service —
+  Guidance on the interpretation of dissolved and free gases analysis*,
+  Edition 4.0, International Electrotechnical Commission, Geneva,
+  2022-05.
+- IEC publication ID 66491. ICS 17.220.99 / 29.040.10 / 29.180. TC 10.
 
 ---
 

--- a/docs/dga_realism_statistical_validation.md
+++ b/docs/dga_realism_statistical_validation.md
@@ -448,10 +448,15 @@ is loaded — and degrades cleanly.
 
 ### 6.5 Dependencies
 
-- `pandas`, `numpy`, `scipy` (all already in repo deps)
-- No new pin required; `scipy.stats.ks_2samp`,
+- `pandas` and `numpy` were already in `requirements.txt`.
+- `scipy` is added by this PR; `scipy.stats.ks_2samp`,
   `scipy.stats.anderson_ksamp`, `scipy.stats.wasserstein_distance`, and
   `scipy.stats.chisquare` cover the test battery.
+- `openpyxl` is added by this PR for `pd.read_excel(.xlsx)` so the IEEE
+  DataPort primary path works without extra setup.
+- Legacy `.xls` is intentionally NOT supported — it would require `xlrd`,
+  which is not pinned. Convert any `.xls` files to `.xlsx` (Excel /
+  LibreOffice "Save as") or `.csv` before running the validator.
 
 ---
 
@@ -578,14 +583,15 @@ git checkout team13/dat/realism-statistical-validation
 # Expect: "0/2 tests passed" (chi² fails vs TC 10 reference, real dataset missing)
 
 # 3. Pull the IEEE DataPort dataset (Columbia IEEE access required; Kaggle
-#    backstop if blocked) and re-run with --real
+#    backstop if blocked) and re-run with --real + --real-source
 mkdir -p data/external
-# … download dga.xlsx to data/external/ieee_dataport_dga.csv …
+# … download IEEE DataPort dga.xlsx to data/external/ieee_dataport_dga.xlsx …
 .venv/bin/python data/scenarios/validate_realism_statistical.py \
-    --synthetic data/processed/dga_records.csv \
-    --real      data/external/ieee_dataport_dga.csv \
-    --report    reports/realism_statistical_v1.md \
-    --json      reports/realism_statistical_v1.json
+    --synthetic   data/processed/dga_records.csv \
+    --real        data/external/ieee_dataport_dga.xlsx \
+    --real-source ieee_dataport \
+    --report      reports/realism_statistical_v1.md \
+    --json        reports/realism_statistical_v1.json
 ```
 
 ### 12.2 What you have

--- a/reports/realism_statistical_v0.json
+++ b/reports/realism_statistical_v0.json
@@ -6,11 +6,11 @@
   "tests": [
     {
       "name": "chi2_fault_prevalence",
-      "statistic": 23.333333333333332,
-      "pvalue": 0.0006921881397879359,
+      "statistic": 16.666666666666664,
+      "pvalue": 0.01058961082225972,
       "threshold": 0.05,
       "passed": false,
-      "detail": "reference=TC10 reference, n_syn=10"
+      "detail": "reference=TC10 reference, n_syn=20"
     },
     {
       "name": "real_dataset_present",

--- a/reports/realism_statistical_v0.json
+++ b/reports/realism_statistical_v0.json
@@ -1,0 +1,28 @@
+{
+  "synthetic_path": "data/processed/dga_records.csv",
+  "real_path": null,
+  "n_synthetic": 20,
+  "n_real": null,
+  "tests": [
+    {
+      "name": "chi2_fault_prevalence",
+      "statistic": 23.333333333333332,
+      "pvalue": 0.0006921881397879359,
+      "threshold": 0.05,
+      "passed": false,
+      "detail": "reference=TC10 reference, n_syn=10"
+    },
+    {
+      "name": "real_dataset_present",
+      "statistic": null,
+      "pvalue": null,
+      "threshold": 0.0,
+      "passed": false,
+      "detail": "No real dataset loaded; only TC10 reference prevalence was checked. Acquire a real DGA dataset (see docs/dga_realism_statistical_validation.md \u00a7 Datasets)."
+    }
+  ],
+  "summary": {
+    "passed": 0,
+    "total": 2
+  }
+}

--- a/reports/realism_statistical_v0.md
+++ b/reports/realism_statistical_v0.md
@@ -6,5 +6,5 @@
 
 | Test | Statistic | p-value | Threshold | Pass | Detail |
 |------|-----------|---------|-----------|------|--------|
-| `chi2_fault_prevalence` | 23.3333 | 0.0007 | 0.05 | ❌ | reference=TC10 reference, n_syn=10 |
+| `chi2_fault_prevalence` | 16.6667 | 0.0106 | 0.05 | ❌ | reference=TC10 reference, n_syn=20 |
 | `real_dataset_present` | — | — | 0.0 | ❌ | No real dataset loaded; only TC10 reference prevalence was checked. Acquire a real DGA dataset (see docs/dga_realism_statistical_validation.md § Datasets). |

--- a/reports/realism_statistical_v0.md
+++ b/reports/realism_statistical_v0.md
@@ -1,0 +1,10 @@
+# DGA Statistical Realism Report
+
+- Synthetic: `data/processed/dga_records.csv` (n=20)
+- Real: `(none loaded)` (n=None)
+- Result: **0/2** tests passed
+
+| Test | Statistic | p-value | Threshold | Pass | Detail |
+|------|-----------|---------|-----------|------|--------|
+| `chi2_fault_prevalence` | 23.3333 | 0.0007 | 0.05 | ❌ | reference=TC10 reference, n_syn=10 |
+| `real_dataset_present` | — | — | 0.0 | ❌ | No real dataset loaded; only TC10 reference prevalence was checked. Acquire a real DGA dataset (see docs/dga_realism_statistical_validation.md § Datasets). |

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ tensorboard
 # Data
 pandas
 numpy
+scipy  # statistical-fidelity validation: KS, AD, Wasserstein, chi-squared
 matplotlib
 seaborn
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ tensorboard
 pandas
 numpy
 scipy  # statistical-fidelity validation: KS, AD, Wasserstein, chi-squared
+openpyxl  # IEEE DataPort DGA dataset is published as .xlsx; pandas needs this engine to read it
 matplotlib
 seaborn
 


### PR DESCRIPTION
## Summary

- Adds Layer 3 (statistical fidelity) to the PS B scenario validation stack alongside L1 (schema, `validate_scenarios.py`) and L2 (narrative realism, `docs/scenario_realism_validation.md`). Plugs into the 6-criteria rubric in `docs/ps_b_evaluation_methodology.md` (#51) by giving the "Realism" criterion a quantitative substrate.
- New runnable validator: `data/scenarios/validate_realism_statistical.py` — six-test battery (KS / Anderson-Darling / Wasserstein per gas; chi-squared on fault prevalence; conditional KS per fault class; correlation-matrix delta), Markdown + JSON report card, non-zero exit on any failure, IEC TC 10 reference fallback when no real dataset is loaded. Includes `PROJECT_LABEL_TO_IEC` and `REAL_LABEL_MAPS` adapter tables, `.xlsx` support for the IEEE DataPort primary path, and structured failure rows for all the precondition cases (missing gas columns, zero expected counts, all-NaN correlation, label-mapping gaps).
- New doc: `docs/dga_realism_statistical_validation.md` — IEC 60599 (publication 66491) ingestion status, ranked real-DGA datasets (IEEE DataPort DOI `10.21227/27vy-h479` first; Kaggle and Duval 2001 TC 10 reproduction as backstops), test rationale, acceptance thresholds, three-way fault-table divergence finding (§ 2.4), pre-May 4 plan, plug-in point for **PR #147** (Aaron's PS B scenario generator scaffold), Akshat-handoff appendix (§ 12), reconciliation procedure pointing at IEC for canonical bounds (§ 13), and the internal three-way diff matrix (§ 14, non-numeric).
- Baseline run on the existing 20-row `data/processed/dga_records.csv` (committed at `reports/realism_statistical_v0.md` + `.json`): synthetic fault prevalence diverges from TC 10 reference at chi-squared **p = 0.0106** on **n_syn = 20** (the original commit recorded `p = 0.0007` because of a label-mapping bug fixed in v4 that silently dropped 10 of 20 rows). Triggers the v1 synthesis-tuning step (extend `make_dga_records()` + adjust per-fault gas means once IEEE DataPort dataset is in hand) and the prerequisite fix-the-table follow-up PR (§ 7 task 2b).
- `scipy` and `openpyxl` added to `requirements.txt` (used by the validator).

## Anchors

- Issue #2 (PS B), #51 (PS B evaluation methodology), #52 (comparative analysis), #53 (Akshat validation).
- PR #147 (PS B scenario generator scaffold) — when it merges, the scenario-batch promotion path should also run L3 and store `reports/realism_statistical_<batch_id>.md` next to each batch manifest. Wired-in details in § 6.4 of the new doc.

## Test plan

- [x] Skeleton runs end-to-end on existing synthetic CSV (`n_syn=20`, full coverage).
- [x] JSON dump round-trips cleanly with `allow_nan=False` (numpy scalars handled, non-finite results fail loudly).
- [x] CHANGELOG updated; `requirements.txt` adds `scipy` and `openpyxl`.
- [x] Reviewer cycle: 3 review passes, all Critical/High addressed; 6 Medium also addressed.
- [ ] Reviewer: final v3 sign-off on the v6 head (`ab95315`).
- [ ] Reviewer: confirm placement of L3 wiring (§ 6.4 of the doc) for PR #147 promotion path.
- [ ] Follow-ups: real-data acquisition (Columbia ILL + Dhaval emailed 2026-04-28); v1 report card from real data; n-extension on the synthesis side; **fix-the-table PR (§ 7 task 2b)** for Tables B + C against IEC 60599 Table 1.