### PR TITLE
Draft NeurIPS submission packet

### DIFF
--- a/docs/neurips_abstract_outline.md
+++ b/docs/neurips_abstract_outline.md
@@ -1,8 +1,8 @@
 # NeurIPS Abstract Outline and Title Candidates
 
-*Last updated: 2026-04-20*  
-*Owner: Alex Xin*  
-*Issue: [#77](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/issues/77)*
+*Last updated: 2026-05-02*
+*Owner: Alex Xin*
+*Issues: #47, with historical scaffold #77*
 
 This note turns the paper lane into a concrete abstract plan early, before the
 final writing crunch. It is not the final abstract. It is the working scaffold
@@ -181,6 +181,35 @@ benchmark paper lane.
 
 If the final title does adopt **SmartGridBench**, the abstract opening can be
 rewritten to name it explicitly.
+
+## May 2 Abstract Candidate for Submission
+
+Industrial-agent benchmarks under-cover Smart Grid transformer diagnostics and
+maintenance, even though these workflows require exactly the kind of multi-tool
+reasoning that industrial LLM agents are expected to perform: telemetry
+inspection, fault diagnosis, degradation forecasting, and work-order planning.
+We present SmartGridBench, a Smart Grid transformer-maintenance extension of
+AssetOpsBench that adds transformer scenarios, public-data-backed asset
+records, and four tool domains exposed through the Model Context Protocol
+(MCP). The benchmark is designed to make two usually conflated systems choices
+measurable: the transport cost of MCP relative to direct tool invocation, and
+the behavioral effect of orchestration strategies such as Agent-as-Tool,
+Plan-Execute, and Verified Plan-Execute when the tool surface is held fixed.
+Current artifacts show a runnable end-to-end benchmark path with committed
+scenario outputs, profiling links, Weights & Biases runs, LLM-as-judge scores,
+and failure-taxonomy exports. Preliminary six-trial captures show that MCP
+standardization introduces measurable overhead in direct comparisons, that
+persistent optimized MCP sessions can reduce steady-state latency but do not by
+themselves improve answer quality, and that PE-family mitigations such as
+Self-Ask and verification can materially change judged quality. We also treat
+scenario realism, generated-scenario circularity, and failure accounting as
+first-class benchmark artifacts rather than post-hoc notes. SmartGridBench
+therefore contributes both a new industrial benchmark domain and an auditable
+systems study of protocol and orchestration choices in tool-using agents.
+
+Submission caveat: if the abstract form enforces a tighter word budget, remove
+the sentence beginning "Preliminary six-trial captures..." first, then fold the
+result gist into the prior sentence.
 
 ## What still needs teammate fact bullets
 

--- a/docs/neurips_abstract_outline.md
+++ b/docs/neurips_abstract_outline.md
@@ -10,7 +10,7 @@ the final abstract should be written from.
 
 ## Working constraints
 
-- Target venue: **NeurIPS 2026 Datasets & Benchmarks Track**
+- Target venue: **NeurIPS 2026 Evaluations & Datasets Track** (formerly Datasets & Benchmarks)
 - Abstract should read as one tight paragraph, not a mini-outline
 - Current default is **seven sentences**, not four - four is too compressed for
   this paper because the abstract still needs room for five sentence-level

--- a/docs/neurips_draft.md
+++ b/docs/neurips_draft.md
@@ -1,9 +1,9 @@
 # NeurIPS Draft Scaffold
 
-*Last updated: 2026-05-01*
+*Last updated: 2026-05-02*
 *Owner: Alex Xin (writing shepherd; section co-authoring under discussion for
 Apr 28 team sync)*
-*Issues: `#5`, `#39`; class-report back-port tracked in `#40`*
+*Issues: `#5`, `#39`, `#47`, `#48`; class-report back-port tracked in `#40`*
 
 This doc is the live draft scaffold for the NeurIPS 2026 Datasets & Benchmarks
 paper lane. It used to live alongside the failure-analysis scaffold inside
@@ -17,6 +17,31 @@ final paper — it is the canonical writing surface for:
 - draft prose that should later move into Overleaf cleanly
 
 Companion conversion surface: `docs/final_report_backport_scaffold.md`.
+Submission control surface: `docs/neurips_submission_packet.md`.
+
+## May 2 submission status
+
+The NeurIPS lane is now a live submission lane rather than only a paper
+scaffold. The Overleaf project at
+https://www.overleaf.com/project/69f5a380e638a31066dc0bd1 has ingested the
+official NeurIPS 2026 template package from the NeurIPS CFP and is configured
+for anonymous Evaluations & Datasets submission mode
+(`\usepackage[eandd]{neurips_2026}`). The remaining LaTeX gate is visual
+compile proof in Overleaf plus completion of the NeurIPS checklist.
+
+Deadline posture from the final-week plan:
+
+| Deliverable | Deadline |
+|---|---|
+| NeurIPS abstract | 2026-05-04 23:59 AOE |
+| NeurIPS full paper | 2026-05-06 23:59 AOE |
+| Class presentation | 2026-05-07 15:00 ET |
+| Class final report | 2026-05-08 23:59 ET |
+
+Writing stance: use the current six-trial captures and failure taxonomy as
+paper-backed evidence now; promote additional scenario counts, mitigation
+reruns, or 70B/context-window appendix evidence only after those artifacts are
+on canonical history or explicitly labeled as pending/appendix.
 
 ## Working title
 
@@ -41,26 +66,30 @@ quietly folded into the baseline comparison.
 
 ## Draft abstract
 
-Draft paragraph:
+Draft paragraph to transfer into Overleaf:
 
+Industrial-agent benchmarks under-cover Smart Grid transformer diagnostics and
+maintenance, even though these workflows require exactly the kind of multi-tool
+reasoning that industrial LLM agents are expected to perform: telemetry
+inspection, fault diagnosis, degradation forecasting, and work-order planning.
 We present SmartGridBench, a Smart Grid transformer-maintenance extension of
-AssetOpsBench designed to evaluate industrial agents that must combine
-telemetry inspection, failure diagnosis, degradation forecasting, and
-maintenance planning. The benchmark exposes four tool domains through
-MCP-backed Smart Grid servers and keeps one benchmark-facing artifact contract
-across direct-tool, MCP, and orchestration conditions. We use this extension to
-study two questions that are usually conflated: what latency cost MCP
-standardization introduces relative to direct tool calls, and how orchestration
-choices such as Agent-as-Tool and Plan-Execute affect benchmark behavior when
-transport is held fixed. The core study therefore separates transport
-comparison (`A/B/C`) from orchestration comparison (`B/Y`, with optional `Z`)
-rather than running an uncontrolled full matrix. Beyond baseline comparison, we
-also treat failure analysis as a first-class benchmark artifact: committed runs
-already expose recurring answer/tool inconsistency and wrapper-level accounting
-failures, which motivates a measurable mitigation lane for PE-family methods.
-This framing keeps the paper honest about what is already proven, while still
-showing how protocol design, orchestration structure, and evidence discipline
-interact in industrial-agent benchmarking.
+AssetOpsBench that adds transformer scenarios, public-data-backed asset
+records, and four tool domains exposed through the Model Context Protocol
+(MCP). The benchmark is designed to make two usually conflated systems choices
+measurable: the transport cost of MCP relative to direct tool invocation, and
+the behavioral effect of orchestration strategies such as Agent-as-Tool,
+Plan-Execute, and Verified Plan-Execute when the tool surface is held fixed.
+Current artifacts show a runnable end-to-end benchmark path with committed
+scenario outputs, profiling links, Weights & Biases runs, LLM-as-judge scores,
+and failure-taxonomy exports. Preliminary six-trial captures show that MCP
+standardization introduces measurable overhead in direct comparisons, that
+persistent optimized MCP sessions can reduce steady-state latency but do not by
+themselves improve answer quality, and that PE-family mitigations such as
+Self-Ask and verification can materially change judged quality. We also treat
+scenario realism, generated-scenario circularity, and failure accounting as
+first-class benchmark artifacts rather than post-hoc notes. SmartGridBench
+therefore contributes both a new industrial benchmark domain and an auditable
+systems study of protocol and orchestration choices in tool-using agents.
 
 ## Working contribution list
 
@@ -100,6 +129,8 @@ Use this table to keep the draft aligned with what the repo can actually prove.
 | AaT Cell A/B runner surface exists and can emit canonical smoke artifacts | `docs/validation_log.md`, jobs `8962310` and `8969519`; upstream parity jobs `8970383`, `8970468` | safe now as smoke proof |
 | AaT Cell A/B canonical captures exist on the same scenario set, same model, same job | `benchmarks/cell_A_direct/summary.json` and `benchmarks/cell_B_mcp_baseline/summary.json` from job `8979314` (PR `#130`); 6 scenarios per side, `Llama-3.1-8B-Instruct`, scenario set `smartgrid_multi_domain` (hash `ca66cd16…2691e48`); both sides hit `success_rate=1.0`, `failure_count=0`, `tool_error_count=0` | safe now as a paired one-job baseline |
 | PE-family failures show recurring correctness/accounting issues worth classifying | `docs/failure_taxonomy_evidence.md`, committed Y/Z artifacts, `docs/validation_log.md` | safe now |
+| Official NeurIPS 2026 submission surface exists | Overleaf project `69f5a380e638a31066dc0bd1`, commit `7e361de`, official `neurips_2026` package and `checklist.tex` | safe now |
+| Scenario corpus is on track for the 30-scenario floor | `team13/main` has 11 main scenarios; PR #156 adds 10 hand-crafted scenarios; generator-accepted scenarios still pending | pending; do not present 30 as complete until merged/validated |
 | Indicative AaT MCP transport overhead (Cell B − Cell A) on the canonical scenario set | job `8979314` paired summaries: latency mean `+1.20s` (`+9.8%`), wall-clock total `+7.17s` (`+9.8%`), tool-call mean `+0.17` (`+5.0%`), zero tool errors | safe now as one-job, six-scenario evidence; **not** safe as a final transport-overhead distribution |
 | Full transport result across `A/B/C` | final comparable captures under `benchmarks/cell_A_direct/`, `cell_B_mcp_baseline/`, `cell_C_mcp_optimized/` with repeat trials and judge data | partial: one-job A/B pair exists from `8979314`; first Cell C capture/judge set exists from `9071639`; final 5-trial matched rerun still missing |
 | Final orchestration comparison across shared `B/Y` anchor | final comparable shared-cell artifacts plus judge outputs | blocked |
@@ -394,6 +425,32 @@ When final numbers land, keep the results section ordered this way:
 That order prevents the paper from front-loading mitigation wins before the
 baseline matrix is actually established.
 
+### Current results snapshot for first full draft
+
+Use this table as the first Overleaf results skeleton. It is paper-useful now,
+but every caption should call it a six-trial first-capture summary unless final
+matched reruns replace it.
+
+| Cell | Meaning | Run | Trials | p50 latency | p95 latency | Judge mean | Judge pass |
+|---|---|---|---:|---:|---:|---:|---:|
+| `A` / `AT-I` | AaT direct Python tools | `8979314_aat_direct` | 6 | 12.15s | 17.29s | 0.167 | 1/6 |
+| `B` / `AT-M` | AaT MCP baseline | `8979314_aat_mcp_baseline` | 6 | 13.09s | 16.27s | 0.278 | 2/6 |
+| `C` / `AT-TP` | AaT optimized MCP transport + prefix cache | `9071639_aat_mcp_optimized` | 6 | 7.40s | 47.93s | 0.167 | 0/6 |
+| `Y` / `PE-M` | Plan-Execute MCP baseline | `8998340_exp2_cell_Y_pe_mcp_baseline` | 6 | 52.06s | 116.32s | 0.111 | 0/6 |
+| `Z` / `V-M` | Verified PE MCP baseline | `8998342_exp2_cell_Z_verified_pe_mcp_baseline` | 6 | 119.64s | 152.36s | 0.639 | 4/6 |
+| `YS` / `PE-S-M` | Plan-Execute + Self-Ask | `8998341_exp2_cell_Y_pe_self_ask_mcp_baseline` | 6 | 59.00s | 83.20s | 0.444 | 3/6 |
+| `ZS` / `V-S-M` | Verified PE + Self-Ask | `8998343_exp2_cell_Z_verified_pe_self_ask_mcp_baseline` | 6 | 33.78s | 58.03s | 0.833 | 5/6 |
+
+Draft sentence:
+
+Across the first six-trial evidence set, optimized persistent MCP sessions
+reduced steady-state AaT latency but did not improve judged answer quality,
+while PE-family variants showed that clarification and verification can matter
+more for semantic quality than transport alone. The strongest current
+PE-family row is Verified PE + Self-Ask (`ZS`), with mean judge score `0.833`
+and `5/6` judge-pass, but it should be framed as a follow-on mitigation lane
+rather than the vanilla orchestration baseline.
+
 ### Preliminary Experiment 1 numbers (one job, six scenarios)
 
 The first canonical transport-overhead measurement is now committed. PR
@@ -630,7 +687,8 @@ What is still missing before `#39` is complete:
 - final result paragraphs after the A/B/C and B/Y analysis exports are frozen
 - final figure captions tied to the committed figure files
 - references formatted in the NeurIPS style
-- Overleaf / LaTeX transfer and compile proof
+- Overleaf / LaTeX visual compile proof with the 2026 template
+- completed NeurIPS checklist answers
 
 ## Back-port handoff for `#40`
 

--- a/docs/neurips_draft.md
+++ b/docs/neurips_draft.md
@@ -5,8 +5,8 @@
 Apr 28 team sync)*
 *Issues: `#5`, `#39`, `#47`, `#48`; class-report back-port tracked in `#40`*
 
-This doc is the live draft scaffold for the NeurIPS 2026 Datasets & Benchmarks
-paper lane. It used to live alongside the failure-analysis scaffold inside
+This doc is the live draft scaffold for the NeurIPS 2026 Evaluations & Datasets
+paper lane (formerly Datasets & Benchmarks). It used to live alongside the failure-analysis scaffold inside
 PR `#124`; on 2026-04-27 each issue (`#35`, `#64`, `#36`, `#5`) was split into
 its own PR so the four lanes can ship independently. This file is not the
 final paper — it is the canonical writing surface for:
@@ -458,15 +458,15 @@ The first canonical transport-overhead measurement is now committed. PR
 job (`8979314`) on `Llama-3.1-8B-Instruct`, running 6 scenarios per side
 over the canonical scenario set `smartgrid_multi_domain` (hash
 `ca66cd16…2691e48`). Both sides hit `success_rate=1.0` with zero tool
-errors. Pairing the two summaries gives the first concrete (Cell B −
-Cell A) row:
+errors. Pairing the Notebook 02 latency export with the experiment-matrix
+summary gives the first concrete paper-facing (Cell B − Cell A) row:
 
 | Metric | Cell A (direct) | Cell B (MCP baseline) | Δ (B − A) | Δ % |
 |---|---:|---:|---:|---:|
 | `wall_clock_seconds_total` | 73.13 | 80.30 | +7.17 | +9.8% |
 | `latency_seconds_mean` | 12.19 | 13.38 | +1.20 | +9.8% |
-| `latency_seconds_p50` | 11.47 | 12.91 | +1.44 | +12.6% |
-| `latency_seconds_p95` | 18.57 | 16.65 | −1.92 | −10.3% |
+| `latency_seconds_p50` | 12.15 | 13.09 | +0.94 | +7.7% |
+| `latency_seconds_p95` | 17.29 | 16.27 | −1.02 | −5.9% |
 | `tool_call_count_total` | 20 | 21 | +1 | +5.0% |
 | `tool_call_count_mean` | 3.33 | 3.50 | +0.17 | +5.0% |
 | `tool_error_count` | 0 | 0 | 0 | n/a |

--- a/docs/neurips_submission_packet.md
+++ b/docs/neurips_submission_packet.md
@@ -1,0 +1,149 @@
+# NeurIPS 2026 Submission Packet
+
+*Created: 2026-05-02*
+*Owner: Alex Xin*
+*Issues: #5, #39, #47, #48*
+
+This packet is the deadline-facing control surface for the NeurIPS 2026
+Datasets & Benchmarks submission. It summarizes what can already go into the
+paper, what still needs a final evidence pass, and where the LaTeX submission
+surface lives.
+
+## Submission Surface
+
+| Field | Current value |
+|---|---|
+| Venue | NeurIPS 2026 Datasets & Benchmarks Track |
+| Abstract deadline | 2026-05-04 23:59 AOE |
+| Full-paper deadline | 2026-05-06 23:59 AOE |
+| Overleaf project | https://www.overleaf.com/project/69f5a380e638a31066dc0bd1 |
+| Template status | Official NeurIPS 2026 template ingested in Overleaf Git commit `7e361de` |
+| Template source | https://media.neurips.cc/Conferences/NeurIPS2026/Formatting_Instructions_For_NeurIPS_2026.zip |
+| LaTeX mode | anonymous `eandd` via `\usepackage[eandd]{neurips_2026}` |
+| Checklist | `checklist.tex` added to Overleaf; content still needs final answers |
+
+## Working Title
+
+**SmartGridBench: MCP-Based Industrial Agent Benchmarking for Smart Grid
+Transformer Operations**
+
+## Abstract Candidate
+
+Industrial-agent benchmarks under-cover Smart Grid transformer diagnostics and
+maintenance, even though these workflows require exactly the kind of multi-tool
+reasoning that industrial LLM agents are expected to perform: telemetry
+inspection, fault diagnosis, degradation forecasting, and work-order planning.
+We present SmartGridBench, a Smart Grid transformer-maintenance extension of
+AssetOpsBench that adds transformer scenarios, public-data-backed asset
+records, and four tool domains exposed through the Model Context Protocol
+(MCP). The benchmark is designed to make two usually conflated systems choices
+measurable: the transport cost of MCP relative to direct tool invocation, and
+the behavioral effect of orchestration strategies such as Agent-as-Tool,
+Plan-Execute, and Verified Plan-Execute when the tool surface is held fixed.
+Current artifacts show a runnable end-to-end benchmark path with committed
+scenario outputs, profiling links, Weights & Biases runs, LLM-as-judge scores,
+and failure-taxonomy exports. Preliminary six-trial captures show that MCP
+standardization introduces measurable overhead in direct comparisons, that
+persistent optimized MCP sessions can reduce steady-state latency but do not by
+themselves improve answer quality, and that PE-family mitigations such as
+Self-Ask and verification can materially change judged quality. We also treat
+scenario realism, generated-scenario circularity, and failure accounting as
+first-class benchmark artifacts rather than post-hoc notes. SmartGridBench
+therefore contributes both a new industrial benchmark domain and an auditable
+systems study of protocol and orchestration choices in tool-using agents.
+
+## Claim Tiers
+
+| Tier | Claim | Evidence now | Paper stance |
+|---|---|---|---|
+| Safe | SmartGridBench adds a Smart Grid transformer-maintenance lane over AssetOpsBench. | `data/`, `mcp_servers/`, `data/scenarios/`, `docs/data_pipeline.tex` | Main contribution. |
+| Safe | The repo has direct-tool, MCP-baseline, and optimized-MCP AaT paths with committed artifacts. | A/B job `8979314`; C job `9071639`; Notebook 02 exports | Report as preliminary six-trial evidence until final reruns freeze. |
+| Safe | The repo has Plan-Execute, Verified PE, and PE-family Self-Ask follow-ons with judge outputs. | jobs `8998340` through `8998343`; Notebook 03 exports | Main orchestration result, with small-sample caveat. |
+| Safe | Failure analysis is artifact-backed. | `failure_evidence_table.csv`, taxonomy SVGs, mitigation inventory | Main reliability/evaluation contribution. |
+| Pending | Scenario floor reaches 30 validated scenarios. | `team13/main` has 11 main scenarios; PR #156 adds 10 hand-authored scenarios; Akshat generator acceptance remains needed for 30 floor | Mention as deadline blocker until merged/validated. |
+| Pending | Missing-evidence guard improves outcomes. | Guard implementation and policy landed; `mitigation_before_after.csv` has header only | Describe as implemented mitigation pending rerun evidence. |
+| Optional | 70B and context-window appendix strengthens generality. | local branch evidence exists outside canonical main | Appendix only if published before final paper freeze. |
+
+## Section Plan
+
+| Section | Draft content to transfer |
+|---|---|
+| 1. Introduction | Benchmark gap, Smart Grid maintenance stakes, protocolized tool-use cost, and why transport/orchestration must be separated. |
+| 2. Benchmark Extension | Dataset sources, shared `transformer_id`, four tool domains, scenario schema, realism controls, and 30-scenario target status. |
+| 3. System Design | MCP servers, direct adapter for Cell A, persistent MCP path for Cell C, run artifact contract, WandB/profiler linkage. |
+| 4. Experimental Design | Experiment 1 A/B/C transport axis; Experiment 2 B/Y/Z orchestration axis; PE-family Self-Ask/Verified follow-ons. |
+| 5. Results | Notebook 02 latency summary, Notebook 03 orchestration/judge table, failure taxonomy counts, and mitigation status. |
+| 6. Limitations | Small six-trial first captures, scenario-count pending work, generated-scenario circularity, and guarded-rerun incompleteness. |
+| 7. Reproducibility | Artifact ledger, run IDs, repo paths, Overleaf source, and NeurIPS checklist. |
+
+## Current Results Snapshot
+
+### Experiment 1 - Transport Axis
+
+| Cell | Meaning | Run | Trials | p50 latency | p95 latency | Judge mean | Judge pass |
+|---|---|---|---:|---:|---:|---:|---:|
+| A / AT-I | Agent-as-Tool direct Python tools | `8979314_aat_direct` | 6 | 12.15s | 17.29s | 0.167 | 1/6 |
+| B / AT-M | Agent-as-Tool MCP baseline | `8979314_aat_mcp_baseline` | 6 | 13.09s | 16.27s | 0.278 | 2/6 |
+| C / AT-TP | Optimized MCP transport + prefix cache | `9071639_aat_mcp_optimized` | 6 | 7.40s | 47.93s | 0.167 | 0/6 |
+
+Interpretation for draft prose: optimized persistent MCP improves steady-state
+latency after the first cold trial, but quality does not automatically improve
+with transport optimization. Keep Cell C quality caveats prominent.
+
+### Experiment 2 - Orchestration Axis
+
+| Cell | Meaning | Run | Success rate | p50 latency | Judge mean | Judge pass |
+|---|---|---|---:|---:|---:|---:|
+| B / AT-M | Agent-as-Tool MCP baseline | `8979314_aat_mcp_baseline` | 1.0 | 13.09s | 0.278 | 2/6 |
+| Y / PE-M | Plan-Execute MCP baseline | `8998340_exp2_cell_Y_pe_mcp_baseline` | 0.5 | 52.06s | 0.111 | 0/6 |
+| Z / V-M | Verified Plan-Execute MCP baseline | `8998342_exp2_cell_Z_verified_pe_mcp_baseline` | 1.0 | 119.64s | 0.639 | 4/6 |
+| YS / PE-S-M | Plan-Execute + Self-Ask | `8998341_exp2_cell_Y_pe_self_ask_mcp_baseline` | 1.0 | 59.00s | 0.444 | 3/6 |
+| ZS / V-S-M | Verified PE + Self-Ask | `8998343_exp2_cell_Z_verified_pe_self_ask_mcp_baseline` | 1.0 | 33.78s | 0.833 | 5/6 |
+
+Interpretation for draft prose: vanilla PE is weak on current evidence, but
+structured PE-family variants become more competitive when clarification and
+verification are added. This supports a nuanced enterprise-readiness story:
+structure helps auditability, but only if the runner also handles missing
+evidence and final-answer grounding.
+
+### Failure Taxonomy
+
+| Failure class | Rows | Percent |
+|---|---:|---:|
+| Task verification failure | 18 | 51.4% |
+| Inter-agent / orchestration failure | 13 | 37.1% |
+| Specification failure | 4 | 11.4% |
+
+Interpretation for draft prose: the largest failure class is not transport or
+execution plumbing; it is evidence verification and unsupported finalization.
+This justifies the mitigation ladder as benchmark reliability work.
+
+## Figure and Table Transfer Checklist
+
+- [ ] Insert Experiment 1 latency figure from `results/figures/notebook02_latency_comparison.png`.
+- [ ] Insert Experiment 2 orchestration figure from `results/figures/notebook03_orchestration_comparison.png`.
+- [ ] Insert PE-family follow-on figure from `results/figures/notebook03_pe_family_follow_on.png` if it fits the page budget.
+- [ ] Insert failure taxonomy count figure from `results/figures/failure_taxonomy_counts.svg`.
+- [ ] Insert failure stage heatmap from `results/figures/failure_stage_cell_heatmap.svg`.
+- [ ] Add artifact ledger table using `docs/validation_log.md` and `results/metrics/experiment_matrix_summary.csv`.
+- [ ] Add scenario corpus table once PR #156 and generator-accepted scenarios settle.
+
+## Final Submission Blockers
+
+| Blocker | Owner | Deadline posture |
+|---|---|---|
+| Compile in Overleaf with official 2026 template | Alex | Must clear before abstract/full-paper upload. |
+| Fill NeurIPS checklist | Alex + factual inputs from team | Must clear before full-paper upload. |
+| Reach and document 30 validated scenarios | Akshat/Tanisha, Alex shepherd | Must clear before final claims. |
+| Freeze final result table captions | Alex, Aaron, Akshat | Can use current six-trial captures if final reruns do not land. |
+| Decide whether to include mitigation rerun rows | Alex | Include only if `mitigation_before_after.csv` has real rows. |
+| Final references and citations | Alex | Must clear before full-paper upload. |
+
+## Teammate Fact Asks
+
+- Aaron: final sentence on Insomnia/vLLM/profiling setup and whether Cell C
+  should be described as persistent MCP session reuse, prefix caching, or both.
+- Tanisha: final sentence on MCP server/data scope and any caveat around
+  Smart Grid data realism.
+- Akshat: final scenario count, generated-scenario validation disposition, and
+  one sentence on judge-score methodology.

--- a/docs/neurips_submission_packet.md
+++ b/docs/neurips_submission_packet.md
@@ -5,15 +5,16 @@
 *Issues: #5, #39, #47, #48*
 
 This packet is the deadline-facing control surface for the NeurIPS 2026
-Datasets & Benchmarks submission. It summarizes what can already go into the
+Evaluations & Datasets submission. It summarizes what can already go into the
 paper, what still needs a final evidence pass, and where the LaTeX submission
-surface lives.
+surface lives. NeurIPS previously used the Datasets & Benchmarks track name for
+this submission lane.
 
 ## Submission Surface
 
 | Field | Current value |
 |---|---|
-| Venue | NeurIPS 2026 Datasets & Benchmarks Track |
+| Venue | NeurIPS 2026 Evaluations & Datasets Track (formerly Datasets & Benchmarks) |
 | Abstract deadline | 2026-05-04 23:59 AOE |
 | Full-paper deadline | 2026-05-06 23:59 AOE |
 | Overleaf project | https://www.overleaf.com/project/69f5a380e638a31066dc0bd1 |


### PR DESCRIPTION
## Summary

- Adds `docs/neurips_submission_packet.md` as the deadline-facing NeurIPS 2026 control surface.
- Refreshes `docs/neurips_draft.md` with May 2 deadlines, Overleaf/template status, a paper-safe abstract candidate, current evidence tiers, and first-capture result snapshot.
- Updates `docs/neurips_abstract_outline.md` with the May 2 abstract candidate for #47.

Refs #5, #39, #47, #48.

## Verification

- `git diff --check team13/main...HEAD`
- Manual check that PR #156 scenario uplift is labeled pending, not merged fact.
- Manual check that the Overleaf 2026 template ingestion is described as status, with visual compile/checklist still open.

## Deferred

- Transfer to Overleaf body text.
- Visual compile proof in Overleaf.
- Completed NeurIPS checklist.
- Final scenario-count and result-table freeze.
