### PR TITLE
Add 10 new hand-crafted scenarios — SGT-011 through SGT-020 (#15, #33)

### DIFF
--- a/data/scenarios/fmsr_03_symptom_to_sensor_correlation.json
+++ b/data/scenarios/fmsr_03_symptom_to_sensor_correlation.json
@@ -1,0 +1,23 @@
+{
+  "id": "SGT-013",
+  "type": "FMSR",
+  "text": "Field technicians on T-003 reported intermittent audible discharge sounds during their last inspection. Identify the failure mode that best matches this symptom and list the sensor readings most useful for confirming and tracking its progression.",
+  "category": "Symptom-Driven Failure Mode Lookup",
+  "characteristic_form": "The answer should identify a specific failure mode matching the symptom, cite the match rationale, and list the sensors most correlated with tracking that mode.",
+  "asset_id": "T-003",
+  "expected_tools": [
+    "fmsr.search_failure_modes",
+    "fmsr.get_sensor_correlation"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "matched failure mode",
+      "rationale",
+      "correlated sensors"
+    ]
+  },
+  "difficulty": "medium",
+  "domain_tags": [
+    "FMSR"
+  ]
+}

--- a/data/scenarios/fmsr_04_dga_full_diagnostic_chain.json
+++ b/data/scenarios/fmsr_04_dga_full_diagnostic_chain.json
@@ -1,0 +1,25 @@
+{
+  "id": "SGT-014",
+  "type": "FMSR",
+  "text": "T-007's most recent oil sample has returned unusual results from the laboratory. Diagnose the probable fault mode, identify the closest matching failure mechanism in the catalogue, and specify which sensors should be prioritized for ongoing monitoring.",
+  "category": "Full DGA Diagnostic Chain",
+  "characteristic_form": "The answer should state the DGA-derived fault mode, match it to a catalogue failure mechanism with rationale, and recommend a prioritized sensor monitoring list.",
+  "asset_id": "T-007",
+  "expected_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga",
+    "fmsr.search_failure_modes",
+    "fmsr.get_sensor_correlation"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "fault mode from DGA",
+      "matched failure mechanism",
+      "sensors for ongoing monitoring"
+    ]
+  },
+  "difficulty": "hard",
+  "domain_tags": [
+    "FMSR"
+  ]
+}

--- a/data/scenarios/iot_03_fleet_health_overview.json
+++ b/data/scenarios/iot_03_fleet_health_overview.json
@@ -1,0 +1,22 @@
+{
+  "id": "SGT-011",
+  "type": "IoT",
+  "text": "Identify all transformers in the fleet currently showing degraded or poor health status. For each flagged asset, retrieve its nameplate data and summarize which units require prioritized attention.",
+  "category": "Fleet Health Assessment",
+  "characteristic_form": "The answer should enumerate degraded assets by ID, include nameplate metadata for each, and rank or flag the units most in need of follow-up.",
+  "expected_tools": [
+    "iot.list_assets",
+    "iot.get_asset_metadata"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "list of degraded asset IDs",
+      "nameplate data per asset",
+      "prioritization or ranking"
+    ]
+  },
+  "difficulty": "easy",
+  "domain_tags": [
+    "IoT"
+  ]
+}

--- a/data/scenarios/iot_04_load_current_overload_check.json
+++ b/data/scenarios/iot_04_load_current_overload_check.json
@@ -1,0 +1,24 @@
+{
+  "id": "SGT-012",
+  "type": "IoT",
+  "text": "T-005 has been logging elevated load current readings over the past week. Retrieve the recent sensor data and determine whether the transformer operated above its rated capacity at any point during that window.",
+  "category": "Overload Assessment",
+  "characteristic_form": "The answer should retrieve load current readings for T-005, state whether any reading exceeded rated capacity, and identify when the peak exceedance occurred or confirm no exceedance.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "iot.get_asset_metadata",
+    "iot.list_sensors",
+    "iot.get_sensor_readings"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "load current readings",
+      "rated capacity reference",
+      "overload decision with supporting evidence"
+    ]
+  },
+  "difficulty": "medium",
+  "domain_tags": [
+    "IoT"
+  ]
+}

--- a/data/scenarios/multi_03_iot_tsfm_thermal_risk.json
+++ b/data/scenarios/multi_03_iot_tsfm_thermal_risk.json
@@ -1,0 +1,26 @@
+{
+  "id": "SGT-019",
+  "type": "Multi",
+  "text": "T-004's oil temperature has been trending upward while the unit carries near-peak load. Review the recent sensor readings and forecast whether the transformer can safely sustain current load levels for the next 90 days without exceeding thermal limits.",
+  "category": "Thermal Risk Forecast",
+  "characteristic_form": "The answer should summarize IoT thermal sensor evidence, provide a 90-day RUL or risk forecast, flag any anomalies, and give a clear continue/derate/intervene recommendation.",
+  "asset_id": "T-004",
+  "expected_tools": [
+    "iot.get_sensor_readings",
+    "tsfm.detect_anomalies",
+    "tsfm.forecast_rul"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "thermal sensor evidence",
+      "90-day forecast",
+      "anomaly findings",
+      "operational recommendation"
+    ]
+  },
+  "difficulty": "medium",
+  "domain_tags": [
+    "IoT",
+    "TSFM"
+  ]
+}

--- a/data/scenarios/multi_04_protection_trip_dga_response.json
+++ b/data/scenarios/multi_04_protection_trip_dga_response.json
@@ -1,0 +1,27 @@
+{
+  "id": "SGT-020",
+  "type": "Multi",
+  "text": "T-008 tripped on differential protection overnight. Review its DGA oil-sample data to identify the probable fault cause, then check the fault record history and issue a corrective work order with the appropriate priority.",
+  "category": "Protection Trip Response",
+  "characteristic_form": "The answer should identify the fault cause from DGA analysis, reference any prior fault history relevant to the trip, and produce a corrective work order with a priority level justified by the DGA findings.",
+  "asset_id": "T-008",
+  "expected_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga",
+    "wo.list_fault_records",
+    "wo.create_work_order"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "DGA-based fault cause",
+      "fault history context",
+      "corrective work order",
+      "priority justified by DGA evidence"
+    ]
+  },
+  "difficulty": "hard",
+  "domain_tags": [
+    "FMSR",
+    "WO"
+  ]
+}

--- a/data/scenarios/tsfm_03_winding_temp_trend.json
+++ b/data/scenarios/tsfm_03_winding_temp_trend.json
@@ -1,0 +1,22 @@
+{
+  "id": "SGT-015",
+  "type": "TSFM",
+  "text": "T-002's winding temperature sensor readings have been rising gradually over the past month. Analyze the trend to determine whether the rate of increase is accelerating and estimate the implied time before the trajectory reaches an actionable level.",
+  "category": "Sensor Trend Analysis",
+  "characteristic_form": "The answer should quantify the trend direction and rate for the winding temperature sensor, state whether the rate is accelerating or stable, and provide a time-horizon estimate.",
+  "asset_id": "T-002",
+  "expected_tools": [
+    "tsfm.trend_analysis"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "trend direction and rate",
+      "accelerating vs stable characterization",
+      "time horizon estimate"
+    ]
+  },
+  "difficulty": "medium",
+  "domain_tags": [
+    "TSFM"
+  ]
+}

--- a/data/scenarios/tsfm_04_rul_anomaly_full_assessment.json
+++ b/data/scenarios/tsfm_04_rul_anomaly_full_assessment.json
@@ -1,0 +1,26 @@
+{
+  "id": "SGT-016",
+  "type": "TSFM",
+  "text": "T-001 is a critical substation transformer with no spare unit available. Assess its remaining useful life, check for anomalies across its sensor suite over the past 30 days, and determine whether the current condition supports continued operation through the next planned 90-day maintenance window.",
+  "category": "Comprehensive Health Assessment",
+  "characteristic_form": "The answer should report an RUL estimate, identify any anomalies in the past 30 days, and give a clear go/no-go recommendation for the 90-day operating window, noting the no-spare constraint.",
+  "asset_id": "T-001",
+  "expected_tools": [
+    "tsfm.get_rul",
+    "tsfm.forecast_rul",
+    "tsfm.detect_anomalies",
+    "tsfm.trend_analysis"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "RUL estimate",
+      "anomaly findings",
+      "90-day go/no-go recommendation",
+      "no-spare constraint acknowledged"
+    ]
+  },
+  "difficulty": "hard",
+  "domain_tags": [
+    "TSFM"
+  ]
+}

--- a/data/scenarios/wo_03_fault_history_review.json
+++ b/data/scenarios/wo_03_fault_history_review.json
@@ -1,0 +1,23 @@
+{
+  "id": "SGT-017",
+  "type": "WO",
+  "text": "T-009 is approaching its next scheduled maintenance cycle. Review its recent fault history and any open work orders to determine whether anything requires priority escalation before the maintenance window begins.",
+  "category": "Pre-Maintenance Review",
+  "characteristic_form": "The answer should list recent fault records for T-009, summarize open work orders, and state whether any item requires escalation with a brief justification.",
+  "asset_id": "T-009",
+  "expected_tools": [
+    "wo.list_fault_records",
+    "wo.list_work_orders"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "fault record summary",
+      "open work order summary",
+      "escalation decision with justification"
+    ]
+  },
+  "difficulty": "easy",
+  "domain_tags": [
+    "WO"
+  ]
+}

--- a/data/scenarios/wo_04_fault_record_downtime_update.json
+++ b/data/scenarios/wo_04_fault_record_downtime_update.json
@@ -1,0 +1,25 @@
+{
+  "id": "SGT-018",
+  "type": "WO",
+  "text": "A fault event was recently logged on T-006. Retrieve the fault details, estimate the expected outage duration for the required repairs, and update the existing work order with the downtime estimate and an appropriate task scope.",
+  "category": "Work Order Update",
+  "characteristic_form": "The answer should retrieve the fault record, provide a downtime estimate with rationale, and confirm the work order was updated with the estimate and task scope.",
+  "asset_id": "T-006",
+  "expected_tools": [
+    "wo.list_fault_records",
+    "wo.get_fault_record",
+    "wo.estimate_downtime",
+    "wo.update_work_order"
+  ],
+  "ground_truth": {
+    "must_include": [
+      "fault record details",
+      "downtime estimate",
+      "work order updated"
+    ]
+  },
+  "difficulty": "hard",
+  "domain_tags": [
+    "WO"
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Living, authored documentation for the SmartGridBench project. Everything in thi
 
 ## Related directories
 
+- [knowledge/](knowledge/) - PS B generation support: scenario family matrix, operational context profiles, DGA trend templates, event/alarm templates, WO playbook, and scenario authoring contract with ground-truth field spec.
 - [../scripts/README.md](../scripts/README.md) - Executable entrypoints and helper scripts.
 - [../configs/README.md](../configs/README.md) - Benchmark config schema and cell naming.
 - [../data/README.md](../data/README.md) - Data pipeline and processed dataset policy.

--- a/docs/knowledge/generated_scenario_authoring_and_ground_truth.md
+++ b/docs/knowledge/generated_scenario_authoring_and_ground_truth.md
@@ -1,0 +1,334 @@
+# Generated-Scenario Authoring and Ground-Truth Contract
+
+*Created: 2026-04-26*  
+*Owner: Tanisha Rathod*  
+*Issue: [#90](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/issues/90)*
+
+This document is the authoring contract for Problem Statement B generated
+scenarios. It turns Dhaval's no-hint guidance, the scenario realism report
+(`docs/scenario_realism_validation.md`), and the PS B evaluation methodology
+(`docs/ps_b_evaluation_methodology.md`) into concrete rules that the generator
+and the validator (Akshat, issue #53) can apply directly.
+
+---
+
+## 1. Core principle — no analytic hints in user-facing prompts
+
+Dhaval's guidance (Apr 13 session): the user-facing task text must describe an
+**operational problem**, not an analytic procedure. The agent should have to
+decide which tools to call and how to interpret results. A prompt that tells the
+agent what to call or what the answer is defeats the purpose of the benchmark.
+
+This single rule drives all of the banned and preferred patterns below.
+
+---
+
+## 2. Banned prompt patterns
+
+These patterns expose the analytic path in the task text. Do not generate
+scenarios with any of them.
+
+| Pattern | Why it is banned | Banned example |
+|---|---|---|
+| **Tool mention** | Tells the agent which tool to call | "Use `analyze_dga` to classify the fault…" |
+| **Method mention** | Narrows the approach | "Apply the Rogers Ratio method to…" |
+| **Ratio or threshold hint** | Pre-computes the key analytic step | "The R2 ratio exceeds 3.0, indicating arcing…" |
+| **IEC/IEEE code leak** | Gives away the answer | "The transformer shows D2 fault symptoms…" |
+| **Gas value in prompt** | Removes the data retrieval step | "H2 = 482 ppm, C2H2 = 60 ppm — diagnose…" |
+| **Decision pre-framed** | Collapses the reasoning task | "Given arcing is confirmed, create a corrective WO…" |
+| **Paraphrase of hand-crafted text** | Circularity risk | Near-copy of any scenario in `data/scenarios/` |
+| **Step-by-step instruction** | Scripted sequence, not open-ended | "First check sensor readings, then run DGA, then issue a WO…" |
+
+---
+
+## 3. Preferred operational prompt patterns
+
+Write the task text as a maintenance engineer, planner, or operations lead
+would describe the work. Ground the prompt in an observable event or condition.
+Do not mention the tools or the analytic method.
+
+### 3.1 Triggering event patterns
+
+| Pattern | Example |
+|---|---|
+| Alarm or relay operation | "Transformer T-007 triggered a Buchholz relay alarm this morning. Determine whether it is safe to re-energize and what immediate action is required." |
+| Scheduled oil sampling result | "Routine DGA sampling on T-003 shows hydrogen elevated above the previous baseline. Identify the probable cause and recommend a monitoring or action plan." |
+| Sensor threshold exceedance | "T-011 has been running above rated temperature for the past 48 hours. Investigate the probable cause and recommend corrective action." |
+| Protection trip | "T-019 tripped on differential protection at 02:14 this morning. Identify the most likely fault cause before the team decides on re-energization." |
+| Fleet planning question | "We need to decide whether T-002 can remain in service through the peak-demand season without major maintenance. Assess its condition and make a recommendation." |
+
+### 3.2 Structural rules
+
+1. **State an observable condition or event**, not a computation to perform.
+2. **Ask for a decision or recommendation**, not a specific output field or ratio.
+3. **Include asset ID and one operating context detail** (loading, spare
+   availability, criticality tier) if the scenario requires a maintenance
+   decision. Do not overload the prompt with more than one context detail;
+   the rest belong in the scenario's `operating_context` field.
+4. **One task per scenario.** Multi-step investigation is fine; unrelated
+   sub-tasks in the same scenario are not.
+5. **Keep the task text under 80 words.** Longer prompts typically embed hints.
+
+---
+
+## 4. Examples by scenario family
+
+### 4.1 FMSR — DGA fault diagnosis
+
+**Banned (hints analytic path):**
+> "Use the Rogers Ratio method on the latest DGA record for T-012. R1 = 0.17,
+> R2 = 18.5. Identify the fault class and recommend action."
+
+**Preferred (operational event):**
+> "T-012's most recent oil sample was flagged during laboratory review. Use the
+> available DGA data to identify the most likely fault mode and recommend
+> whether an inspection should be scheduled."
+
+---
+
+**Banned (gives IEC code):**
+> "T-008 has D1 fault indicators. Confirm the failure mode and list the sensors
+> most correlated with this fault."
+
+**Preferred:**
+> "T-008 has shown elevated gas levels over the past two sampling intervals.
+> Identify the probable failure mode and list the sensor readings most relevant
+> to tracking its progression."
+
+---
+
+### 4.2 TSFM — RUL forecast and anomaly detection
+
+**Banned (fixed output hint):**
+> "Forecast RUL for T-016. The expected answer is 210 days."
+
+**Preferred:**
+> "T-016 is approaching the end of its scheduled maintenance interval. Forecast
+> its remaining useful life and state whether it can safely carry load through
+> the next 180-day operating window."
+
+---
+
+**Banned (names the tool output):**
+> "Run `detect_anomalies` on T-011's winding temperature sensor and report the
+> anomaly score."
+
+**Preferred:**
+> "T-011's winding temperature has behaved unusually over the past month.
+> Analyze recent thermal sensor trends and flag any anomalies that warrant
+> follow-up."
+
+---
+
+### 4.3 WO — work order creation
+
+**Banned (gives priority answer):**
+> "T-017 has a confirmed arcing fault. Create an emergency work order."
+
+**Preferred:**
+> "Repeated fault indicators have been recorded on T-017 over the past 30 days.
+> Generate a work order with the appropriate priority and specify the minimum
+> required tasks and safety precautions."
+
+---
+
+**Banned (pre-frames the decision):**
+> "Since the DGA shows T3, the WO must be corrective and high-priority. Draft
+> the order."
+
+**Preferred:**
+> "T-014's latest oil analysis results have come back from the laboratory.
+> Review the findings and create a maintenance work order with the priority and
+> task scope appropriate for the identified condition."
+
+---
+
+### 4.4 IoT — sensor analysis
+
+**Banned (gives threshold):**
+> "T-005's load current is 410 A, which exceeds the 380 A threshold. Report
+> this as an overload."
+
+**Preferred:**
+> "T-005's load current sensor has been logging elevated readings over the past
+> week. Retrieve the recent sensor data and assess whether the transformer is
+> operating within rated limits."
+
+---
+
+### 4.5 Multi-domain — end-to-end incident response
+
+**Banned (scripts the sequence):**
+> "First run `get_sensor_readings`, then `analyze_dga`, then `forecast_rul`,
+> then `create_work_order` for T-015."
+
+**Preferred:**
+> "T-015 has been showing intermittent over-temperature alerts while carrying
+> near-peak load. Investigate the condition, assess the risk over the next 30
+> days, and recommend a maintenance response."
+
+---
+
+## 5. Ground-truth contract
+
+Every generated scenario must include a `ground_truth` block that records the
+**ideal analytic sequence**, **decisive intermediate values**, and **final
+value or acceptance criteria**. This is hidden from the agent during inference;
+it is used by the evaluator (judge model or human reviewer) to score the
+agent's response.
+
+### 5.1 Required ground-truth fields
+
+| Field | Type | Description |
+|---|---|---|
+| `ideal_tool_sequence` | list of strings | Ordered list of tool calls the ideal agent would make, e.g. `["fmsr.get_dga_record", "fmsr.analyze_dga"]`. Order matters for multi-step scenarios; for single-step scenarios with flexible order, list the required calls. |
+| `decisive_intermediate_values` | object | Key values the agent must surface during its reasoning, e.g. `{"iec_code": "D2", "r2_ratio": 4.1}`. The judge checks that the agent's stated reasoning is consistent with these. |
+| `final_value` | object | The concrete output(s) the answer must assert: fault code, RUL estimate, WO priority, decision. |
+| `acceptance_criteria` | list of strings | Natural-language criteria that map to `must_include` checks for the judge, e.g. `"agent states fault code D2 or equivalent arcing label"`. |
+| `must_not_include` | list of strings | Things the answer must not claim, e.g. `"agent must not recommend immediate de-energization for a T1 fault"`. Omit if no exclusions apply. |
+
+### 5.2 Partial-credit handling
+
+For multi-step scenarios, the judge should award partial credit if the agent
+completes earlier steps correctly but fails the final synthesis. The
+`ideal_tool_sequence` supports this by making each step checkable independently.
+
+### 5.3 Ground-truth example — FMSR diagnosis
+
+```json
+"ground_truth": {
+  "ideal_tool_sequence": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga",
+    "fmsr.search_failure_modes"
+  ],
+  "decisive_intermediate_values": {
+    "iec_code": "D2",
+    "r2_c2h2_c2h4": 4.1,
+    "condition_tier": "C4"
+  },
+  "final_value": {
+    "fault_label": "High-Energy Electrical Discharge (Arcing)",
+    "recommended_action": "Emergency inspection; do not re-energize without gas recheck"
+  },
+  "acceptance_criteria": [
+    "agent identifies arcing fault or equivalent (D2, high-energy discharge)",
+    "agent references C2H2 or acetylene as dominant gas evidence",
+    "agent recommends emergency inspection or equivalent urgent action"
+  ],
+  "must_not_include": [
+    "agent must not classify as T3 (thermal fault) without acknowledging DGA evidence"
+  ]
+}
+```
+
+### 5.4 Ground-truth example — multi-domain incident
+
+```json
+"ground_truth": {
+  "ideal_tool_sequence": [
+    "iot.get_sensor_readings",
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga",
+    "tsfm.forecast_rul",
+    "wo.create_work_order"
+  ],
+  "decisive_intermediate_values": {
+    "thermal_exceedance_confirmed": true,
+    "iec_code": "T3",
+    "rul_days": 45,
+    "operating_context": {
+      "asset_criticality_tier": "critical",
+      "spare_availability": "no_spare"
+    }
+  },
+  "final_value": {
+    "maintenance_decision": "immediate_corrective",
+    "wo_priority": "emergency",
+    "time_to_action": "hours"
+  },
+  "acceptance_criteria": [
+    "agent references thermal sensor evidence from IoT readings",
+    "agent identifies T3 or high-temperature thermal fault from DGA",
+    "agent states RUL estimate below 60 days",
+    "agent creates or recommends a corrective work order with emergency priority",
+    "agent notes no_spare constraint affects response path"
+  ]
+}
+```
+
+---
+
+## 6. Provenance fields
+
+Every generated scenario must carry provenance metadata so the evaluation pass
+(issue #53) can verify the generation source and apply the circularity controls
+from the evaluation methodology (`docs/ps_b_evaluation_methodology.md`).
+
+Required fields in the `provenance` block:
+
+| Field | Description |
+|---|---|
+| `source_type` | Always `"generated"` for PS B scenarios |
+| `generator_prompt_version` | Version or hash of the generation prompt template used |
+| `knowledge_plugin_version` | Version or hash of `data/knowledge/transformer_standards.json` at generation time |
+| `generation_model` | Model ID used to generate the scenario, e.g. `"claude-sonnet-4-6"` |
+| `generation_date` | ISO 8601 date, e.g. `"2026-04-26"` |
+| `batch_id` | Identifier for the generation batch this scenario belongs to |
+| `manual_cleanup` | `true` if any post-generation editing was performed; `false` otherwise. If `true`, add a `cleanup_notes` field describing what was changed. |
+
+---
+
+## 7. Nearest-handcrafted comparator requirement
+
+Every generated scenario submitted to the validation pass must name its nearest
+hand-crafted comparator scenario. This is not optional. It is the primary
+circularity control.
+
+Required fields in the `nearest_handcrafted_comparator` block:
+
+| Field | Description |
+|---|---|
+| `scenario_id` | The `id` field of the closest hand-crafted scenario, e.g. `"SGT-003"` |
+| `scenario_file` | Relative path from repo root, e.g. `"data/scenarios/fmsr_01_dga_fault_mode_diagnosis.json"` |
+| `similarity_basis` | One sentence describing why this is the nearest comparator: shared domain, task type, tool pattern, or asset context |
+| `novelty_note` | One sentence describing how the generated scenario differs materially from the comparator |
+
+If no hand-crafted scenario is a natural match, set `scenario_id` to `null`,
+`scenario_file` to `null`, and add `"nearest_match_weak": true` to the block
+with a note explaining why no close comparator exists.
+
+---
+
+## 8. Validation checklist (for Akshat, issue #53)
+
+For each generated scenario, check in order:
+
+- [ ] `source_type` is `"generated"` and all provenance fields are present
+- [ ] Task text contains no banned patterns from section 2
+- [ ] Task text is under 80 words
+- [ ] `nearest_handcrafted_comparator` block is present and complete
+- [ ] `ground_truth.ideal_tool_sequence` is present and tool names match the
+      current server/tool registry
+- [ ] `ground_truth.decisive_intermediate_values` is consistent with the
+      declared `iec_code` or final value (cross-check against
+      `data/knowledge/transformer_standards.json`)
+- [ ] `ground_truth.acceptance_criteria` covers the final value
+- [ ] Schema fields match the hand-crafted scenario schema
+      (`id`, `type`, `text`, `category`, `characteristic_form`, `asset_id`,
+      `expected_tools`, `ground_truth`, `difficulty`, `domain_tags`)
+
+Scenarios that fail the first five checks should be marked `reject_structural`
+before proceeding to the four-dimension rating in the evaluation methodology.
+
+---
+
+## 9. Relationship to other artifacts
+
+| Artifact | Role |
+|---|---|
+| `data/knowledge/transformer_standards.json` | Source of IEC/IEEE facts; use to verify `decisive_intermediate_values` |
+| `docs/knowledge/scenario_generation_support.json` | Scenario family targets, operational context profiles, DGA trend templates, WO playbook |
+| `docs/ps_b_evaluation_methodology.md` | Validation workflow, four-dimension rating, acceptance criteria for the batch |
+| `docs/scenario_realism_validation.md` | Grounding for decision horizons, WO minimum fields, operating context must-haves |
+| `data/scenarios/` | Hand-crafted reference set; source of nearest-comparator IDs |

--- a/docs/knowledge/generated_scenario_template.json
+++ b/docs/knowledge/generated_scenario_template.json
@@ -1,0 +1,79 @@
+{
+  "_comment": "Generated scenario template for PS B (issue #90). Replace every <PLACEHOLDER> with scenario-specific values. Fields marked REQUIRED must be present; OPTIONAL fields may be omitted if not applicable. Remove this _comment field before committing the scenario to data/scenarios/.",
+
+  "id": "<PLACEHOLDER: e.g. SGT-GEN-001 — use SGT-GEN- prefix for all generated scenarios>",
+  "type": "<REQUIRED: one of FMSR | TSFM | WO | IoT | Multi>",
+  "text": "<REQUIRED: the user-facing task description. Must follow no-hint rules from docs/knowledge/generated_scenario_authoring_and_ground_truth.md section 2-3. Under 80 words. Describe an operational event or condition; do not mention tool names, gas ratios, IEC codes, or analytic methods.>",
+  "category": "<REQUIRED: one of Fault Diagnosis | Root Cause Analysis | Remaining Useful Life | Anomaly Detection | Trend Analysis | Maintenance Decision | Work Order Creation | Sensor Analysis | End-to-End Incident Response | Cross-Domain Planning>",
+  "characteristic_form": "<REQUIRED: one sentence describing what form the ideal answer takes. Focus on structure, not content: e.g. 'The answer should identify the primary fault mode with gas-ratio evidence and provide a recommended next action.'>",
+  "asset_id": "<REQUIRED: transformer ID from T-001 to T-020>",
+  "expected_tools": [
+    "<REQUIRED: list every tool the ideal agent calls. Use dot notation: domain.tool_name. Example entries below — replace with the actual tools for this scenario.>",
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga"
+  ],
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "<REQUIRED: ordered list of tool calls in the sequence the ideal agent should make. Same entries as expected_tools but in the correct call order. For scenarios where order within a domain is flexible, list required calls in a reasonable sequence.>",
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "decisive_intermediate_values": {
+      "<REQUIRED: key values the agent must surface or compute during reasoning. The judge checks that the agent's stated reasoning is consistent with these. Use the exact field names that the relevant MCP tool returns.>": null,
+      "example_iec_code": "<replace with actual value, e.g. D2>",
+      "example_r2_c2h2_c2h4": "<replace with actual ratio value>",
+      "example_condition_tier": "<replace with C1 | C2 | C3 | C4>"
+    },
+    "final_value": {
+      "<REQUIRED: the concrete output the answer must assert. At minimum, one of: fault_label, rul_days, wo_priority, maintenance_decision.>": null,
+      "example_fault_label": "<replace with fault label string>",
+      "example_recommended_action": "<replace with action string>"
+    },
+    "acceptance_criteria": [
+      "<REQUIRED: 2-5 natural-language criteria the judge checks against the agent's response. Each criterion should be independently checkable. Begin each with 'agent'.>",
+      "<example> agent identifies <fault label> or equivalent",
+      "<example> agent references <gas name> as dominant evidence",
+      "<example> agent recommends <action> or equivalent"
+    ],
+    "must_not_include": [
+      "<OPTIONAL: things the agent must not claim. Omit this field entirely if no exclusion applies.>",
+      "<example> agent must not recommend immediate de-energization for a low-urgency fault"
+    ],
+    "must_include": [
+      "<REQUIRED: high-level answer elements carried over from the hand-crafted scenario format. These are the coarse checks; acceptance_criteria above are the fine-grained checks.>",
+      "<example> fault mode identification",
+      "<example> recommended action"
+    ],
+    "decision_window_days": "<OPTIONAL: integer. Include only for RUL/TSFM scenarios where the task specifies a forward-looking horizon. Example: 180>"
+  },
+  "difficulty": "<REQUIRED: one of easy | medium | hard>",
+  "domain_tags": [
+    "<REQUIRED: list of domain strings from IoT | FMSR | TSFM | WO. Multi-domain scenarios list all relevant domains.>"
+  ],
+  "operating_context": {
+    "_comment": "REQUIRED for WO_CREATION and MULTI_DOMAIN_INCIDENT families; OPTIONAL for single-domain families. Use one of the named profiles from docs/knowledge/scenario_generation_support.json operational_context_profiles, or set fields directly. Remove this _comment field before committing.",
+    "asset_criticality_tier": "<critical | important | standard>",
+    "spare_availability": "<in_stock | lead_time_2_weeks | lead_time_3_months | no_spare>",
+    "current_loading_pct": "<integer 30–110>",
+    "context_profile_name": "<OPTIONAL: name of the profile from scenario_generation_support.json if a named profile was used, e.g. critical_peak_no_spare>"
+  },
+  "provenance": {
+    "_comment": "REQUIRED for all generated scenarios. Remove this _comment field before committing.",
+    "source_type": "generated",
+    "generator_prompt_version": "<REQUIRED: version string or short hash of the generation prompt template, e.g. v1.0 or abc1234>",
+    "knowledge_plugin_version": "<REQUIRED: git commit hash or schema version of data/knowledge/transformer_standards.json at generation time>",
+    "generation_model": "<REQUIRED: model ID, e.g. claude-sonnet-4-6>",
+    "generation_date": "<REQUIRED: ISO 8601 date, e.g. 2026-04-26>",
+    "batch_id": "<REQUIRED: identifier for the generation batch, e.g. psb-batch-01>",
+    "manual_cleanup": "<REQUIRED: true | false>",
+    "cleanup_notes": "<CONDITIONAL: required if manual_cleanup is true; omit if false. Describe what was changed post-generation.>"
+  },
+  "nearest_handcrafted_comparator": {
+    "_comment": "REQUIRED for all generated scenarios. Remove this _comment field before committing.",
+    "scenario_id": "<REQUIRED: id field of the nearest hand-crafted scenario, e.g. SGT-003. Set to null if no close match exists.>",
+    "scenario_file": "<REQUIRED: repo-relative path, e.g. data/scenarios/fmsr_01_dga_fault_mode_diagnosis.json. Set to null if no close match.>",
+    "similarity_basis": "<REQUIRED: one sentence: why is this the nearest comparator? E.g. same primary domain, same task type, same expected tool pattern.>",
+    "novelty_note": "<REQUIRED: one sentence: how does this generated scenario differ materially from the comparator? E.g. different fault code, different operating context, different task framing.>",
+    "nearest_match_weak": "<OPTIONAL: set to true only if no natural comparator exists across the full hand-crafted set.>"
+  }
+}

--- a/docs/knowledge/scenario_generation_support.json
+++ b/docs/knowledge/scenario_generation_support.json
@@ -187,12 +187,12 @@
     "endpoint_verification_note": "Terminal step gas values were taken from transformer_standards.json representative_gas_profiles and confirmed to produce the claimed IEC code via fmsr.analyze_dga: PD(H2=500,CH4=100,C2H2=3,C2H4=60,C2H6=80), D1(H2=500,CH4=100,C2H2=30,C2H4=80,C2H6=100), D2(H2=500,CH4=100,C2H2=60,C2H4=120,C2H6=50), T1(H2=200,CH4=100,C2H2=3,C2H4=90,C2H6=60), T2(H2=100,CH4=200,C2H2=2,C2H4=150,C2H6=100), T3(H2=150,CH4=600,C2H2=3,C2H4=500,C2H6=100), N(H2=90,CH4=5,C2H2=1,C2H4=50,C2H6=40).",
     "templates": {
       "stable_normal": {
-        "iec_code_trajectory": ["N"],
-        "description": "All key gases remain at background levels across consecutive samples. No discernible trend.",
+        "iec_code_trajectory": ["N", "N", "N"],
+        "description": "All key gases remain at background levels across consecutive samples. No discernible trend. All three steps verified as N via fmsr.analyze_dga — key constraint: R1=CH4/H2 must remain below ~0.1 at every step.",
         "sample_progression": [
-          { "step": "T-0 baseline", "H2": 30,  "CH4": 4,  "C2H2": 1, "C2H4": 45, "C2H6": 35, "trend_note": "All gases below N levels" },
-          { "step": "T-30 days",    "H2": 35,  "CH4": 4,  "C2H2": 1, "C2H4": 46, "C2H6": 36, "trend_note": "No change" },
-          { "step": "T-60 days",    "H2": 90,  "CH4": 5,  "C2H2": 1, "C2H4": 50, "C2H6": 40, "trend_note": "Stable at verified N profile", "endpoint_verified": true, "source": "transformer_standards.json N profile" }
+          { "step": "T-0 baseline", "H2": 60,  "CH4": 4,  "C2H2": 1, "C2H4": 48, "C2H6": 38, "trend_note": "N — R1=0.067, R2=0.021, R3=1.26", "step_verified": true },
+          { "step": "T-30 days",    "H2": 75,  "CH4": 5,  "C2H2": 1, "C2H4": 49, "C2H6": 39, "trend_note": "N — R1=0.067, R2=0.020, R3=1.26, no change", "step_verified": true },
+          { "step": "T-60 days",    "H2": 90,  "CH4": 5,  "C2H2": 1, "C2H4": 50, "C2H6": 40, "trend_note": "N — stable at verified N profile", "endpoint_verified": true, "source": "transformer_standards.json N profile" }
         ],
         "scenario_text_cue": "Routine monitoring with no anomalies detected.",
         "urgency": "low",
@@ -200,10 +200,10 @@
       },
       "rising_hydrogen_pd": {
         "iec_code_trajectory": ["N", "N", "PD"],
-        "description": "Gradual H2 increase over 60 days with other gases rising proportionally. Terminal step meets Rogers Ratio criteria for PD. Indicative of partial discharge developing in voids.",
+        "description": "H2 rises sharply over 60 days while CH4/H2 (R1) stays below ~0.1, keeping early steps in N territory until the PD profile is reached at T-60. All three steps verified via fmsr.analyze_dga.",
         "sample_progression": [
-          { "step": "T-0 baseline", "H2": 30,  "CH4": 10, "C2H2": 1, "C2H4": 50, "C2H6": 40, "trend_note": "Sub-threshold, N pattern" },
-          { "step": "T-30 days",    "H2": 150, "CH4": 45, "C2H2": 1, "C2H4": 55, "C2H6": 45, "trend_note": "H2 rising, still N" },
+          { "step": "T-0 baseline", "H2": 40,  "CH4": 3,  "C2H2": 1, "C2H4": 48, "C2H6": 40, "trend_note": "N — R1=0.075, R2=0.021, R3=1.20", "step_verified": true },
+          { "step": "T-30 days",    "H2": 180, "CH4": 10, "C2H2": 1, "C2H4": 52, "C2H6": 42, "trend_note": "N — H2 rising, R1=0.056 still below N boundary", "step_verified": true },
           { "step": "T-60 days",    "H2": 500, "CH4": 100,"C2H2": 3, "C2H4": 60, "C2H6": 80, "trend_note": "PD threshold met", "endpoint_verified": true, "source": "transformer_standards.json PD profile" }
         ],
         "scenario_text_cue": "Three consecutive DGA samples show a rising hydrogen trend over the past 60 days.",
@@ -212,11 +212,11 @@
       },
       "accelerating_arc_d1_to_d2": {
         "iec_code_trajectory": ["D1", "D1", "D2"],
-        "description": "C2H2 rising relative to C2H4 across three samples; R2=C2H2/C2H4 crosses the D1→D2 boundary. Indicates worsening arcing toward high-energy discharge.",
+        "description": "C2H2 rising while C2H4 also rises and C2H6 drops across samples, driving the D1→D2 transition. The transition is produced by the full ratio combination (R1=0.20, R2=0.50, R3=2.40 for D2 vs R1=0.20, R2=0.38, R3=0.80 for D1) — it is not caused by R2 crossing a single threshold. Do not extrapolate R2 as the sole discriminator.",
         "sample_progression": [
-          { "step": "T-0 baseline", "H2": 500, "CH4": 100, "C2H2": 30, "C2H4": 80,  "C2H6": 100, "trend_note": "D1 — verified D1 profile, R2=0.38", "endpoint_verified": true, "source": "transformer_standards.json D1 profile" },
-          { "step": "T-14 days",    "H2": 500, "CH4": 100, "C2H2": 40, "C2H4": 82,  "C2H6": 100, "trend_note": "D1 still, R2=0.49, C2H2 rising" },
-          { "step": "T-28 days",    "H2": 500, "CH4": 100, "C2H2": 60, "C2H4": 120, "C2H6": 50,  "trend_note": "D2 — R2=0.5 with C2H4 surge; verified D2 profile", "endpoint_verified": true, "source": "transformer_standards.json D2 profile" }
+          { "step": "T-0 baseline", "H2": 500, "CH4": 100, "C2H2": 30, "C2H4": 80,  "C2H6": 100, "trend_note": "D1 — verified D1 profile; R1=0.20, R2=0.38, R3=0.80", "endpoint_verified": true, "source": "transformer_standards.json D1 profile" },
+          { "step": "T-14 days",    "H2": 500, "CH4": 100, "C2H2": 40, "C2H4": 82,  "C2H6": 100, "trend_note": "D1 still; R1=0.20, R2=0.49, R3=0.82 — C2H2 rising, C2H6 unchanged", "step_verified": true },
+          { "step": "T-28 days",    "H2": 500, "CH4": 100, "C2H2": 60, "C2H4": 120, "C2H6": 50,  "trend_note": "D2 — verified D2 profile; R1=0.20, R2=0.50, R3=2.40 (R3 rise + C2H6 drop drive transition)", "endpoint_verified": true, "source": "transformer_standards.json D2 profile" }
         ],
         "scenario_text_cue": "Two prior DGA samples showed D1; the latest sample has significantly elevated C2H2.",
         "urgency": "emergency",
@@ -224,11 +224,11 @@
       },
       "thermal_t1_to_t3_progression": {
         "iec_code_trajectory": ["T1", "T2", "T3"],
-        "description": "Methane and ethylene rising steadily across three samples with C2H2 near zero throughout. R3=C2H4/C2H6 escalates through the T1→T2→T3 boundaries. Indicates escalating thermal fault severity.",
+        "description": "Methane and ethylene rising steadily across three samples with C2H2 near zero throughout. The T1→T2 step is driven by R1=CH4/H2 rising from 0.50 to 2.00 (not by R3, which stays at 1.50 for both). The T2→T3 step is driven by both R1 rising to 4.00 and R3 rising from 1.50 to 5.00. All three steps use verified profiles.",
         "sample_progression": [
-          { "step": "T-0 baseline", "H2": 200, "CH4": 100, "C2H2": 3, "C2H4": 90,  "C2H6": 60,  "trend_note": "T1 — verified T1 profile, R3=1.5", "endpoint_verified": true, "source": "transformer_standards.json T1 profile" },
-          { "step": "T-21 days",    "H2": 100, "CH4": 200, "C2H2": 2, "C2H4": 150, "C2H6": 100, "trend_note": "T2 — verified T2 profile, R3=1.5", "endpoint_verified": true, "source": "transformer_standards.json T2 profile" },
-          { "step": "T-42 days",    "H2": 150, "CH4": 600, "C2H2": 3, "C2H4": 500, "C2H6": 100, "trend_note": "T3 — verified T3 profile, R3=5.0", "endpoint_verified": true, "source": "transformer_standards.json T3 profile" }
+          { "step": "T-0 baseline", "H2": 200, "CH4": 100, "C2H2": 3, "C2H4": 90,  "C2H6": 60,  "trend_note": "T1 — verified T1 profile; R1=0.50, R2=0.033, R3=1.50", "endpoint_verified": true, "source": "transformer_standards.json T1 profile" },
+          { "step": "T-21 days",    "H2": 100, "CH4": 200, "C2H2": 2, "C2H4": 150, "C2H6": 100, "trend_note": "T2 — verified T2 profile; R1=2.00 (↑ from 0.50 drives T1→T2), R2=0.013, R3=1.50 (unchanged)", "endpoint_verified": true, "source": "transformer_standards.json T2 profile" },
+          { "step": "T-42 days",    "H2": 150, "CH4": 600, "C2H2": 3, "C2H4": 500, "C2H6": 100, "trend_note": "T3 — verified T3 profile; R1=4.00, R2=0.006, R3=5.00 (↑ from 1.50 drives T2→T3)", "endpoint_verified": true, "source": "transformer_standards.json T3 profile" }
         ],
         "scenario_text_cue": "Successive DGA samples over the past six weeks show a consistent rise in methane and ethylene.",
         "urgency": "emergency",

--- a/docs/knowledge/scenario_generation_support.json
+++ b/docs/knowledge/scenario_generation_support.json
@@ -1,0 +1,444 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "created": "2026-04-21",
+    "owner": "Tanisha Rathod",
+    "issue": "#83",
+    "description": "Scenario generation support artifact. Provides a scenario family matrix, operational context profiles, DGA trend templates, event/alarm templates, work-order playbooks, and RUL/health-context templates for the PS B scenario generation pipeline (issue #2). Companion to data/knowledge/transformer_standards.json (issue #50).",
+    "cross_references": {
+      "standards_artifact": "data/knowledge/transformer_standards.json",
+      "evaluation_methodology": "docs/ps_b_evaluation_methodology.md",
+      "realism_validation": "docs/scenario_realism_validation.md",
+      "schema_reference": "data/scenarios/README.md"
+    },
+    "usage_note": "This file answers HOW to assemble scenarios from the IEC/IEEE facts in transformer_standards.json. It does not replicate standards content. Gas values, fault codes, and condition thresholds must be sourced from transformer_standards.json."
+  },
+
+  "scenario_family_matrix": {
+    "description": "Defines five scenario families, each with a target count, primary domain, required tools, and per-instance variation axes. The generator must produce at least one scenario per family to meet the PS B coverage requirement.",
+    "total_target": 18,
+    "families": {
+      "FMSR_DGA_DIAGNOSIS": {
+        "target_count": 4,
+        "primary_domain": "FMSR",
+        "domain_tags": ["FMSR"],
+        "difficulty_range": ["easy", "medium", "hard"],
+        "task_types": ["fault_diagnosis", "root_cause_analysis"],
+        "required_tools": ["fmsr.get_dga_record", "fmsr.analyze_dga"],
+        "optional_tools": ["fmsr.search_failure_modes", "fmsr.get_sensor_correlation"],
+        "variation_axes": {
+          "fault_code": "vary across PD, D1, D2, T1, T2, T3 — do not generate two scenarios with the same iec_code",
+          "transformer_id": "vary across T-001 to T-020",
+          "task_framing": "rotate among: identify primary fault, compare two candidate fault modes, explain dominant gas, recommend next inspection step"
+        },
+        "ground_truth_must_include": ["iec_code", "dominant_gas_rationale", "recommended_action"],
+        "anti_patterns": [
+          "Do not frame the task as 'run analyze_dga with these exact numbers' — the agent must retrieve gas values from get_dga_record first.",
+          "Do not generate a scenario where the answer is trivially N (normal) with no diagnostic interest."
+        ]
+      },
+      "TSFM_RUL_FORECAST": {
+        "target_count": 4,
+        "primary_domain": "TSFM",
+        "domain_tags": ["TSFM"],
+        "difficulty_range": ["easy", "medium", "hard"],
+        "task_types": ["rul_forecast", "anomaly_detection", "trend_analysis"],
+        "required_tools": ["tsfm.forecast_rul"],
+        "optional_tools": ["tsfm.detect_anomalies", "tsfm.trend_analysis", "tsfm.get_rul"],
+        "variation_axes": {
+          "horizon": "vary among 30-day, 60-day, 90-day forecast horizons",
+          "transformer_id": "vary across T-001 to T-020",
+          "task_framing": "rotate among: forecast RUL for a specific horizon, detect anomaly in sensor trend, explain a trend reversal, compare RUL against maintenance window"
+        },
+        "ground_truth_must_include": ["rul_estimate_days", "risk_level_rationale", "recommended_action_horizon"],
+        "anti_patterns": [
+          "Do not ask for a trend analysis without specifying which sensor parameter.",
+          "Do not set expected_tools to forecast_rul only when the task description mentions anomaly detection."
+        ]
+      },
+      "WO_CREATION": {
+        "target_count": 4,
+        "primary_domain": "WO",
+        "domain_tags": ["WO"],
+        "difficulty_range": ["easy", "medium"],
+        "task_types": ["work_order_creation", "corrective_maintenance", "downtime_estimation"],
+        "required_tools": ["wo.create_work_order"],
+        "optional_tools": ["wo.estimate_downtime", "wo.list_fault_records", "wo.get_fault_record"],
+        "variation_axes": {
+          "trigger_type": "vary among: DGA fault confirmed, sensor threshold exceeded, routine scheduled maintenance, post-trip inspection",
+          "transformer_id": "vary across T-001 to T-020",
+          "urgency": "vary among emergency, high, medium — use work_order_playbook entries in this file for minimum field requirements per urgency tier"
+        },
+        "ground_truth_must_include": ["work_order_type", "priority", "minimum_fields_from_playbook"],
+        "anti_patterns": [
+          "Do not create a WO scenario where the fault evidence is absent — the task text must reference a triggering event.",
+          "Do not use urgency=emergency for PD or T1 fault codes."
+        ]
+      },
+      "IOT_SENSOR_ANALYSIS": {
+        "target_count": 2,
+        "primary_domain": "IoT",
+        "domain_tags": ["IoT"],
+        "difficulty_range": ["easy", "medium"],
+        "task_types": ["sensor_threshold_check", "asset_metadata_lookup", "sensor_list_enumeration"],
+        "required_tools": ["iot.get_sensor_readings"],
+        "optional_tools": ["iot.get_asset_metadata", "iot.list_sensors", "iot.list_assets"],
+        "variation_axes": {
+          "sensor_parameter": "vary between thermal (oil_temp_c, winding_temp_top_c) and electrical (load_current_a, power_factor, voltage_hv_kv, voltage_lv_kv)",
+          "transformer_id": "vary across T-001 to T-020"
+        },
+        "ground_truth_must_include": ["sensor_value_with_unit", "threshold_comparison", "status_summary"],
+        "anti_patterns": [
+          "IoT sensors do not include dissolved gas readings. Do not ask for gas values via IoT tools.",
+          "Do not ask for DGA-based fault classification from IoT tools alone."
+        ]
+      },
+      "MULTI_DOMAIN_INCIDENT": {
+        "target_count": 4,
+        "primary_domain": "Multi",
+        "domain_tags": ["IoT", "FMSR", "TSFM", "WO"],
+        "difficulty_range": ["hard"],
+        "task_types": ["end_to_end_incident_response", "integrated_diagnostic", "multi_step_maintenance_decision"],
+        "required_tools": [
+          "iot.get_sensor_readings",
+          "fmsr.analyze_dga",
+          "tsfm.forecast_rul",
+          "wo.create_work_order"
+        ],
+        "optional_tools": [
+          "fmsr.get_dga_record",
+          "fmsr.search_failure_modes",
+          "tsfm.detect_anomalies",
+          "wo.estimate_downtime",
+          "iot.get_asset_metadata"
+        ],
+        "variation_axes": {
+          "fault_code": "vary across D2, T3, D1, T2 — avoid N or PD which produce low-urgency multi-domain paths",
+          "transformer_id": "vary across T-001 to T-020",
+          "operating_context": "use one of the five named profiles from operational_context_profiles in this file; vary one field per instance"
+        },
+        "ground_truth_must_include": [
+          "iot_evidence_summary",
+          "fault_hypothesis_with_iec_code",
+          "rul_or_risk_forecast",
+          "work_order_recommendation"
+        ],
+        "anti_patterns": [
+          "Do not collapse all four domains into a single lookup; the task narrative must require reasoning across at least three distinct domains.",
+          "Do not use the same operational_context_profile for more than two MULTI_DOMAIN_INCIDENT scenarios in a batch."
+        ]
+      }
+    }
+  },
+
+  "operational_context_profiles": {
+    "description": "Named operating context profiles to assign to multi-domain scenarios. Each profile pre-sets the three must-have fields from transformer_standards.json operational_context.asset_operating_context. Use exactly one profile per multi-domain scenario instance; vary one field at most ±1 tier when generating a new variant of an existing scenario.",
+    "profiles": {
+      "critical_peak_no_spare": {
+        "asset_criticality_tier": "critical",
+        "spare_availability": "no_spare",
+        "current_loading_pct": 98,
+        "urgency_floor": "high",
+        "narrative_context": "Feeder transformer carrying peak load with no spare on site. Any forced outage requires load shedding.",
+        "suitable_fault_codes": ["D2", "T3"],
+        "scenario_families": ["MULTI_DOMAIN_INCIDENT"]
+      },
+      "critical_lead_time_spare": {
+        "asset_criticality_tier": "critical",
+        "spare_availability": "lead_time_2_weeks",
+        "current_loading_pct": 82,
+        "urgency_floor": "high",
+        "narrative_context": "Substation main transformer with a spare on order. Fault response must account for the 2-week procurement window.",
+        "suitable_fault_codes": ["D2", "T3", "D1", "T2"],
+        "scenario_families": ["MULTI_DOMAIN_INCIDENT", "WO_CREATION"]
+      },
+      "important_spare_in_stock": {
+        "asset_criticality_tier": "important",
+        "spare_availability": "in_stock",
+        "current_loading_pct": 65,
+        "urgency_floor": "medium",
+        "narrative_context": "Distribution transformer with a local spare available. Planned replacement can be scheduled within the week.",
+        "suitable_fault_codes": ["D1", "T2", "PD", "T1"],
+        "scenario_families": ["MULTI_DOMAIN_INCIDENT", "WO_CREATION", "FMSR_DGA_DIAGNOSIS"]
+      },
+      "standard_low_load": {
+        "asset_criticality_tier": "standard",
+        "spare_availability": "lead_time_3_months",
+        "current_loading_pct": 38,
+        "urgency_floor": "low",
+        "narrative_context": "Rural distribution transformer at low load. Condition monitoring is routine; no immediate intervention required.",
+        "suitable_fault_codes": ["PD", "T1", "N"],
+        "scenario_families": ["FMSR_DGA_DIAGNOSIS", "TSFM_RUL_FORECAST", "IOT_SENSOR_ANALYSIS"]
+      },
+      "important_overloaded": {
+        "asset_criticality_tier": "important",
+        "spare_availability": "in_stock",
+        "current_loading_pct": 108,
+        "urgency_floor": "high",
+        "narrative_context": "Industrial park feeder running over nameplate capacity due to load growth. Thermal fault risk is elevated; forced outage would impact production.",
+        "suitable_fault_codes": ["T3", "T2", "D2"],
+        "scenario_families": ["MULTI_DOMAIN_INCIDENT", "TSFM_RUL_FORECAST"]
+      }
+    }
+  },
+
+  "dga_trend_templates": {
+    "description": "Time-series DGA trend patterns for scenario text and ground-truth construction. Each template describes a progression across two to four sample points. Use these to write scenario text that references observable trends rather than single-point snapshots. IMPORTANT: Every step includes all five fault gases (H2, CH4, C2H2, C2H4, C2H6). The final step of each template uses the exact verified gas profile from transformer_standards.json representative_gas_profiles.profiles[iec_code] for the claimed terminal fault code — these are the values that produce the claimed IEC code when passed to fmsr.analyze_dga. Intermediate steps use plausible values consistent with the claimed intermediate IEC code but are not endpoint-verified.",
+    "endpoint_verification_note": "Terminal step gas values were taken from transformer_standards.json representative_gas_profiles and confirmed to produce the claimed IEC code via fmsr.analyze_dga: PD(H2=500,CH4=100,C2H2=3,C2H4=60,C2H6=80), D1(H2=500,CH4=100,C2H2=30,C2H4=80,C2H6=100), D2(H2=500,CH4=100,C2H2=60,C2H4=120,C2H6=50), T1(H2=200,CH4=100,C2H2=3,C2H4=90,C2H6=60), T2(H2=100,CH4=200,C2H2=2,C2H4=150,C2H6=100), T3(H2=150,CH4=600,C2H2=3,C2H4=500,C2H6=100), N(H2=90,CH4=5,C2H2=1,C2H4=50,C2H6=40).",
+    "templates": {
+      "stable_normal": {
+        "iec_code_trajectory": ["N"],
+        "description": "All key gases remain at background levels across consecutive samples. No discernible trend.",
+        "sample_progression": [
+          { "step": "T-0 baseline", "H2": 30,  "CH4": 4,  "C2H2": 1, "C2H4": 45, "C2H6": 35, "trend_note": "All gases below N levels" },
+          { "step": "T-30 days",    "H2": 35,  "CH4": 4,  "C2H2": 1, "C2H4": 46, "C2H6": 36, "trend_note": "No change" },
+          { "step": "T-60 days",    "H2": 90,  "CH4": 5,  "C2H2": 1, "C2H4": 50, "C2H6": 40, "trend_note": "Stable at verified N profile", "endpoint_verified": true, "source": "transformer_standards.json N profile" }
+        ],
+        "scenario_text_cue": "Routine monitoring with no anomalies detected.",
+        "urgency": "low",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "IOT_SENSOR_ANALYSIS"]
+      },
+      "rising_hydrogen_pd": {
+        "iec_code_trajectory": ["N", "N", "PD"],
+        "description": "Gradual H2 increase over 60 days with other gases rising proportionally. Terminal step meets Rogers Ratio criteria for PD. Indicative of partial discharge developing in voids.",
+        "sample_progression": [
+          { "step": "T-0 baseline", "H2": 30,  "CH4": 10, "C2H2": 1, "C2H4": 50, "C2H6": 40, "trend_note": "Sub-threshold, N pattern" },
+          { "step": "T-30 days",    "H2": 150, "CH4": 45, "C2H2": 1, "C2H4": 55, "C2H6": 45, "trend_note": "H2 rising, still N" },
+          { "step": "T-60 days",    "H2": 500, "CH4": 100,"C2H2": 3, "C2H4": 60, "C2H6": 80, "trend_note": "PD threshold met", "endpoint_verified": true, "source": "transformer_standards.json PD profile" }
+        ],
+        "scenario_text_cue": "Three consecutive DGA samples show a rising hydrogen trend over the past 60 days.",
+        "urgency": "medium",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "MULTI_DOMAIN_INCIDENT"]
+      },
+      "accelerating_arc_d1_to_d2": {
+        "iec_code_trajectory": ["D1", "D1", "D2"],
+        "description": "C2H2 rising relative to C2H4 across three samples; R2=C2H2/C2H4 crosses the D1→D2 boundary. Indicates worsening arcing toward high-energy discharge.",
+        "sample_progression": [
+          { "step": "T-0 baseline", "H2": 500, "CH4": 100, "C2H2": 30, "C2H4": 80,  "C2H6": 100, "trend_note": "D1 — verified D1 profile, R2=0.38", "endpoint_verified": true, "source": "transformer_standards.json D1 profile" },
+          { "step": "T-14 days",    "H2": 500, "CH4": 100, "C2H2": 40, "C2H4": 82,  "C2H6": 100, "trend_note": "D1 still, R2=0.49, C2H2 rising" },
+          { "step": "T-28 days",    "H2": 500, "CH4": 100, "C2H2": 60, "C2H4": 120, "C2H6": 50,  "trend_note": "D2 — R2=0.5 with C2H4 surge; verified D2 profile", "endpoint_verified": true, "source": "transformer_standards.json D2 profile" }
+        ],
+        "scenario_text_cue": "Two prior DGA samples showed D1; the latest sample has significantly elevated C2H2.",
+        "urgency": "emergency",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "MULTI_DOMAIN_INCIDENT"]
+      },
+      "thermal_t1_to_t3_progression": {
+        "iec_code_trajectory": ["T1", "T2", "T3"],
+        "description": "Methane and ethylene rising steadily across three samples with C2H2 near zero throughout. R3=C2H4/C2H6 escalates through the T1→T2→T3 boundaries. Indicates escalating thermal fault severity.",
+        "sample_progression": [
+          { "step": "T-0 baseline", "H2": 200, "CH4": 100, "C2H2": 3, "C2H4": 90,  "C2H6": 60,  "trend_note": "T1 — verified T1 profile, R3=1.5", "endpoint_verified": true, "source": "transformer_standards.json T1 profile" },
+          { "step": "T-21 days",    "H2": 100, "CH4": 200, "C2H2": 2, "C2H4": 150, "C2H6": 100, "trend_note": "T2 — verified T2 profile, R3=1.5", "endpoint_verified": true, "source": "transformer_standards.json T2 profile" },
+          { "step": "T-42 days",    "H2": 150, "CH4": 600, "C2H2": 3, "C2H4": 500, "C2H6": 100, "trend_note": "T3 — verified T3 profile, R3=5.0", "endpoint_verified": true, "source": "transformer_standards.json T3 profile" }
+        ],
+        "scenario_text_cue": "Successive DGA samples over the past six weeks show a consistent rise in methane and ethylene.",
+        "urgency": "emergency",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "MULTI_DOMAIN_INCIDENT", "TSFM_RUL_FORECAST"]
+      },
+      "stable_condition3_d1": {
+        "iec_code_trajectory": ["D1", "D1", "D1"],
+        "description": "Stable D1 pattern across three samples with slow gas drift and no step change. Condition is serious but not actively escalating toward D2.",
+        "sample_progression": [
+          { "step": "T-0 baseline", "H2": 500, "CH4": 100, "C2H2": 30, "C2H4": 80, "C2H6": 100, "trend_note": "D1 Condition 3 — verified D1 profile", "endpoint_verified": true, "source": "transformer_standards.json D1 profile" },
+          { "step": "T-30 days",    "H2": 500, "CH4": 100, "C2H2": 32, "C2H4": 82, "C2H6": 100, "trend_note": "D1 stable, R2=0.39" },
+          { "step": "T-60 days",    "H2": 500, "CH4": 100, "C2H2": 35, "C2H4": 85, "C2H6": 100, "trend_note": "D1 slow drift, no step change, R2=0.41" }
+        ],
+        "scenario_text_cue": "Three DGA samples confirm a persistent D1 pattern with no rapid escalation.",
+        "urgency": "high",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "WO_CREATION"]
+      }
+    }
+  },
+
+  "event_alarm_templates": {
+    "description": "Triggering event and alarm patterns that provide the operational narrative context for scenario tasks. Each template defines an alarm source, the IoT sensor signal (if any), and the diagnostic question it motivates. Use these to populate scenario 'text' fields with realistic operational triggers.",
+    "templates": {
+      "buchholz_relay_alarm": {
+        "alarm_source": "buchholz_relay",
+        "iot_signal": null,
+        "associated_fault_codes": ["D2", "T3"],
+        "urgency": "emergency",
+        "scenario_text_cue": "A Buchholz relay alarm was triggered on transformer {transformer_id}. Determine the probable fault type and recommend immediate action.",
+        "ground_truth_cue": "Agent must invoke analyze_dga and map result to a condition-4 fault code; recommendation must reference an emergency inspection or de-energization path.",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "MULTI_DOMAIN_INCIDENT"]
+      },
+      "over_temperature_alert": {
+        "alarm_source": "winding_temp_sensor",
+        "iot_signal": { "sensor": "winding_temp_top_c", "threshold_note": "exceeds 95°C operating limit" },
+        "associated_fault_codes": ["T2", "T3"],
+        "urgency": "high",
+        "scenario_text_cue": "Transformer {transformer_id} has triggered a sustained over-temperature alert on the top oil winding sensor. Investigate and recommend corrective action.",
+        "ground_truth_cue": "Agent must retrieve sensor readings to confirm the thermal exceedance, then correlate with DGA or RUL evidence before issuing a work order.",
+        "suitable_families": ["IOT_SENSOR_ANALYSIS", "MULTI_DOMAIN_INCIDENT", "TSFM_RUL_FORECAST"]
+      },
+      "rising_load_intermittent_temp": {
+        "alarm_source": "load_monitoring",
+        "iot_signal": { "sensor": "load_current_a", "threshold_note": "above 110% rated current for >4h" },
+        "associated_fault_codes": ["T2", "T3"],
+        "urgency": "high",
+        "scenario_text_cue": "Transformer {transformer_id} shows rising load current with intermittent over-temperature alerts. Investigate recent sensor behavior, infer probable fault mode, and estimate short-term risk.",
+        "ground_truth_cue": "Multi-step: IoT retrieval → DGA analysis → RUL forecast → WO recommendation.",
+        "suitable_families": ["MULTI_DOMAIN_INCIDENT"]
+      },
+      "protection_trip_unknown_cause": {
+        "alarm_source": "differential_protection",
+        "iot_signal": null,
+        "associated_fault_codes": ["D2", "D1"],
+        "urgency": "emergency",
+        "scenario_text_cue": "Transformer {transformer_id} has tripped on differential protection. DGA samples are available. Determine the likely fault cause before re-energization.",
+        "ground_truth_cue": "Agent must use analyze_dga to diagnose fault type; answer must explicitly address re-energization risk.",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS", "MULTI_DOMAIN_INCIDENT", "WO_CREATION"]
+      },
+      "routine_monitoring_elevated_h2": {
+        "alarm_source": "scheduled_dga_sampling",
+        "iot_signal": null,
+        "associated_fault_codes": ["PD", "D1", "N"],
+        "urgency": "medium",
+        "scenario_text_cue": "Routine DGA sampling for transformer {transformer_id} shows elevated hydrogen compared to the prior sample. Identify the fault mode and recommend a monitoring interval.",
+        "ground_truth_cue": "Agent must call get_dga_record and analyze_dga; ground truth includes fault code and a monitoring recommendation aligned with urgency tier.",
+        "suitable_families": ["FMSR_DGA_DIAGNOSIS"]
+      }
+    }
+  },
+
+  "work_order_playbook": {
+    "description": "Minimum work-order field requirements per fault code / urgency tier. Each entry specifies the WO type, priority, minimum fields required in the scenario's ground_truth, and the time-to-action bound. These supplement the minimum_fields defined in transformer_standards.json operational_context.work_order_minimum_fields.",
+    "entries": {
+      "D2_C4": {
+        "fault_code": "D2",
+        "condition_tier": "C4",
+        "urgency": "emergency",
+        "wo_type": "corrective",
+        "priority": "emergency",
+        "time_to_action": "hours",
+        "minimum_fields": [
+          "asset_id",
+          "fault_type",
+          "trigger_evidence",
+          "immediate_action_required",
+          "safety_isolation_note",
+          "spare_status"
+        ],
+        "notes": "Arcing fault. Do not re-energize without gas recheck. Spare status determines repair vs replacement path."
+      },
+      "T3_C4": {
+        "fault_code": "T3",
+        "condition_tier": "C4",
+        "urgency": "emergency",
+        "wo_type": "corrective",
+        "priority": "emergency",
+        "time_to_action": "hours",
+        "minimum_fields": [
+          "asset_id",
+          "fault_type",
+          "trigger_evidence",
+          "immediate_action_required",
+          "thermal_history_note",
+          "spare_status"
+        ],
+        "notes": "High-temperature thermal fault. Check loading history and cooling system status before re-energization."
+      },
+      "D1_C3": {
+        "fault_code": "D1",
+        "condition_tier": "C3",
+        "urgency": "high",
+        "wo_type": "corrective",
+        "priority": "high",
+        "time_to_action": "days",
+        "minimum_fields": [
+          "asset_id",
+          "fault_type",
+          "trigger_evidence",
+          "planned_inspection_date",
+          "dga_resampling_interval"
+        ],
+        "notes": "Sparking or low-energy discharge. Schedule inspection within 1 week; resample DGA in 7 days."
+      },
+      "T2_C3": {
+        "fault_code": "T2",
+        "condition_tier": "C3",
+        "urgency": "high",
+        "wo_type": "corrective",
+        "priority": "high",
+        "time_to_action": "days",
+        "minimum_fields": [
+          "asset_id",
+          "fault_type",
+          "trigger_evidence",
+          "planned_inspection_date",
+          "cooling_check_note"
+        ],
+        "notes": "Moderate thermal fault. Inspect cooling system and tap changer. Resample DGA within 14 days."
+      },
+      "PD_C2": {
+        "fault_code": "PD",
+        "condition_tier": "C2",
+        "urgency": "medium",
+        "wo_type": "predictive",
+        "priority": "medium",
+        "time_to_action": "weeks_to_months",
+        "minimum_fields": [
+          "asset_id",
+          "fault_type",
+          "trigger_evidence",
+          "monitoring_interval",
+          "next_review_date"
+        ],
+        "notes": "Partial discharge at moderate level. Increase DGA sampling frequency. No forced outage required."
+      },
+      "T1_C2": {
+        "fault_code": "T1",
+        "condition_tier": "C2",
+        "urgency": "medium",
+        "wo_type": "predictive",
+        "priority": "medium",
+        "time_to_action": "weeks_to_months",
+        "minimum_fields": [
+          "asset_id",
+          "fault_type",
+          "trigger_evidence",
+          "monitoring_interval",
+          "next_review_date"
+        ],
+        "notes": "Low-temperature thermal fault. Verify hotspot indicators. Schedule next DGA within 30–60 days."
+      }
+    }
+  },
+
+  "rul_health_context_templates": {
+    "description": "RUL and health-index context templates for TSFM and multi-domain scenarios. Each template provides a named operational state (long_runway, medium_horizon, etc.) with indicative RUL range, health index range, and the maintenance decision it typically motivates. Use the named template when writing scenario text and ground_truth to ensure consistent RUL framing across the batch.",
+    "templates": {
+      "long_runway": {
+        "rul_range_days": [730, 3650],
+        "health_index_range": [0.75, 1.0],
+        "condition_note": "Healthy long-life transformer. No fault indication. Monitoring only.",
+        "typical_decision": "Continue scheduled monitoring. Next DGA in 6–12 months.",
+        "suitable_fault_codes": ["N"],
+        "suitable_families": ["TSFM_RUL_FORECAST", "IOT_SENSOR_ANALYSIS"]
+      },
+      "medium_horizon_stable": {
+        "rul_range_days": [180, 729],
+        "health_index_range": [0.4, 0.74],
+        "condition_note": "Aging transformer with some degradation indicators. Stable trend but planning horizon is relevant.",
+        "typical_decision": "Plan for replacement or major overhaul within 1–2 years. Increase DGA sampling to quarterly.",
+        "suitable_fault_codes": ["PD", "T1", "D1"],
+        "suitable_families": ["TSFM_RUL_FORECAST", "FMSR_DGA_DIAGNOSIS"]
+      },
+      "short_horizon_critical_load": {
+        "rul_range_days": [30, 179],
+        "health_index_range": [0.15, 0.39],
+        "condition_note": "Transformer under critical load with short remaining useful life. Fault escalation risk is high.",
+        "typical_decision": "Expedite replacement planning. De-load if possible. Emergency WO if fault code escalates.",
+        "suitable_fault_codes": ["T2", "T3", "D1", "D2"],
+        "suitable_families": ["TSFM_RUL_FORECAST", "MULTI_DOMAIN_INCIDENT"]
+      },
+      "critical_immediate": {
+        "rul_range_days": [0, 29],
+        "health_index_range": [0.0, 0.14],
+        "condition_note": "Critically degraded transformer. Immediate intervention required to prevent unplanned outage.",
+        "typical_decision": "Issue emergency corrective WO. Confirm spare availability. De-energize if condition-4 gases confirmed.",
+        "suitable_fault_codes": ["D2", "T3"],
+        "suitable_families": ["MULTI_DOMAIN_INCIDENT", "WO_CREATION"]
+      }
+    }
+  }
+}

--- a/docs/knowledge/scenario_generation_support.json
+++ b/docs/knowledge/scenario_generation_support.json
@@ -239,8 +239,8 @@
         "description": "Stable D1 pattern across three samples with slow gas drift and no step change. Condition is serious but not actively escalating toward D2.",
         "sample_progression": [
           { "step": "T-0 baseline", "H2": 500, "CH4": 100, "C2H2": 30, "C2H4": 80, "C2H6": 100, "trend_note": "D1 Condition 3 — verified D1 profile", "endpoint_verified": true, "source": "transformer_standards.json D1 profile" },
-          { "step": "T-30 days",    "H2": 500, "CH4": 100, "C2H2": 32, "C2H4": 82, "C2H6": 100, "trend_note": "D1 stable, R2=0.39" },
-          { "step": "T-60 days",    "H2": 500, "CH4": 100, "C2H2": 35, "C2H4": 85, "C2H6": 100, "trend_note": "D1 slow drift, no step change, R2=0.41" }
+          { "step": "T-30 days",    "H2": 500, "CH4": 100, "C2H2": 32, "C2H4": 82, "C2H6": 100, "trend_note": "D1 stable, R2=0.39", "step_verified": true },
+          { "step": "T-60 days",    "H2": 500, "CH4": 100, "C2H2": 35, "C2H4": 85, "C2H6": 100, "trend_note": "D1 slow drift, no step change, R2=0.41", "step_verified": true }
         ],
         "scenario_text_cue": "Three DGA samples confirm a persistent D1 pattern with no rapid escalation.",
         "urgency": "high",


### PR DESCRIPTION
## Summary

Adds 10 new hand-crafted scenarios (SGT-011 – SGT-020) across all five domain types, bringing the total validated hand-crafted set from 11 to 21. All 21 pass `validate_scenarios.py`.

## New scenarios

| ID | File | Domain | Difficulty | Tools |
|---|---|---|---|---|
| SGT-011 | `iot_03_fleet_health_overview.json` | IoT | easy | `list_assets`, `get_asset_metadata` |
| SGT-012 | `iot_04_load_current_overload_check.json` | IoT | medium | `get_asset_metadata`, `list_sensors`, `get_sensor_readings` |
| SGT-013 | `fmsr_03_symptom_to_sensor_correlation.json` | FMSR | medium | `search_failure_modes`, `get_sensor_correlation` |
| SGT-014 | `fmsr_04_dga_full_diagnostic_chain.json` | FMSR | hard | `get_dga_record`, `analyze_dga`, `search_failure_modes`, `get_sensor_correlation` |
| SGT-015 | `tsfm_03_winding_temp_trend.json` | TSFM | medium | `trend_analysis` |
| SGT-016 | `tsfm_04_rul_anomaly_full_assessment.json` | TSFM | hard | `get_rul`, `forecast_rul`, `detect_anomalies`, `trend_analysis` |
| SGT-017 | `wo_03_fault_history_review.json` | WO | easy | `list_fault_records`, `list_work_orders` |
| SGT-018 | `wo_04_fault_record_downtime_update.json` | WO | hard | `list_fault_records`, `get_fault_record`, `estimate_downtime`, `update_work_order` |
| SGT-019 | `multi_03_iot_tsfm_thermal_risk.json` | IoT + TSFM | medium | `get_sensor_readings`, `detect_anomalies`, `forecast_rul` |
| SGT-020 | `multi_04_protection_trip_dga_response.json` | FMSR + WO | hard | `get_dga_record`, `analyze_dga`, `list_fault_records`, `create_work_order` |

## Coverage after this PR

| Domain | easy | medium | hard |
|---|---|---|---|
| IoT | 1 + fleet (2) | 2 | 0 |
| FMSR | 2 | 2 | 1 |
| TSFM | 1 | 2 | 1 |
| WO | 2 | 1 | 1 |
| Multi | 0 | 1 | 3 |

## Authoring contract compliance

- All task texts use operational event language (no tool hints, no ratio/threshold leaks, no IEC code mentions)
- All texts are under 80 words
- All tools reference current MCP registry names
- Asset IDs T-001 – T-009 used (no overlap with existing SGT-001–010 assets)
- All ground truth uses `must_include` string criteria consistent with existing hand-crafted set

## Test plan

- [x] `python3 data/scenarios/validate_scenarios.py` → 21 passed, 5 negative fixtures