### PR TITLE
Add final deck run of show (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Added `docs/final_presentation_run_of_show.md` and expanded
+  `docs/final_presentation_deck.md` with timing, speaker-note, source-proof,
+  and production-checklist scaffolding for #44.
 - Added `docs/mitigation_recovery_adjudication.md`, an implementation-ready
   spec for the follow-on mitigation ladder: bounded missing-evidence
   retry/replan recovery and explicit fault/risk adjudication. The spec keeps

--- a/docs/final_presentation_deck.md
+++ b/docs/final_presentation_deck.md
@@ -9,6 +9,27 @@ This is the first reviewable slide-by-slide deck draft for the HPML final
 presentation. It is intentionally Markdown so teammates and reviewers can
 comment on the story before we convert it into the class PowerPoint template.
 
+Production companion: `docs/final_presentation_run_of_show.md`.
+
+## May 2 Deck Readiness
+
+The deck is ready for a first PowerPoint build pass. The slide spine, current
+tables, source paths, and backup Q&A are in place. The remaining work is not
+"find the story"; it is final evidence freeze, visual conversion, and dry-run.
+
+| Component | Status | Open caveat |
+|---|---|---|
+| Core deck spine | ready | final timing pass still needed |
+| Scenario status slide | draft-ready | 30-scenario claim waits for PR #156 + generated acceptance |
+| Transport result slide | draft-ready | caption as first six-trial capture |
+| Orchestration result slide | draft-ready | keep Self-Ask as follow-on, not core baseline |
+| Failure taxonomy slide | ready | figure placement and caption polish needed |
+| Mitigation ladder slide | draft-ready | before/after outcome rows pending |
+| Backup Q&A | draft-ready | add Cell D / 70B only if promoted before freeze |
+
+Recommended target: 10-12 minutes plus Q&A. If time compresses, keep Slides
+1-9 and 12; shorten Slide 10 rather than cutting failure taxonomy.
+
 ## Deck Spine
 
 Core thesis:
@@ -24,6 +45,14 @@ Audience job:
 - see the strongest current quantitative evidence
 - see why failure taxonomy and mitigation matter
 - leave with a clear sense of what is complete and what remains caveated
+
+Run-of-show rule:
+
+- slides 1-3 establish the artifact
+- slides 4-6 establish why the experiment matrix is controlled rather than a
+  full grid
+- slides 7-9 deliver the evidence
+- slides 10-12 convert evidence into the benchmark-design conclusion
 
 ## Visual System Notes
 
@@ -53,6 +82,8 @@ Presenter notes:
 - One-sentence opener: "We extended AssetOpsBench into Smart Grid transformer
   maintenance and used it to measure how tool protocol and orchestration choices
   affect agent latency, quality, and evidence reliability."
+- Transition: "The important part is that we did not treat the benchmark
+  plumbing as invisible; we made it measurable."
 
 ### Slide 2 - Problem: Industrial Agents Need Evidence, Not Just Answers
 
@@ -73,6 +104,11 @@ Visual:
 
 Four-step maintenance workflow: telemetry -> diagnosis -> forecast -> work
 order.
+
+Speaker note:
+
+"This is why the domain works for HPML: it is small enough to benchmark, but it
+still forces multi-tool evidence gathering."
 
 ### Slide 3 - What We Built
 
@@ -95,6 +131,11 @@ Source:
 `mcp_servers/`, `data/scenarios/README.md`, `docs/data_pipeline.tex`,
 `data/scenarios/*.json`, `data/scenarios/negative_checks/*.json`, PR #156.
 
+Speaker note:
+
+"The shared transformer key is what turns these into one benchmark trajectory
+instead of four unrelated toy tools."
+
 ### Slide 4 - Scenario Corpus Status
 
 Claim:
@@ -112,6 +153,12 @@ Current status:
 Visual:
 
 Progress bar: 11 merged -> 21 after PR #156 -> 30 required.
+
+Speaker note:
+
+"This slide is intentionally honest. The proposal commitment is 30 validated
+scenarios, so the deck should distinguish what is merged from what is in
+review or acceptance."
 
 ### Slide 5 - Architecture: One Artifact Contract Across Cells
 
@@ -160,6 +207,13 @@ Speaker note:
 "B is the anchor cell: it is both the MCP transport baseline and the
 Agent-as-Tool orchestration baseline."
 
+Avoid:
+
+- implying that every orchestration strategy was crossed with every transport
+  condition
+- treating Cell D as the main optimized MCP result; it changes model-serving
+  variables too
+
 ### Slide 7 - Result 1: MCP Transport Has a Cost, but Optimization Changes the Shape
 
 Claim:
@@ -185,6 +239,12 @@ Source:
 
 `results/metrics/notebook02_latency_summary.csv`,
 `results/metrics/experiment_matrix_summary.csv`
+
+Speaker note:
+
+"This result is a systems story, not a leaderboard. The p50 improvement is real
+in the first capture, but the p95 tail and judge score tell us not to oversell
+transport optimization as quality improvement."
 
 ### Slide 8 - Result 2: Orchestration Quality Is Not Monotonic
 
@@ -213,6 +273,12 @@ Source:
 
 `results/metrics/notebook03_orchestration_comparison.csv`,
 `results/metrics/notebook03_self_ask_ablation.csv`
+
+Speaker note addendum:
+
+"The result I would emphasize is not 'PE wins.' Vanilla PE is weak. The result
+is that structured orchestration needs clarification and verification to become
+competitive."
 
 ### Slide 9 - Failure Taxonomy: Most Failures Are Evidence Failures
 
@@ -245,6 +311,11 @@ Speaker note:
 "The important thing here is that a run can complete and still be semantically
 unsafe. That is why we treat failure accounting as part of the benchmark."
 
+Transition:
+
+"Once we know the dominant failure mode, the mitigation space gets smaller and
+more disciplined."
+
 ### Slide 10 - Mitigation Ladder
 
 Claim:
@@ -266,6 +337,11 @@ Source:
 `docs/failure_visuals_mitigation.md`,
 `results/metrics/mitigation_run_inventory.csv`
 
+Speaker note:
+
+"If reruns do not land, this remains a mitigation design slide. If reruns land,
+we can promote it to a before/after result slide."
+
 ### Slide 11 - Reproducibility and Deliverables
 
 Claim:
@@ -286,6 +362,11 @@ Proof objects:
 Visual:
 
 Artifact map from run ID -> metrics CSV -> figure -> paper/deck claim.
+
+Speaker note:
+
+"This is the reproducibility promise: every claim on the results slides should
+point to a metric file, figure, or run ID."
 
 ### Slide 12 - Conclusion
 

--- a/docs/final_presentation_deck.md
+++ b/docs/final_presentation_deck.md
@@ -28,7 +28,8 @@ tables, source paths, and backup Q&A are in place. The remaining work is not
 | Backup Q&A | draft-ready | add Cell D / 70B only if promoted before freeze |
 
 Recommended target: 10-12 minutes plus Q&A. If time compresses, keep Slides
-1-9 and 12; shorten Slide 10 rather than cutting failure taxonomy.
+1-9 and 12; shorten Slide 10 (mitigation) rather than cutting Slide 9 (failure
+taxonomy).
 
 ## Deck Spine
 

--- a/docs/final_presentation_run_of_show.md
+++ b/docs/final_presentation_run_of_show.md
@@ -30,7 +30,7 @@ Target: 10-12 minutes plus Q&A.
 | Results | 7-9 | 3:30 | Show transport, orchestration, and failure-taxonomy evidence. |
 | Mitigation + reproducibility | 10-11 | 2:00 | Explain why failures become a mitigation ladder and how claims trace to artifacts. |
 | Close | 12 | 1:00 | Land the benchmark-design thesis. |
-| Buffer | backup | 1:30 | Use only if asked about grid size, quality caveats, or remaining work. |
+| Buffer | backup | 1:30 | In-envelope reserve; use only if asked about grid size, quality caveats, or remaining work. |
 
 If time is tight, cut Slide 10 down to one sentence and move mitigation details
 to backup. Do not cut Slide 9; the failure-taxonomy result is one of the
@@ -107,11 +107,11 @@ Say:
 | Slide | Proof object | Source |
 |---:|---|---|
 | 3 | Tool-domain table | `mcp_servers/`, `docs/data_pipeline.tex` |
-| 4 | Scenario-count status | `data/scenarios/`, PR #156, generator acceptance status |
+| 4 | Scenario-count status | `data/scenarios/`, `data/scenarios/validate_scenarios.py`, PR #156, generator acceptance status |
 | 5 | Artifact-contract diagram | `scripts/run_experiment.sh`, `benchmarks/cell_<X>/` |
 | 6 | Experiment matrix | `docs/experiment_matrix.md` |
 | 7 | Transport table | `results/metrics/notebook02_latency_summary.csv`, `results/metrics/experiment_matrix_summary.csv` |
-| 8 | Orchestration table | `results/metrics/notebook03_orchestration_comparison.csv`, `results/metrics/notebook03_pe_family_follow_on.csv` |
+| 8 | Orchestration table | `results/metrics/notebook03_orchestration_comparison.csv`, `results/metrics/notebook03_self_ask_ablation.csv`, `results/metrics/experiment_matrix_summary.csv` |
 | 9 | Failure taxonomy | `results/metrics/failure_taxonomy_counts.csv`, `results/figures/failure_taxonomy_counts.svg` |
 | 10 | Mitigation ladder | `docs/mitigation_recovery_adjudication.md`, `results/metrics/mitigation_run_inventory.csv` |
 | 11 | Reproducibility map | `docs/validation_log.md`, `results/metrics/`, `results/figures/` |
@@ -136,7 +136,7 @@ Say:
 | Gate | Owner | Deck effect |
 |---|---|---|
 | PR #156 and generated scenarios | Tanisha/Akshat, Alex shepherd | Slide 4 can claim 30 validated scenarios only after this settles. |
-| Mitigation rerun rows | Alex | Slide 10 can become results-bearing only if `mitigation_before_after.csv` has real rows. |
+| Mitigation rerun rows | Alex | Slide 10 can become results-bearing only if header-only `results/metrics/mitigation_before_after.csv` gets real rows. |
 | Final paper figures | Alex + team inputs | Slides 7-9 should mirror the paper figures and captions. |
 | Overleaf/source paper freeze | Alex | Deck conclusion should match the final paper claim wording. |
 

--- a/docs/final_presentation_run_of_show.md
+++ b/docs/final_presentation_run_of_show.md
@@ -1,0 +1,143 @@
+# Final Presentation Run of Show
+
+*Created: 2026-05-02*
+*Owner: Alex Xin*
+*Issue: #44*
+
+This is the production companion for `docs/final_presentation_deck.md`. The deck
+already has slide-by-slide content; this file turns it into a presentation plan
+with timing, proof objects, and final build gates.
+
+## Presentation Goal
+
+In one class presentation, make three ideas stick:
+
+1. SmartGridBench is a real AssetOpsBench extension for Smart Grid transformer
+   maintenance.
+2. The experiment separates transport effects from orchestration effects instead
+   of blending every variable into a full grid.
+3. Failure accounting matters because many "successful" agent trajectories are
+   still weak if they do not ground the final maintenance recommendation.
+
+## Recommended Time Budget
+
+Target: 10-12 minutes plus Q&A.
+
+| Segment | Slides | Time | Job |
+|---|---|---:|---|
+| Setup | 1-3 | 2:00 | Name the artifact and why Smart Grid transformer maintenance matters. |
+| Experimental design | 4-6 | 2:00 | Explain scenario status, artifact contract, and A/B/C vs B/Y/Z split. |
+| Results | 7-9 | 3:30 | Show transport, orchestration, and failure-taxonomy evidence. |
+| Mitigation + reproducibility | 10-11 | 2:00 | Explain why failures become a mitigation ladder and how claims trace to artifacts. |
+| Close | 12 | 1:00 | Land the benchmark-design thesis. |
+| Buffer | backup | 1:30 | Use only if asked about grid size, quality caveats, or remaining work. |
+
+If time is tight, cut Slide 10 down to one sentence and move mitigation details
+to backup. Do not cut Slide 9; the failure-taxonomy result is one of the
+strongest differentiators.
+
+## Main Story Beats
+
+### Opening
+
+Say:
+
+> We built SmartGridBench, a Smart Grid transformer-maintenance extension of
+> AssetOpsBench, then used it to measure how tool protocol, orchestration, and
+> failure accounting change what an industrial-agent benchmark can honestly
+> claim.
+
+Why:
+
+This frames the project as more than a dataset port and more than a demo.
+
+### Benchmark artifact
+
+Keep the artifact claim concrete:
+
+- four Smart Grid tool domains
+- shared transformer asset key
+- committed scenario artifacts
+- common benchmark output contract
+
+Avoid claiming final scenario counts until the 30-scenario floor is merged and
+validated.
+
+### Experiment split
+
+Say:
+
+> B is our anchor cell. In Experiment 1, it is the MCP baseline against direct
+> tools and optimized MCP. In Experiment 2, it is the Agent-as-Tool baseline
+> against Plan-Execute variants.
+
+Why:
+
+This helps the audience understand why the matrix is intentionally not a full
+cartesian product.
+
+### Results interpretation
+
+Use conservative wording:
+
+- Transport: optimized MCP improves the first-capture p50, but C has a cold-tail
+  p95 and does not improve judge quality.
+- Orchestration: vanilla PE is weak, while Verified PE + Self-Ask is currently
+  strongest on judged quality.
+- Failure taxonomy: evidence verification, not transport plumbing, is the
+  dominant failure class.
+
+Avoid:
+
+- "MCP is faster" as a global claim.
+- "Plan-Execute is better" as a global claim.
+- "30 scenarios are complete" until merged/validated.
+
+### Close
+
+Say:
+
+> The lesson is that benchmark infrastructure choices are part of the scientific
+> result. If protocol, orchestration, and failure accounting are not recorded,
+> the benchmark can look clean while hiding the reasons an agent actually
+> succeeded or failed.
+
+## Proof Objects by Slide
+
+| Slide | Proof object | Source |
+|---:|---|---|
+| 3 | Tool-domain table | `mcp_servers/`, `docs/data_pipeline.tex` |
+| 4 | Scenario-count status | `data/scenarios/`, PR #156, generator acceptance status |
+| 5 | Artifact-contract diagram | `scripts/run_experiment.sh`, `benchmarks/cell_<X>/` |
+| 6 | Experiment matrix | `docs/experiment_matrix.md` |
+| 7 | Transport table | `results/metrics/notebook02_latency_summary.csv`, `results/metrics/experiment_matrix_summary.csv` |
+| 8 | Orchestration table | `results/metrics/notebook03_orchestration_comparison.csv`, `results/metrics/notebook03_pe_family_follow_on.csv` |
+| 9 | Failure taxonomy | `results/metrics/failure_taxonomy_counts.csv`, `results/figures/failure_taxonomy_counts.svg` |
+| 10 | Mitigation ladder | `docs/mitigation_recovery_adjudication.md`, `results/metrics/mitigation_run_inventory.csv` |
+| 11 | Reproducibility map | `docs/validation_log.md`, `results/metrics/`, `results/figures/` |
+
+## PowerPoint Build Checklist
+
+- [ ] Convert `docs/final_presentation_deck.md` into the class deck template.
+- [ ] Use one claim per slide; move extra bullets into speaker notes.
+- [ ] Add source footer to every result slide.
+- [ ] Insert `results/figures/failure_taxonomy_counts.svg` and
+      `results/figures/failure_stage_cell_heatmap.svg`.
+- [ ] Decide whether `results/figures/notebook03_pe_family_follow_on.png` is a
+      main slide or backup slide.
+- [ ] Keep Cell D / 70B context evidence in backup unless the paper promotes it
+      before deck freeze.
+- [ ] Dry-run once against 10-12 minute timing.
+- [ ] Re-check every numeric slide against `results/metrics/` after any final
+      rerun PR merges.
+
+## Open Gates
+
+| Gate | Owner | Deck effect |
+|---|---|---|
+| PR #156 and generated scenarios | Tanisha/Akshat, Alex shepherd | Slide 4 can claim 30 validated scenarios only after this settles. |
+| Mitigation rerun rows | Alex | Slide 10 can become results-bearing only if `mitigation_before_after.csv` has real rows. |
+| Final paper figures | Alex + team inputs | Slides 7-9 should mirror the paper figures and captions. |
+| Overleaf/source paper freeze | Alex | Deck conclusion should match the final paper claim wording. |
+
+Until those gates clear, #44 should remain open.


### PR DESCRIPTION
## Summary

- Add docs/final_presentation_run_of_show.md as the production companion for the class presentation deck.
- Expand docs/final_presentation_deck.md with readiness status, timing, speaker notes, source-proof guidance, caveats, and transition framing.
- Keep the deck in the current Markdown scaffold lane so teammates can review story and claims before PowerPoint conversion.

## Issue refs

Refs #44.

This does not close #44. The issue should stay open until the PowerPoint deck is built/exported, final numbers are frozen, and the presentation has a dry-run pass.

## Test plan

- git diff --check
- git diff --cached --check
