### PR TITLE
Add NeurIPS Overleaf transfer plan (#5, #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Added `docs/neurips_overleaf_transfer_plan.md` and linked it from the
+  NeurIPS draft, submission packet, and IEEE back-port scaffold so #5 / #39 /
+  #40 / #47 / #48 / #78 have a concrete Overleaf copy queue with caveats for
+  pending scenario-count, rerun, mitigation, and compile gates.
 - Added `docs/mitigation_recovery_adjudication.md`, an implementation-ready
   spec for the follow-on mitigation ladder: bounded missing-evidence
   retry/replan recovery and explicit fault/risk adjudication. The spec keeps

--- a/docs/final_report_backport_scaffold.md
+++ b/docs/final_report_backport_scaffold.md
@@ -11,6 +11,8 @@ content drift. The source of truth for claims and prose remains
 content-bearing class report drafting surface is now
 `reports/final_report_ieee_draft.md`.
 
+Overleaf transfer surface: `docs/neurips_overleaf_transfer_plan.md`.
+
 ## Source-of-truth order
 
 Use this order when the report and paper disagree:
@@ -73,6 +75,12 @@ pending deadline work. In particular, it does not claim the 30-scenario floor is
 complete until PR #156 plus generator-accepted scenarios are merged and
 validated.
 
+The next useful scaffolding step is to populate the NeurIPS Overleaf source
+first, then back-port from that source into the IEEE template. This keeps #40
+and #78 aligned with #5/#39 instead of creating a second independent paper.
+Until the NeurIPS source is compiled, the Markdown report draft should remain a
+working conversion surface rather than the class-submission artifact.
+
 ## Back-port checklist
 
 - [ ] Freeze the result tables and figure files that the class report cites.
@@ -89,6 +97,8 @@ validated.
       `docs/validation_log.md`.
 - [ ] Compile the IEEE Overleaf report and record the compile/export status in
       the issue or PR thread.
+- [ ] After the NeurIPS Overleaf source is populated, re-check this Markdown
+      draft against `main.tex` before copying into the IEEE template.
 
 ## Current status
 

--- a/docs/neurips_draft.md
+++ b/docs/neurips_draft.md
@@ -18,6 +18,7 @@ final paper — it is the canonical writing surface for:
 
 Companion conversion surface: `docs/final_report_backport_scaffold.md`.
 Submission control surface: `docs/neurips_submission_packet.md`.
+Overleaf copy plan: `docs/neurips_overleaf_transfer_plan.md`.
 
 ## May 2 submission status
 
@@ -42,6 +43,28 @@ Writing stance: use the current six-trial captures and failure taxonomy as
 paper-backed evidence now; promote additional scenario counts, mitigation
 reruns, or 70B/context-window appendix evidence only after those artifacts are
 on canonical history or explicitly labeled as pending/appendix.
+
+## May 2 Overleaf readiness
+
+The draft is now ready for a first Overleaf population pass. This means the
+structure, conservative prose, current first-capture tables, and limitation
+language can move into the NeurIPS source even though final evidence gates
+remain open.
+
+| Paper block | Ready to paste? | Caveat to leave visible |
+|---|---:|---|
+| Title and abstract | yes | re-check word budget and final numerical language |
+| Introduction | yes | none beyond normal final polish |
+| Benchmark extension | yes | final scenario count is pending |
+| System design | yes | final Cell C wording depends on Aaron's last fact bullet |
+| Experimental design | yes | keep follow-ons separate from core axes |
+| Results tables | yes as first-capture evidence | do not call repeat-rerun distribution final |
+| Failure taxonomy | yes | mitigation outcome rows pending |
+| Limitations/reproducibility | yes | update after final scenario/rerun decisions |
+
+Use `docs/neurips_overleaf_transfer_plan.md` as the copy queue. The most useful
+next Overleaf action is not more outline work; it is pasting the section
+scaffold into `main.tex` with TODOs for the remaining empirical gates.
 
 ## Working title
 

--- a/docs/neurips_overleaf_transfer_plan.md
+++ b/docs/neurips_overleaf_transfer_plan.md
@@ -1,0 +1,227 @@
+# NeurIPS Overleaf Transfer Plan
+
+*Created: 2026-05-02*
+*Owner: Alex Xin*
+*Issues: #5, #39, #40, #47, #48, #78*
+
+This is the paper handoff layer between the repo Markdown drafts and the
+NeurIPS 2026 Overleaf project:
+
+https://www.overleaf.com/project/69f5a380e638a31066dc0bd1
+
+The Overleaf project already contains the official NeurIPS 2026 template and is
+configured for anonymous Evaluations & Datasets mode. This repo file records
+what can be copied into Overleaf now, what must stay caveated, and what remains
+blocked on final evidence.
+
+## Transfer Principle
+
+Move stable structure and conservative prose into Overleaf immediately. Do not
+wait for the final scenario floor, mitigation reruns, or any 70B appendix
+decision before populating the paper skeleton. Those pending facts can remain
+as TODO markers or explicitly caveated result rows.
+
+Source-of-truth order:
+
+1. `docs/validation_log.md` and committed benchmark artifacts for run IDs.
+2. `results/metrics/*.csv` and `results/figures/*` for numbers and figures.
+3. `docs/neurips_draft.md` for canonical prose.
+4. `docs/neurips_submission_packet.md` for deadline and claim-state control.
+5. This transfer plan for Overleaf copy order and blocked/pending markers.
+
+## Copy Into Overleaf Now
+
+### Title and abstract
+
+Source:
+
+- `docs/neurips_submission_packet.md`
+- `docs/neurips_abstract_outline.md`
+- `docs/neurips_draft.md`
+
+Transfer:
+
+- Working title: "SmartGridBench: MCP-Based Industrial Agent Benchmarking for
+  Smart Grid Transformer Operations"
+- Abstract candidate from `docs/neurips_submission_packet.md`.
+- If the abstract form enforces a tighter word budget, first remove the
+  sentence beginning "Preliminary six-trial captures show...".
+
+Status: ready for Overleaf draft paste; final numerical language should be
+rechecked after any new captures land.
+
+### Introduction
+
+Source:
+
+- `docs/neurips_draft.md` section `1. Introduction`
+
+Transfer:
+
+- Benchmark gap: Smart Grid transformer maintenance is under-covered.
+- Systems gap: protocolized tool access is usually treated as plumbing, not a
+  measured variable.
+- Study frame: SmartGridBench separates transport effects from orchestration
+  behavior.
+
+Status: ready for Overleaf draft paste.
+
+### Benchmark extension
+
+Source:
+
+- `docs/neurips_draft.md` section `2. Benchmark Extension`
+- `docs/data_pipeline.tex`
+- `docs/scenario_realism_validation.md`
+- `docs/knowledge/generated_scenario_authoring_and_ground_truth.md`
+
+Transfer:
+
+- Public transformer-related sources reconciled onto a shared synthetic
+  `transformer_id`.
+- Four tool domains: IoT, FMSR, TSFM, and WO.
+- Scenario realism and generated-scenario circularity controls.
+
+Status: ready for Overleaf draft paste with one TODO: final scenario count.
+
+Do not yet write "30 validated scenarios" as complete. Use:
+
+> The deadline target is a 30-scenario validated corpus; the final count is
+> frozen only after PR #156 and generator-accepted scenarios are merged and
+> validated.
+
+### System design and artifact contract
+
+Source:
+
+- `docs/neurips_draft.md` section `3. System Design`
+- `docs/runbook.md`
+- `docs/wandb_schema.md`
+- `docs/orchestration_wiring.md`
+
+Transfer:
+
+- MCP servers and direct adapter explain Cells A/B/C.
+- `scripts/run_experiment.sh` explains the common artifact contract.
+- `benchmarks/cell_<X>/raw/<run-id>/` explains run-level traceability.
+- W&B and profiling references are supporting artifacts, not standalone claims.
+
+Status: ready for Overleaf draft paste.
+
+### Experimental design
+
+Source:
+
+- `docs/neurips_draft.md` section `4. Experimental Design`
+- `docs/experiment_matrix.md`
+
+Transfer:
+
+- Experiment 1: A/B/C transport axis.
+- Experiment 2: B/Y/Z orchestration axis.
+- B is the anchor condition shared by both experiments.
+- PE + Self-Ask, Verified PE + Self-Ask, Cell D, and 70B/context-window checks
+  are follow-ons or appendix candidates unless promoted by final evidence.
+
+Status: ready for Overleaf draft paste.
+
+### Results skeleton
+
+Source:
+
+- `docs/neurips_submission_packet.md` current results snapshot
+- `results/metrics/experiment_matrix_summary.csv`
+- `results/metrics/notebook02_latency_summary.csv`
+- `results/metrics/notebook03_orchestration_comparison.csv`
+- `results/metrics/notebook03_pe_family_follow_on.csv`
+
+Transfer:
+
+- Add the current A/B/C transport table with a caption that says
+  "first six-trial capture".
+- Add the B/Y/Z and PE-family table with a caption that says "small-sample
+  orchestration and follow-on evidence".
+- Keep C and D separate: C is the clean optimized-MCP transport row; D is an
+  optimized-serving ablation.
+
+Status: ready for Overleaf as a draft results table. Do not call these final
+rerun results unless a later PR replaces them.
+
+### Failure analysis and mitigation
+
+Source:
+
+- `docs/neurips_draft.md` section `6. Failure Analysis and Mitigation`
+- `docs/failure_taxonomy_evidence.md`
+- `docs/failure_visuals_mitigation.md`
+- `docs/mitigation_recovery_adjudication.md`
+- `results/metrics/failure_taxonomy_counts.csv`
+- `results/figures/failure_taxonomy_counts.svg`
+- `results/figures/failure_stage_cell_heatmap.svg`
+
+Transfer:
+
+- Failure taxonomy class counts.
+- Evidence-resolution failure as the dominant paper discussion point.
+- Missing-evidence guard as implemented mitigation, with outcome rows pending.
+
+Status: taxonomy ready; mitigation before/after rows pending.
+
+### Limitations and reproducibility
+
+Source:
+
+- `docs/neurips_draft.md` section `7. Reproducibility and Limitations`
+- `docs/neurips_submission_packet.md` final blockers
+- `docs/validation_log.md`
+
+Transfer:
+
+- Small first-capture result set.
+- Final scenario count pending.
+- Generated-scenario circularity.
+- Academic GPU/resource limits.
+- Artifact-led reproducibility.
+
+Status: ready for Overleaf draft paste.
+
+## Leave As TODO In Overleaf
+
+Use visible TODO markers for these until evidence freezes:
+
+- final scenario count and corpus table
+- final repeated transport distribution, if reruns land
+- missing-evidence mitigation before/after rows
+- final citations and related-work compression
+- NeurIPS checklist answers
+- final figure captions with run IDs and source CSV paths
+- class-report back-port proof after NeurIPS source stabilizes
+
+## Figure Insertion Queue
+
+Minimum figure set:
+
+| Order | Figure | Source | Status |
+|---:|---|---|---|
+| 1 | Experiment 1 latency comparison | `results/figures/notebook02_latency_comparison.png` | ready as first-capture figure |
+| 2 | Experiment 2 orchestration comparison | `results/figures/notebook03_orchestration_comparison.png` | ready as first-capture figure |
+| 3 | PE-family follow-on | `results/figures/notebook03_pe_family_follow_on.png` | optional; include if space permits |
+| 4 | Failure taxonomy counts | `results/figures/failure_taxonomy_counts.svg` | ready |
+| 5 | Failure stage/cell heatmap | `results/figures/failure_stage_cell_heatmap.svg` | ready |
+
+Every caption should include either a source CSV path or a run-ID reference.
+
+## Class Report Back-Port Note
+
+The class IEEE report should not be authored separately from scratch. After the
+Overleaf NeurIPS source is populated, use `reports/final_report_ieee_draft.md`
+and `docs/final_report_backport_scaffold.md` as the conversion checklist:
+
+- NeurIPS Introduction -> IEEE Introduction.
+- NeurIPS Benchmark Extension -> IEEE Models and Data Description.
+- NeurIPS System/Experimental Design -> IEEE Training and Profiling Methodology.
+- NeurIPS Results/Failure Analysis -> IEEE Experimental Results.
+- NeurIPS Limitations/Conclusion -> IEEE Conclusion.
+
+Issue #40 and #78 should stay open until the IEEE LaTeX template is populated,
+compiled, exported, and checked against the final NeurIPS source.

--- a/docs/neurips_submission_packet.md
+++ b/docs/neurips_submission_packet.md
@@ -22,6 +22,7 @@ this submission lane.
 | Template source | https://media.neurips.cc/Conferences/NeurIPS2026/Formatting_Instructions_For_NeurIPS_2026.zip |
 | LaTeX mode | anonymous `eandd` via `\usepackage[eandd]{neurips_2026}` |
 | Checklist | `checklist.tex` added to Overleaf; content still needs final answers |
+| Overleaf transfer plan | `docs/neurips_overleaf_transfer_plan.md` |
 
 ## Working Title
 
@@ -76,6 +77,26 @@ systems study of protocol and orchestration choices in tool-using agents.
 | 5. Results | Notebook 02 latency summary, Notebook 03 orchestration/judge table, failure taxonomy counts, and mitigation status. |
 | 6. Limitations | Small six-trial first captures, scenario-count pending work, generated-scenario circularity, and guarded-rerun incompleteness. |
 | 7. Reproducibility | Artifact ledger, run IDs, repo paths, Overleaf source, and NeurIPS checklist. |
+
+## Immediate Overleaf Population Plan
+
+This is the next practical writing block. We can populate Overleaf now without
+waiting for final reruns:
+
+1. Paste the title, abstract candidate, and contribution paragraph.
+2. Paste Introduction, Benchmark Extension, System Design, Experimental Design,
+   Results Skeleton, Failure Analysis, Limitations, and Reproducibility from
+   `docs/neurips_draft.md`.
+3. Insert the current results tables from this packet with captions labeled as
+   first six-trial captures.
+4. Add TODO markers for final scenario count, repeated transport distribution,
+   mitigation before/after rows, references, checklist answers, and compile
+   proof.
+5. Insert figures only after captions include source CSV paths or run IDs.
+
+The detailed copy order and caveats live in
+`docs/neurips_overleaf_transfer_plan.md`. Issue #39 tracks the Overleaf content
+transfer; issue #40 / #78 track the later IEEE report back-port.
 
 ## Current Results Snapshot
 


### PR DESCRIPTION
## Summary

- Add docs/neurips_overleaf_transfer_plan.md as the copy queue from repo Markdown drafts into the NeurIPS 2026 Overleaf project.
- Link the transfer plan from docs/neurips_draft.md, docs/neurips_submission_packet.md, and docs/final_report_backport_scaffold.md.
- Record which sections can move into Overleaf now, which result tables must stay caveated as first-capture evidence, and which gates remain open for scenario count, mitigation rows, references, checklist answers, compile proof, and IEEE back-port.

## Issue refs

Refs #5, #39, #40, #47, #48, #78.

This does not close any issue. The writing/submission/report issues should stay open until Overleaf is populated, compiled, submitted/exported, and the IEEE back-port is checked against the frozen NeurIPS source.

## Test plan

- git diff --check
- git diff --cached --check
