### PR TITLE
Add first generated scenario batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Added `docs/final_presentation_run_of_show.md` and expanded
   `docs/final_presentation_deck.md` with timing, speaker-note, source-proof,
   and production-checklist scaffolding for #44.
+- Added the first reviewable #2 generated-scenario batch under
+  `data/scenarios/generated/first_review_20260502/`: five WatsonX-generated
+  candidate scenarios, one per PS B family, with prompts, raw responses,
+  provenance, nearest-handcrafted comparators, and a batch-local validation
+  summary for the #53 review pass.
 - Added `docs/mitigation_recovery_adjudication.md`, an implementation-ready
   spec for the follow-on mitigation ladder: bounded missing-evidence
   retry/replan recovery and explicit fault/risk adjudication. The spec keeps

--- a/data/scenarios/generated/first_review_20260502/SGT-GEN-001.json
+++ b/data/scenarios/generated/first_review_20260502/SGT-GEN-001.json
@@ -1,0 +1,68 @@
+{
+  "id": "SGT-GEN-001",
+  "type": "FMSR",
+  "text": "Transformer T-005 shows stable gas levels during routine monitoring. Confirm whether any fault is indicated and recommend the next monitoring step.",
+  "category": "Fault Diagnosis",
+  "characteristic_form": "A normal/no-fault confirmation with a routine-monitoring recommendation.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga"
+  ],
+  "domain_tags": [
+    "FMSR"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "decisive_intermediate_values": {
+      "iec_code": "N",
+      "R1": "0.056",
+      "R2": "0.020",
+      "R3": "1.25",
+      "final_sample_gases_ppm": {
+        "H2": 90,
+        "CH4": 5,
+        "C2H2": 1,
+        "C2H4": 50,
+        "C2H6": 40
+      },
+      "condition": "normal/background gas profile"
+    },
+    "final_value": {
+      "primary_fault": "Normal/no active fault",
+      "recommended_action": "Continue routine monitoring; no immediate inspection beyond the scheduled interval"
+    },
+    "acceptance_criteria": [
+      "agent identifies no active fault or an N/normal DGA profile",
+      "agent recommends continued routine monitoring or equivalent non-urgent follow-up",
+      "agent uses the background gas profile to justify the non-fault diagnosis"
+    ],
+    "must_include": [
+      "normal/no active fault",
+      "recommended monitoring action",
+      "background gas rationale"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-03T03:25:40.482330+00:00",
+    "batch_id": "first_review_20260502",
+    "manual_cleanup": true,
+    "cleanup_notes": "Corrected generated ground truth from contradictory T3 diagnosis to N/normal based on the committed stable_normal prompt template and final-sample R1=0.056."
+  },
+  "family": "FMSR_DGA_DIAGNOSIS",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-003",
+    "scenario_file": "data/scenarios/fmsr_01_dga_fault_mode_diagnosis.json",
+    "similarity_basis": "shares type='FMSR' and 2 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/SGT-GEN-002.json
+++ b/data/scenarios/generated/first_review_20260502/SGT-GEN-002.json
@@ -1,0 +1,62 @@
+{
+  "id": "SGT-GEN-002",
+  "type": "TSFM",
+  "text": "Transformer T-005 shows signs of aging, with recent DGA indicating potential issues. Estimate its remaining useful life and whether it can safely operate through the next 60 days.",
+  "category": "Remaining Useful Life",
+  "characteristic_form": "The answer will provide a forecasted RUL in days, along with a risk level rationale and recommended action horizon.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "tsfm.forecast_rul",
+    "tsfm.detect_anomalies"
+  ],
+  "domain_tags": [
+    "TSFM"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "tsfm.forecast_rul",
+      "tsfm.detect_anomalies"
+    ],
+    "decisive_intermediate_values": {
+      "health_index": "0.6",
+      "rul_range_days": "180-729"
+    },
+    "final_value": {
+      "rul_estimate_days": "420",
+      "sixty_day_status": "can remain in service through the next 60 days with monitoring",
+      "risk_level_rationale": "Medium risk due to degradation indicators",
+      "recommended_action_horizon": "Schedule replacement within 1-2 years"
+    },
+    "acceptance_criteria": [
+      "agent provides a RUL estimate in days",
+      "agent states whether the transformer can safely operate through the next 60 days",
+      "agent includes a risk level rationale",
+      "agent recommends an action horizon"
+    ],
+    "must_include": [
+      "RUL estimate",
+      "60-day operability decision",
+      "risk level rationale",
+      "recommended action horizon"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-03T03:25:50.330070+00:00",
+    "batch_id": "first_review_20260502",
+    "manual_cleanup": true,
+    "cleanup_notes": "Aligned the prompt with the 420-day ground truth by asking for long-term RUL plus an explicit 60-day operability decision."
+  },
+  "family": "TSFM_RUL_FORECAST",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-005",
+    "scenario_file": "data/scenarios/tsfm_01_rul_forecast_maintenance_window.json",
+    "similarity_basis": "shares type='TSFM' and 1 expected_tools entry",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/SGT-GEN-003.json
+++ b/data/scenarios/generated/first_review_20260502/SGT-GEN-003.json
@@ -1,0 +1,58 @@
+{
+  "id": "SGT-GEN-003",
+  "type": "WO",
+  "text": "Transformer T-005 has a high-temperature reading. Create a work order to address the issue.",
+  "category": "Work Order Creation",
+  "characteristic_form": "A work order with minimum required fields.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "wo.create_work_order",
+    "wo.estimate_downtime"
+  ],
+  "domain_tags": [
+    "WO"
+  ],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "wo.create_work_order",
+      "wo.estimate_downtime"
+    ],
+    "decisive_intermediate_values": {
+      "reported_issue": "high-temperature reading",
+      "requested_action": "create corrective maintenance work order"
+    },
+    "final_value": {
+      "work_order_type": "corrective",
+      "priority": "high"
+    },
+    "acceptance_criteria": [
+      "agent creates a work order",
+      "agent estimates downtime",
+      "agent avoids asserting a specific DGA fault code without diagnostic evidence"
+    ],
+    "must_include": [
+      "work_order_type",
+      "priority",
+      "minimum_fields_from_playbook (see transformer_standards.json operational_context.work_order_minimum_fields.required_fields)"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-03T03:25:58.255093+00:00",
+    "batch_id": "first_review_20260502",
+    "manual_cleanup": true,
+    "cleanup_notes": "Removed unsupported T3/C4 diagnostic ground truth so the WO-only scenario grades work-order creation rather than hidden FMSR diagnosis."
+  },
+  "family": "WO_CREATION",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-007",
+    "scenario_file": "data/scenarios/wo_01_create_inspection_order.json",
+    "similarity_basis": "shares type='WO' and 2 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/SGT-GEN-004.json
+++ b/data/scenarios/generated/first_review_20260502/SGT-GEN-004.json
@@ -1,0 +1,55 @@
+{
+  "id": "SGT-GEN-004",
+  "type": "IoT",
+  "text": "Transformer T-005 is operating at 98% capacity with no spare available. Check if the oil temperature is within a safe range.",
+  "category": "Sensor Analysis",
+  "characteristic_form": "The answer will include a sensor value with unit and a threshold comparison.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "iot.get_sensor_readings"
+  ],
+  "domain_tags": [
+    "IoT"
+  ],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "iot.get_sensor_readings"
+    ],
+    "decisive_intermediate_values": {
+      "oil_temp_c": "70"
+    },
+    "final_value": {
+      "sensor_value_with_unit": "70\u00b0C",
+      "threshold_comparison": "within safe range",
+      "status_summary": "normal operation"
+    },
+    "acceptance_criteria": [
+      "agent checks oil temperature",
+      "agent compares temperature to a safe threshold",
+      "agent reports the status of the transformer"
+    ],
+    "must_include": [
+      "sensor_value_with_unit",
+      "threshold_comparison",
+      "status_summary"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-03T03:26:11.457400+00:00",
+    "batch_id": "first_review_20260502",
+    "manual_cleanup": false
+  },
+  "family": "IOT_SENSOR_ANALYSIS",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-001",
+    "scenario_file": "data/scenarios/iot_01_list_transformer_sensors.json",
+    "similarity_basis": "shares type='IoT' and 1 expected_tools entry",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/SGT-GEN-005.json
+++ b/data/scenarios/generated/first_review_20260502/SGT-GEN-005.json
@@ -1,0 +1,77 @@
+{
+  "id": "SGT-GEN-005",
+  "type": "Multi",
+  "text": "Transformer T-005, critical to the grid, shows elevated hydrogen and rising methane levels in recent DGA samples. Determine the fault mode and recommend maintenance.",
+  "category": "End-to-End Incident Response",
+  "characteristic_form": "A diagnosis with a recommended maintenance action based on integrated analysis of DGA trends and asset criticality.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "iot.get_sensor_readings",
+    "fmsr.analyze_dga",
+    "tsfm.forecast_rul",
+    "wo.create_work_order"
+  ],
+  "domain_tags": [
+    "IoT",
+    "FMSR",
+    "TSFM",
+    "WO"
+  ],
+  "difficulty": "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "iot.get_sensor_readings",
+      "fmsr.analyze_dga",
+      "tsfm.forecast_rul",
+      "wo.create_work_order"
+    ],
+    "decisive_intermediate_values": {
+      "fault_code": "D2",
+      "R1_ratio": "0.40",
+      "R2_ratio": "1.20",
+      "R3_ratio": "3.33",
+      "representative_gases_ppm": {
+        "H2": 500,
+        "CH4": 200,
+        "C2H2": 120,
+        "C2H4": 100,
+        "C2H6": 30
+      }
+    },
+    "final_value": {
+      "fault_label": "Arcing fault",
+      "rul_days": "14",
+      "work_order_type": "corrective"
+    },
+    "acceptance_criteria": [
+      "agent identifies the fault mode as arcing",
+      "agent forecasts the remaining useful life in days",
+      "agent creates a work order with the correct type and priority",
+      "agent includes safety isolation notes in the work order"
+    ],
+    "must_include": [
+      "iot_evidence_summary",
+      "fault_hypothesis_with_iec_code",
+      "rul_or_risk_forecast",
+      "work_order_recommendation"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-03T03:26:23.387665+00:00",
+    "batch_id": "first_review_20260502",
+    "manual_cleanup": true,
+    "cleanup_notes": "Corrected generated Rogers-ratio ground truth to the repo-standard D2 representative profile: R1=0.40, R2=1.20, R3=3.33."
+  },
+  "family": "MULTI_DOMAIN_INCIDENT",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-009",
+    "scenario_file": "data/scenarios/multi_01_end_to_end_fault_response.json",
+    "similarity_basis": "shares type='Multi' and 4 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/batch_manifest.json
+++ b/data/scenarios/generated/first_review_20260502/batch_manifest.json
@@ -1,0 +1,43 @@
+{
+  "batch_id": "first_review_20260502",
+  "created_at": "2026-05-03T03:26:23.388590+00:00",
+  "last_updated_at": "2026-05-03T03:26:23.388590+00:00",
+  "prompt_version": "v0.1",
+  "knowledge_plugin_version": "0eacec24441e",
+  "generator_script": "scripts/generate_scenarios.py",
+  "support_data": "docs/knowledge/scenario_generation_support.json",
+  "handcrafted_corpus_size": 11,
+  "scenarios_emitted": [
+    "SGT-GEN-001",
+    "SGT-GEN-002",
+    "SGT-GEN-003",
+    "SGT-GEN-004",
+    "SGT-GEN-005"
+  ],
+  "invocations": [
+    {
+      "started_at": "2026-05-03T03:26:23.388590+00:00",
+      "model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "temperature": 0.7,
+      "seed": 42,
+      "families_requested": [
+        "FMSR_DGA_DIAGNOSIS",
+        "TSFM_RUL_FORECAST",
+        "WO_CREATION",
+        "IOT_SENSOR_ANALYSIS",
+        "MULTI_DOMAIN_INCIDENT"
+      ],
+      "n_per_family": 1,
+      "scenarios_emitted": [
+        "SGT-GEN-001",
+        "SGT-GEN-002",
+        "SGT-GEN-003",
+        "SGT-GEN-004",
+        "SGT-GEN-005"
+      ],
+      "starting_scenario_id": "SGT-GEN-001",
+      "dry_run": false,
+      "append": false
+    }
+  ]
+}

--- a/data/scenarios/generated/first_review_20260502/prompts/FMSR_DGA_DIAGNOSIS_SGT-GEN-001.txt
+++ b/data/scenarios/generated/first_review_20260502/prompts/FMSR_DGA_DIAGNOSIS_SGT-GEN-001.txt
@@ -1,0 +1,155 @@
+You are generating a single Smart Grid maintenance scenario for the SmartGridBench benchmark suite. The scenario will be evaluated against an LLM agent with access to four MCP servers (IoT, FMSR, TSFM, WO).
+
+FAMILY: FMSR_DGA_DIAGNOSIS
+FAMILY SPEC:
+{
+  "target_count": 4,
+  "primary_domain": "FMSR",
+  "domain_tags": [
+    "FMSR"
+  ],
+  "difficulty_range": [
+    "easy",
+    "medium",
+    "hard"
+  ],
+  "task_types": [
+    "fault_diagnosis",
+    "root_cause_analysis"
+  ],
+  "required_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga"
+  ],
+  "optional_tools": [
+    "fmsr.search_failure_modes",
+    "fmsr.get_sensor_correlation"
+  ],
+  "variation_axes": {
+    "fault_code": "vary across PD, D1, D2, T1, T2, T3 \u2014 do not generate two scenarios with the same iec_code",
+    "transformer_id": "vary across T-001 to T-020",
+    "task_framing": "rotate among: identify primary fault, compare two candidate fault modes, explain dominant gas, recommend next inspection step"
+  },
+  "ground_truth_must_include": [
+    "iec_code",
+    "dominant_gas_rationale",
+    "recommended_action"
+  ],
+  "anti_patterns": [
+    "Do not frame the task as 'run analyze_dga with these exact numbers' \u2014 the agent must retrieve gas values from get_dga_record first.",
+    "Do not generate a scenario where the answer is trivially N (normal) with no diagnostic interest."
+  ]
+}
+
+OPERATIONAL CONTEXT (`critical_peak_no_spare`):
+{
+  "asset_criticality_tier": "critical",
+  "spare_availability": "no_spare",
+  "current_loading_pct": 98,
+  "urgency_floor": "high",
+  "narrative_context": "Feeder transformer carrying peak load with no spare on site. Any forced outage requires load shedding.",
+  "suitable_fault_codes": [
+    "D2",
+    "T3"
+  ],
+  "scenario_families": [
+    "MULTI_DOMAIN_INCIDENT"
+  ]
+}
+
+DGA TREND TEMPLATE (`stable_normal`):
+{
+  "iec_code_trajectory": [
+    "N",
+    "N",
+    "N"
+  ],
+  "description": "All key gases remain at background levels across consecutive samples. No discernible trend. All three steps verified as N via fmsr.analyze_dga \u2014 key constraint: R1=CH4/H2 must remain below ~0.1 at every step.",
+  "sample_progression": [
+    {
+      "step": "T-0 baseline",
+      "H2": 60,
+      "CH4": 4,
+      "C2H2": 1,
+      "C2H4": 48,
+      "C2H6": 38,
+      "trend_note": "N \u2014 R1=0.067, R2=0.021, R3=1.26",
+      "step_verified": true
+    },
+    {
+      "step": "T-30 days",
+      "H2": 75,
+      "CH4": 5,
+      "C2H2": 1,
+      "C2H4": 49,
+      "C2H6": 39,
+      "trend_note": "N \u2014 R1=0.067, R2=0.020, R3=1.26, no change",
+      "step_verified": true
+    },
+    {
+      "step": "T-60 days",
+      "H2": 90,
+      "CH4": 5,
+      "C2H2": 1,
+      "C2H4": 50,
+      "C2H6": 40,
+      "trend_note": "N \u2014 stable at verified N profile",
+      "endpoint_verified": true,
+      "source": "transformer_standards.json N profile"
+    }
+  ],
+  "scenario_text_cue": "Routine monitoring with no anomalies detected.",
+  "urgency": "low",
+  "suitable_families": [
+    "FMSR_DGA_DIAGNOSIS",
+    "IOT_SENSOR_ANALYSIS"
+  ]
+}
+
+
+NO-HINT RULES — banned in the user-facing `text` field:
+- Tool names (e.g. `fmsr.analyze_dga`, `wo.create_work_order`)
+- Method names or analytic technique names (e.g. "Duval triangle", "Rogers ratio")
+- IEC fault codes (PD, D1, D2, T1, T2, T3) in the prompt itself — they may appear in `decisive_intermediate_values` only
+- Specific gas concentrations or ratio thresholds
+- Pre-framed decisions ("you should create a work order")
+- Step-by-step instructions
+- Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
+
+PREFERRED:
+- Describe an operational event or condition naturally
+- Ask for a decision (diagnosis / RUL / work order / sensor anomaly), not a tool call
+- Ground in one transformer ID and one or two context details (criticality, alarm, recent reading)
+- One task per scenario
+- Under 80 words
+
+
+OUTPUT FORMAT (return one JSON object, no markdown fence):
+{
+  "id": "SGT-GEN-XXX",                                  // caller fills XXX
+  "type": "FMSR" | "TSFM" | "WO" | "IoT" | "Multi",
+  "text": "<the user-facing prompt, follows NO-HINT RULES>",
+  "category": "<one of: Fault Diagnosis | Root Cause Analysis | Remaining Useful Life | Anomaly Detection | Trend Analysis | Maintenance Decision | Work Order Creation | Sensor Analysis | End-to-End Incident Response | Cross-Domain Planning>",
+  "characteristic_form": "<one-sentence description of the answer's structure>",
+  "asset_id": "T-NNN",                                  // T-001 .. T-020
+  "expected_tools": ["domain.tool", ...],               // every tool the ideal agent calls
+  "domain_tags": ["FMSR", ...],                         // matches the type for single-domain; >=2 for Multi
+  "difficulty": "easy" | "medium" | "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": ["domain.tool", ...],        // ordered, same entries as expected_tools
+    "decisive_intermediate_values": { "<key>": "<value>", ... },
+    "final_value": { "<key>": "<value>", ... },         // concrete output (e.g. fault_label, rul_days)
+    "acceptance_criteria": ["agent <does X>", ...],     // 2-5 checks, each starting with "agent "
+    "must_include": ["<element>", ...]                  // coarse high-level answer elements
+  }
+}
+
+DO NOT include `provenance` or `nearest_handcrafted_comparator` blocks in
+your output — the caller fills those after generation. DO NOT emit
+`source_type`, `generator_prompt_version`, `generation_model`, or any
+other generator-metadata field at the top level. The scenario JSON should
+contain ONLY the canonical scenario contract (id, type, text, category,
+characteristic_form, asset_id, expected_tools, domain_tags, difficulty,
+ground_truth).
+
+Return ONLY the JSON object. No commentary, no markdown fences, no explanation.

--- a/data/scenarios/generated/first_review_20260502/prompts/IOT_SENSOR_ANALYSIS_SGT-GEN-004.txt
+++ b/data/scenarios/generated/first_review_20260502/prompts/IOT_SENSOR_ANALYSIS_SGT-GEN-004.txt
@@ -1,0 +1,122 @@
+You are generating a single Smart Grid maintenance scenario for the SmartGridBench benchmark suite. The scenario will be evaluated against an LLM agent with access to four MCP servers (IoT, FMSR, TSFM, WO).
+
+FAMILY: IOT_SENSOR_ANALYSIS
+FAMILY SPEC:
+{
+  "target_count": 2,
+  "primary_domain": "IoT",
+  "domain_tags": [
+    "IoT"
+  ],
+  "difficulty_range": [
+    "easy",
+    "medium"
+  ],
+  "task_types": [
+    "sensor_threshold_check",
+    "asset_metadata_lookup",
+    "sensor_list_enumeration"
+  ],
+  "required_tools": [
+    "iot.get_sensor_readings"
+  ],
+  "optional_tools": [
+    "iot.get_asset_metadata",
+    "iot.list_sensors",
+    "iot.list_assets"
+  ],
+  "variation_axes": {
+    "sensor_parameter": "vary between thermal (oil_temp_c, winding_temp_top_c) and electrical (load_current_a, power_factor, voltage_hv_kv, voltage_lv_kv)",
+    "transformer_id": "vary across T-001 to T-020"
+  },
+  "ground_truth_must_include": [
+    "sensor_value_with_unit",
+    "threshold_comparison",
+    "status_summary"
+  ],
+  "anti_patterns": [
+    "IoT sensors do not include dissolved gas readings. Do not ask for gas values via IoT tools.",
+    "Do not ask for DGA-based fault classification from IoT tools alone."
+  ]
+}
+
+OPERATIONAL CONTEXT (`critical_peak_no_spare`):
+{
+  "asset_criticality_tier": "critical",
+  "spare_availability": "no_spare",
+  "current_loading_pct": 98,
+  "urgency_floor": "high",
+  "narrative_context": "Feeder transformer carrying peak load with no spare on site. Any forced outage requires load shedding.",
+  "suitable_fault_codes": [
+    "D2",
+    "T3"
+  ],
+  "scenario_families": [
+    "MULTI_DOMAIN_INCIDENT"
+  ]
+}
+
+EVENT/ALARM TEMPLATE (`routine_monitoring_elevated_h2`):
+{
+  "alarm_source": "scheduled_dga_sampling",
+  "iot_signal": null,
+  "associated_fault_codes": [
+    "PD",
+    "D1",
+    "N"
+  ],
+  "urgency": "medium",
+  "scenario_text_cue": "Routine DGA sampling for transformer {transformer_id} shows elevated hydrogen compared to the prior sample. Identify the fault mode and recommend a monitoring interval.",
+  "ground_truth_cue": "Agent must call get_dga_record and analyze_dga; ground truth includes fault code and a monitoring recommendation aligned with urgency tier.",
+  "suitable_families": [
+    "FMSR_DGA_DIAGNOSIS"
+  ]
+}
+
+
+NO-HINT RULES — banned in the user-facing `text` field:
+- Tool names (e.g. `fmsr.analyze_dga`, `wo.create_work_order`)
+- Method names or analytic technique names (e.g. "Duval triangle", "Rogers ratio")
+- IEC fault codes (PD, D1, D2, T1, T2, T3) in the prompt itself — they may appear in `decisive_intermediate_values` only
+- Specific gas concentrations or ratio thresholds
+- Pre-framed decisions ("you should create a work order")
+- Step-by-step instructions
+- Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
+
+PREFERRED:
+- Describe an operational event or condition naturally
+- Ask for a decision (diagnosis / RUL / work order / sensor anomaly), not a tool call
+- Ground in one transformer ID and one or two context details (criticality, alarm, recent reading)
+- One task per scenario
+- Under 80 words
+
+
+OUTPUT FORMAT (return one JSON object, no markdown fence):
+{
+  "id": "SGT-GEN-XXX",                                  // caller fills XXX
+  "type": "FMSR" | "TSFM" | "WO" | "IoT" | "Multi",
+  "text": "<the user-facing prompt, follows NO-HINT RULES>",
+  "category": "<one of: Fault Diagnosis | Root Cause Analysis | Remaining Useful Life | Anomaly Detection | Trend Analysis | Maintenance Decision | Work Order Creation | Sensor Analysis | End-to-End Incident Response | Cross-Domain Planning>",
+  "characteristic_form": "<one-sentence description of the answer's structure>",
+  "asset_id": "T-NNN",                                  // T-001 .. T-020
+  "expected_tools": ["domain.tool", ...],               // every tool the ideal agent calls
+  "domain_tags": ["FMSR", ...],                         // matches the type for single-domain; >=2 for Multi
+  "difficulty": "easy" | "medium" | "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": ["domain.tool", ...],        // ordered, same entries as expected_tools
+    "decisive_intermediate_values": { "<key>": "<value>", ... },
+    "final_value": { "<key>": "<value>", ... },         // concrete output (e.g. fault_label, rul_days)
+    "acceptance_criteria": ["agent <does X>", ...],     // 2-5 checks, each starting with "agent "
+    "must_include": ["<element>", ...]                  // coarse high-level answer elements
+  }
+}
+
+DO NOT include `provenance` or `nearest_handcrafted_comparator` blocks in
+your output — the caller fills those after generation. DO NOT emit
+`source_type`, `generator_prompt_version`, `generation_model`, or any
+other generator-metadata field at the top level. The scenario JSON should
+contain ONLY the canonical scenario contract (id, type, text, category,
+characteristic_form, asset_id, expected_tools, domain_tags, difficulty,
+ground_truth).
+
+Return ONLY the JSON object. No commentary, no markdown fences, no explanation.

--- a/data/scenarios/generated/first_review_20260502/prompts/MULTI_DOMAIN_INCIDENT_SGT-GEN-005.txt
+++ b/data/scenarios/generated/first_review_20260502/prompts/MULTI_DOMAIN_INCIDENT_SGT-GEN-005.txt
@@ -1,0 +1,202 @@
+You are generating a single Smart Grid maintenance scenario for the SmartGridBench benchmark suite. The scenario will be evaluated against an LLM agent with access to four MCP servers (IoT, FMSR, TSFM, WO).
+
+FAMILY: MULTI_DOMAIN_INCIDENT
+FAMILY SPEC:
+{
+  "target_count": 4,
+  "primary_domain": "Multi",
+  "domain_tags": [
+    "IoT",
+    "FMSR",
+    "TSFM",
+    "WO"
+  ],
+  "difficulty_range": [
+    "hard"
+  ],
+  "task_types": [
+    "end_to_end_incident_response",
+    "integrated_diagnostic",
+    "multi_step_maintenance_decision"
+  ],
+  "required_tools": [
+    "iot.get_sensor_readings",
+    "fmsr.analyze_dga",
+    "tsfm.forecast_rul",
+    "wo.create_work_order"
+  ],
+  "optional_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.search_failure_modes",
+    "tsfm.detect_anomalies",
+    "wo.estimate_downtime",
+    "iot.get_asset_metadata"
+  ],
+  "variation_axes": {
+    "fault_code": "vary across D2, T3, D1, T2 \u2014 avoid N or PD which produce low-urgency multi-domain paths",
+    "transformer_id": "vary across T-001 to T-020",
+    "operating_context": "use one of the five named profiles from operational_context_profiles in this file; vary one field per instance"
+  },
+  "ground_truth_must_include": [
+    "iot_evidence_summary",
+    "fault_hypothesis_with_iec_code",
+    "rul_or_risk_forecast",
+    "work_order_recommendation"
+  ],
+  "anti_patterns": [
+    "Do not collapse all four domains into a single lookup; the task narrative must require reasoning across at least three distinct domains.",
+    "Do not use the same operational_context_profile for more than two MULTI_DOMAIN_INCIDENT scenarios in a batch."
+  ]
+}
+
+OPERATIONAL CONTEXT (`critical_peak_no_spare`):
+{
+  "asset_criticality_tier": "critical",
+  "spare_availability": "no_spare",
+  "current_loading_pct": 98,
+  "urgency_floor": "high",
+  "narrative_context": "Feeder transformer carrying peak load with no spare on site. Any forced outage requires load shedding.",
+  "suitable_fault_codes": [
+    "D2",
+    "T3"
+  ],
+  "scenario_families": [
+    "MULTI_DOMAIN_INCIDENT"
+  ]
+}
+
+EVENT/ALARM TEMPLATE (`routine_monitoring_elevated_h2`):
+{
+  "alarm_source": "scheduled_dga_sampling",
+  "iot_signal": null,
+  "associated_fault_codes": [
+    "PD",
+    "D1",
+    "N"
+  ],
+  "urgency": "medium",
+  "scenario_text_cue": "Routine DGA sampling for transformer {transformer_id} shows elevated hydrogen compared to the prior sample. Identify the fault mode and recommend a monitoring interval.",
+  "ground_truth_cue": "Agent must call get_dga_record and analyze_dga; ground truth includes fault code and a monitoring recommendation aligned with urgency tier.",
+  "suitable_families": [
+    "FMSR_DGA_DIAGNOSIS"
+  ]
+}
+
+DGA TREND TEMPLATE (`thermal_t1_to_t3_progression`):
+{
+  "iec_code_trajectory": [
+    "T1",
+    "T2",
+    "T3"
+  ],
+  "description": "Methane and ethylene rise steadily across three samples with C2H2 near zero throughout. T1\u2192T2 is driven by R3=C2H4/C2H6 rising from 0.67 to 1.875 (crossing 1.0 into the T2 window); R1=CH4/H2 stays at 2.0. T2\u2192T3 is driven by R3 rising further from 1.875 to 6.25 (crossing 4.0) and R1 rising from 2.0 to 6.0 as CH4 climbs 200\u2192600. All three steps use IEC-aligned profiles from transformer_standards.json.",
+  "sample_progression": [
+    {
+      "step": "T-0 baseline",
+      "H2": 100,
+      "CH4": 200,
+      "C2H2": 2,
+      "C2H4": 80,
+      "C2H6": 120,
+      "trend_note": "T1 \u2014 verified T1 profile; R1=2.00, R2=0.025, R3=0.67 (R3 below 1.0 keeps T1)",
+      "endpoint_verified": true,
+      "source": "transformer_standards.json T1 profile"
+    },
+    {
+      "step": "T-21 days",
+      "H2": 100,
+      "CH4": 200,
+      "C2H2": 2,
+      "C2H4": 150,
+      "C2H6": 80,
+      "trend_note": "T2 \u2014 verified T2 profile; R1=2.00 (unchanged), R2=0.013, R3=1.875 (\u2191 from 0.67 drives T1\u2192T2)",
+      "endpoint_verified": true,
+      "source": "transformer_standards.json T2 profile"
+    },
+    {
+      "step": "T-42 days",
+      "H2": 100,
+      "CH4": 600,
+      "C2H2": 3,
+      "C2H4": 500,
+      "C2H6": 80,
+      "trend_note": "T3 \u2014 verified T3 profile; R1=6.00, R2=0.006, R3=6.25 (\u2191 from 1.875 drives T2\u2192T3)",
+      "endpoint_verified": true,
+      "source": "transformer_standards.json T3 profile"
+    }
+  ],
+  "scenario_text_cue": "Successive DGA samples over the past six weeks show a consistent rise in methane and ethylene.",
+  "urgency": "emergency",
+  "suitable_families": [
+    "FMSR_DGA_DIAGNOSIS",
+    "MULTI_DOMAIN_INCIDENT",
+    "TSFM_RUL_FORECAST"
+  ]
+}
+
+WORK-ORDER PLAYBOOK ENTRY (`D2_C4`):
+{
+  "fault_code": "D2",
+  "condition_tier": "C4",
+  "urgency": "emergency",
+  "wo_type": "corrective",
+  "priority": "emergency",
+  "time_to_action": "hours",
+  "minimum_fields": [
+    "asset_id",
+    "fault_type",
+    "trigger_evidence",
+    "immediate_action_required",
+    "safety_isolation_note",
+    "spare_status"
+  ],
+  "notes": "Arcing fault. Do not re-energize without gas recheck. Spare status determines repair vs replacement path."
+}
+
+
+NO-HINT RULES — banned in the user-facing `text` field:
+- Tool names (e.g. `fmsr.analyze_dga`, `wo.create_work_order`)
+- Method names or analytic technique names (e.g. "Duval triangle", "Rogers ratio")
+- IEC fault codes (PD, D1, D2, T1, T2, T3) in the prompt itself — they may appear in `decisive_intermediate_values` only
+- Specific gas concentrations or ratio thresholds
+- Pre-framed decisions ("you should create a work order")
+- Step-by-step instructions
+- Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
+
+PREFERRED:
+- Describe an operational event or condition naturally
+- Ask for a decision (diagnosis / RUL / work order / sensor anomaly), not a tool call
+- Ground in one transformer ID and one or two context details (criticality, alarm, recent reading)
+- One task per scenario
+- Under 80 words
+
+
+OUTPUT FORMAT (return one JSON object, no markdown fence):
+{
+  "id": "SGT-GEN-XXX",                                  // caller fills XXX
+  "type": "FMSR" | "TSFM" | "WO" | "IoT" | "Multi",
+  "text": "<the user-facing prompt, follows NO-HINT RULES>",
+  "category": "<one of: Fault Diagnosis | Root Cause Analysis | Remaining Useful Life | Anomaly Detection | Trend Analysis | Maintenance Decision | Work Order Creation | Sensor Analysis | End-to-End Incident Response | Cross-Domain Planning>",
+  "characteristic_form": "<one-sentence description of the answer's structure>",
+  "asset_id": "T-NNN",                                  // T-001 .. T-020
+  "expected_tools": ["domain.tool", ...],               // every tool the ideal agent calls
+  "domain_tags": ["FMSR", ...],                         // matches the type for single-domain; >=2 for Multi
+  "difficulty": "easy" | "medium" | "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": ["domain.tool", ...],        // ordered, same entries as expected_tools
+    "decisive_intermediate_values": { "<key>": "<value>", ... },
+    "final_value": { "<key>": "<value>", ... },         // concrete output (e.g. fault_label, rul_days)
+    "acceptance_criteria": ["agent <does X>", ...],     // 2-5 checks, each starting with "agent "
+    "must_include": ["<element>", ...]                  // coarse high-level answer elements
+  }
+}
+
+DO NOT include `provenance` or `nearest_handcrafted_comparator` blocks in
+your output — the caller fills those after generation. DO NOT emit
+`source_type`, `generator_prompt_version`, `generation_model`, or any
+other generator-metadata field at the top level. The scenario JSON should
+contain ONLY the canonical scenario contract (id, type, text, category,
+characteristic_form, asset_id, expected_tools, domain_tags, difficulty,
+ground_truth).
+
+Return ONLY the JSON object. No commentary, no markdown fences, no explanation.

--- a/data/scenarios/generated/first_review_20260502/prompts/TSFM_RUL_FORECAST_SGT-GEN-002.txt
+++ b/data/scenarios/generated/first_review_20260502/prompts/TSFM_RUL_FORECAST_SGT-GEN-002.txt
@@ -1,0 +1,134 @@
+You are generating a single Smart Grid maintenance scenario for the SmartGridBench benchmark suite. The scenario will be evaluated against an LLM agent with access to four MCP servers (IoT, FMSR, TSFM, WO).
+
+FAMILY: TSFM_RUL_FORECAST
+FAMILY SPEC:
+{
+  "target_count": 4,
+  "primary_domain": "TSFM",
+  "domain_tags": [
+    "TSFM"
+  ],
+  "difficulty_range": [
+    "easy",
+    "medium",
+    "hard"
+  ],
+  "task_types": [
+    "rul_forecast",
+    "anomaly_detection",
+    "trend_analysis"
+  ],
+  "required_tools": [
+    "tsfm.forecast_rul"
+  ],
+  "optional_tools": [
+    "tsfm.detect_anomalies",
+    "tsfm.trend_analysis",
+    "tsfm.get_rul"
+  ],
+  "variation_axes": {
+    "horizon": "vary among 30-day, 60-day, 90-day forecast horizons",
+    "transformer_id": "vary across T-001 to T-020",
+    "task_framing": "rotate among: forecast RUL for a specific horizon, detect anomaly in sensor trend, explain a trend reversal, compare RUL against maintenance window"
+  },
+  "ground_truth_must_include": [
+    "rul_estimate_days",
+    "risk_level_rationale",
+    "recommended_action_horizon"
+  ],
+  "anti_patterns": [
+    "Do not ask for a trend analysis without specifying which sensor parameter.",
+    "Do not set expected_tools to forecast_rul only when the task description mentions anomaly detection."
+  ]
+}
+
+OPERATIONAL CONTEXT (`important_spare_in_stock`):
+{
+  "asset_criticality_tier": "important",
+  "spare_availability": "in_stock",
+  "current_loading_pct": 65,
+  "urgency_floor": "medium",
+  "narrative_context": "Distribution transformer with a local spare available. Planned replacement can be scheduled within the week.",
+  "suitable_fault_codes": [
+    "D1",
+    "T2",
+    "PD",
+    "T1"
+  ],
+  "scenario_families": [
+    "MULTI_DOMAIN_INCIDENT",
+    "WO_CREATION",
+    "FMSR_DGA_DIAGNOSIS"
+  ]
+}
+
+RUL/HEALTH CONTEXT TEMPLATE (`medium_horizon_stable`):
+{
+  "rul_range_days": [
+    180,
+    729
+  ],
+  "health_index_range": [
+    0.4,
+    0.74
+  ],
+  "condition_note": "Aging transformer with some degradation indicators. Stable trend but planning horizon is relevant.",
+  "typical_decision": "Plan for replacement or major overhaul within 1\u20132 years. Increase DGA sampling to quarterly.",
+  "suitable_fault_codes": [
+    "PD",
+    "T1",
+    "D1"
+  ],
+  "suitable_families": [
+    "TSFM_RUL_FORECAST",
+    "FMSR_DGA_DIAGNOSIS"
+  ]
+}
+
+
+NO-HINT RULES — banned in the user-facing `text` field:
+- Tool names (e.g. `fmsr.analyze_dga`, `wo.create_work_order`)
+- Method names or analytic technique names (e.g. "Duval triangle", "Rogers ratio")
+- IEC fault codes (PD, D1, D2, T1, T2, T3) in the prompt itself — they may appear in `decisive_intermediate_values` only
+- Specific gas concentrations or ratio thresholds
+- Pre-framed decisions ("you should create a work order")
+- Step-by-step instructions
+- Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
+
+PREFERRED:
+- Describe an operational event or condition naturally
+- Ask for a decision (diagnosis / RUL / work order / sensor anomaly), not a tool call
+- Ground in one transformer ID and one or two context details (criticality, alarm, recent reading)
+- One task per scenario
+- Under 80 words
+
+
+OUTPUT FORMAT (return one JSON object, no markdown fence):
+{
+  "id": "SGT-GEN-XXX",                                  // caller fills XXX
+  "type": "FMSR" | "TSFM" | "WO" | "IoT" | "Multi",
+  "text": "<the user-facing prompt, follows NO-HINT RULES>",
+  "category": "<one of: Fault Diagnosis | Root Cause Analysis | Remaining Useful Life | Anomaly Detection | Trend Analysis | Maintenance Decision | Work Order Creation | Sensor Analysis | End-to-End Incident Response | Cross-Domain Planning>",
+  "characteristic_form": "<one-sentence description of the answer's structure>",
+  "asset_id": "T-NNN",                                  // T-001 .. T-020
+  "expected_tools": ["domain.tool", ...],               // every tool the ideal agent calls
+  "domain_tags": ["FMSR", ...],                         // matches the type for single-domain; >=2 for Multi
+  "difficulty": "easy" | "medium" | "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": ["domain.tool", ...],        // ordered, same entries as expected_tools
+    "decisive_intermediate_values": { "<key>": "<value>", ... },
+    "final_value": { "<key>": "<value>", ... },         // concrete output (e.g. fault_label, rul_days)
+    "acceptance_criteria": ["agent <does X>", ...],     // 2-5 checks, each starting with "agent "
+    "must_include": ["<element>", ...]                  // coarse high-level answer elements
+  }
+}
+
+DO NOT include `provenance` or `nearest_handcrafted_comparator` blocks in
+your output — the caller fills those after generation. DO NOT emit
+`source_type`, `generator_prompt_version`, `generation_model`, or any
+other generator-metadata field at the top level. The scenario JSON should
+contain ONLY the canonical scenario contract (id, type, text, category,
+characteristic_form, asset_id, expected_tools, domain_tags, difficulty,
+ground_truth).
+
+Return ONLY the JSON object. No commentary, no markdown fences, no explanation.

--- a/data/scenarios/generated/first_review_20260502/prompts/WO_CREATION_SGT-GEN-003.txt
+++ b/data/scenarios/generated/first_review_20260502/prompts/WO_CREATION_SGT-GEN-003.txt
@@ -1,0 +1,128 @@
+You are generating a single Smart Grid maintenance scenario for the SmartGridBench benchmark suite. The scenario will be evaluated against an LLM agent with access to four MCP servers (IoT, FMSR, TSFM, WO).
+
+FAMILY: WO_CREATION
+FAMILY SPEC:
+{
+  "target_count": 4,
+  "primary_domain": "WO",
+  "domain_tags": [
+    "WO"
+  ],
+  "difficulty_range": [
+    "easy",
+    "medium"
+  ],
+  "task_types": [
+    "work_order_creation",
+    "corrective_maintenance",
+    "downtime_estimation"
+  ],
+  "required_tools": [
+    "wo.create_work_order"
+  ],
+  "optional_tools": [
+    "wo.estimate_downtime",
+    "wo.list_fault_records",
+    "wo.get_fault_record"
+  ],
+  "variation_axes": {
+    "trigger_type": "vary among: DGA fault confirmed, sensor threshold exceeded, routine scheduled maintenance, post-trip inspection",
+    "transformer_id": "vary across T-001 to T-020",
+    "urgency": "vary among emergency, high, medium \u2014 use work_order_playbook entries in this file for minimum field requirements per urgency tier"
+  },
+  "ground_truth_must_include": [
+    "work_order_type",
+    "priority",
+    "minimum_fields_from_playbook"
+  ],
+  "anti_patterns": [
+    "Do not create a WO scenario where the fault evidence is absent \u2014 the task text must reference a triggering event.",
+    "Do not use urgency=emergency for PD or T1 fault codes."
+  ]
+}
+
+OPERATIONAL CONTEXT (`critical_lead_time_spare`):
+{
+  "asset_criticality_tier": "critical",
+  "spare_availability": "lead_time_2_weeks",
+  "current_loading_pct": 82,
+  "urgency_floor": "high",
+  "narrative_context": "Substation main transformer with a spare on order. Fault response must account for the 2-week procurement window.",
+  "suitable_fault_codes": [
+    "D2",
+    "T3",
+    "D1",
+    "T2"
+  ],
+  "scenario_families": [
+    "MULTI_DOMAIN_INCIDENT",
+    "WO_CREATION"
+  ]
+}
+
+WORK-ORDER PLAYBOOK ENTRY (`T3_C4`):
+{
+  "fault_code": "T3",
+  "condition_tier": "C4",
+  "urgency": "emergency",
+  "wo_type": "corrective",
+  "priority": "emergency",
+  "time_to_action": "hours",
+  "minimum_fields": [
+    "asset_id",
+    "fault_type",
+    "trigger_evidence",
+    "immediate_action_required",
+    "thermal_history_note",
+    "spare_status"
+  ],
+  "notes": "High-temperature thermal fault. Check loading history and cooling system status before re-energization."
+}
+
+
+NO-HINT RULES — banned in the user-facing `text` field:
+- Tool names (e.g. `fmsr.analyze_dga`, `wo.create_work_order`)
+- Method names or analytic technique names (e.g. "Duval triangle", "Rogers ratio")
+- IEC fault codes (PD, D1, D2, T1, T2, T3) in the prompt itself — they may appear in `decisive_intermediate_values` only
+- Specific gas concentrations or ratio thresholds
+- Pre-framed decisions ("you should create a work order")
+- Step-by-step instructions
+- Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
+
+PREFERRED:
+- Describe an operational event or condition naturally
+- Ask for a decision (diagnosis / RUL / work order / sensor anomaly), not a tool call
+- Ground in one transformer ID and one or two context details (criticality, alarm, recent reading)
+- One task per scenario
+- Under 80 words
+
+
+OUTPUT FORMAT (return one JSON object, no markdown fence):
+{
+  "id": "SGT-GEN-XXX",                                  // caller fills XXX
+  "type": "FMSR" | "TSFM" | "WO" | "IoT" | "Multi",
+  "text": "<the user-facing prompt, follows NO-HINT RULES>",
+  "category": "<one of: Fault Diagnosis | Root Cause Analysis | Remaining Useful Life | Anomaly Detection | Trend Analysis | Maintenance Decision | Work Order Creation | Sensor Analysis | End-to-End Incident Response | Cross-Domain Planning>",
+  "characteristic_form": "<one-sentence description of the answer's structure>",
+  "asset_id": "T-NNN",                                  // T-001 .. T-020
+  "expected_tools": ["domain.tool", ...],               // every tool the ideal agent calls
+  "domain_tags": ["FMSR", ...],                         // matches the type for single-domain; >=2 for Multi
+  "difficulty": "easy" | "medium" | "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": ["domain.tool", ...],        // ordered, same entries as expected_tools
+    "decisive_intermediate_values": { "<key>": "<value>", ... },
+    "final_value": { "<key>": "<value>", ... },         // concrete output (e.g. fault_label, rul_days)
+    "acceptance_criteria": ["agent <does X>", ...],     // 2-5 checks, each starting with "agent "
+    "must_include": ["<element>", ...]                  // coarse high-level answer elements
+  }
+}
+
+DO NOT include `provenance` or `nearest_handcrafted_comparator` blocks in
+your output — the caller fills those after generation. DO NOT emit
+`source_type`, `generator_prompt_version`, `generation_model`, or any
+other generator-metadata field at the top level. The scenario JSON should
+contain ONLY the canonical scenario contract (id, type, text, category,
+characteristic_form, asset_id, expected_tools, domain_tags, difficulty,
+ground_truth).
+
+Return ONLY the JSON object. No commentary, no markdown fences, no explanation.

--- a/data/scenarios/generated/first_review_20260502/raw_responses/FMSR_DGA_DIAGNOSIS_SGT-GEN-001.json
+++ b/data/scenarios/generated/first_review_20260502/raw_responses/FMSR_DGA_DIAGNOSIS_SGT-GEN-001.json
@@ -1,0 +1,20 @@
+```
+{
+  "id": "SGT-GEN-001",
+  "type": "FMSR",
+  "text": "Transformer T-005 shows stable gas levels during routine monitoring. Determine the primary fault and recommend the next inspection step.",
+  "category": "Fault Diagnosis",
+  "characteristic_form": "A diagnosis with a recommended action.",
+  "asset_id": "T-005",
+  "expected_tools": ["fmsr.get_dga_record", "fmsr.analyze_dga"],
+  "domain_tags": ["FMSR"],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": ["fmsr.get_dga_record", "fmsr.analyze_dga"],
+    "decisive_intermediate_values": { "iec_code": "T3", "R1": "0.067" },
+    "final_value": { "primary_fault": "T3", "recommended_action": "Schedule a detailed inspection" },
+    "acceptance_criteria": ["agent identifies the primary fault", "agent recommends a reasonable next step", "agent uses DGA data to support the diagnosis"],
+    "must_include": ["primary fault", "recommended action", "dominant gas rationale"]
+  }
+}
+```

--- a/data/scenarios/generated/first_review_20260502/raw_responses/IOT_SENSOR_ANALYSIS_SGT-GEN-004.json
+++ b/data/scenarios/generated/first_review_20260502/raw_responses/IOT_SENSOR_ANALYSIS_SGT-GEN-004.json
@@ -1,0 +1,18 @@
+{
+  "id": "SGT-GEN-001",
+  "type": "IoT",
+  "text": "Transformer T-005 is operating at 98% capacity with no spare available. Check if the oil temperature is within a safe range.",
+  "category": "Sensor Analysis",
+  "characteristic_form": "The answer will include a sensor value with unit and a threshold comparison.",
+  "asset_id": "T-005",
+  "expected_tools": ["iot.get_sensor_readings"],
+  "domain_tags": ["IoT"],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": ["iot.get_sensor_readings"],
+    "decisive_intermediate_values": { "oil_temp_c": "70" },
+    "final_value": { "sensor_value_with_unit": "70°C", "threshold_comparison": "within safe range", "status_summary": "normal operation" },
+    "acceptance_criteria": ["agent checks oil temperature", "agent compares temperature to a safe threshold", "agent reports the status of the transformer"],
+    "must_include": ["sensor_value_with_unit", "threshold_comparison", "status_summary"]
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/raw_responses/MULTI_DOMAIN_INCIDENT_SGT-GEN-005.json
+++ b/data/scenarios/generated/first_review_20260502/raw_responses/MULTI_DOMAIN_INCIDENT_SGT-GEN-005.json
@@ -1,0 +1,33 @@
+```json
+{
+  "id": "SGT-GEN-001",
+  "type": "Multi",
+  "text": "Transformer T-005, critical to the grid, shows elevated hydrogen and rising methane levels in recent DGA samples. Determine the fault mode and recommend maintenance.",
+  "category": "End-to-End Incident Response",
+  "characteristic_form": "A diagnosis with a recommended maintenance action based on integrated analysis of DGA trends and asset criticality.",
+  "asset_id": "T-005",
+  "expected_tools": ["iot.get_sensor_readings", "fmsr.analyze_dga", "tsfm.forecast_rul", "wo.create_work_order"],
+  "domain_tags": ["IoT", "FMSR", "TSFM", "WO"],
+  "difficulty": "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": ["iot.get_sensor_readings", "fmsr.analyze_dga", "tsfm.forecast_rul", "wo.create_work_order"],
+    "decisive_intermediate_values": {
+      "fault_code": "D2",
+      "R1_ratio": "6.0",
+      "R3_ratio": "6.25"
+    },
+    "final_value": {
+      "fault_label": "Arcing fault",
+      "rul_days": "14",
+      "work_order_type": "corrective"
+    },
+    "acceptance_criteria": [
+      "agent identifies the fault mode as arcing",
+      "agent forecasts the remaining useful life in days",
+      "agent creates a work order with the correct type and priority",
+      "agent includes safety isolation notes in the work order"
+    ],
+    "must_include": ["iot_evidence_summary", "fault_hypothesis_with_iec_code", "rul_or_risk_forecast", "work_order_recommendation"]
+  }
+}
+```

--- a/data/scenarios/generated/first_review_20260502/raw_responses/TSFM_RUL_FORECAST_SGT-GEN-002.json
+++ b/data/scenarios/generated/first_review_20260502/raw_responses/TSFM_RUL_FORECAST_SGT-GEN-002.json
@@ -1,0 +1,18 @@
+{
+  "id": "SGT-GEN-001",
+  "type": "TSFM",
+  "text": "Transformer T-005 shows signs of aging, with recent DGA indicating potential issues. Estimate its remaining useful life for the next 60 days.",
+  "category": "Remaining Useful Life",
+  "characteristic_form": "The answer will provide a forecasted RUL in days, along with a risk level rationale and recommended action horizon.",
+  "asset_id": "T-005",
+  "expected_tools": ["tsfm.forecast_rul", "tsfm.detect_anomalies"],
+  "domain_tags": ["TSFM"],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": ["tsfm.forecast_rul", "tsfm.detect_anomalies"],
+    "decisive_intermediate_values": { "health_index": "0.6", "rul_range_days": "180-729" },
+    "final_value": { "rul_estimate_days": "420", "risk_level_rationale": "Medium risk due to degradation indicators", "recommended_action_horizon": "Schedule replacement within 1-2 years" },
+    "acceptance_criteria": ["agent provides a RUL estimate in days", "agent includes a risk level rationale", "agent recommends an action horizon"],
+    "must_include": ["RUL estimate", "risk level rationale", "recommended action horizon"]
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/raw_responses/WO_CREATION_SGT-GEN-003.json
+++ b/data/scenarios/generated/first_review_20260502/raw_responses/WO_CREATION_SGT-GEN-003.json
@@ -1,0 +1,18 @@
+{
+  "id": "SGT-GEN-001",
+  "type": "WO",
+  "text": "Transformer T-005 has a high-temperature reading. Create a work order to address the issue.",
+  "category": "Work Order Creation",
+  "characteristic_form": "A work order with minimum required fields.",
+  "asset_id": "T-005",
+  "expected_tools": ["wo.create_work_order", "wo.estimate_downtime"],
+  "domain_tags": ["WO"],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": ["wo.create_work_order", "wo.estimate_downtime"],
+    "decisive_intermediate_values": { "fault_code": "T3", "condition_tier": "C4" },
+    "final_value": { "work_order_type": "corrective", "priority": "emergency" },
+    "acceptance_criteria": ["agent creates a work order", "agent estimates downtime"],
+    "must_include": ["work_order_type", "priority", "minimum_fields_from_playbook"]
+  }
+}

--- a/data/scenarios/generated/first_review_20260502/validation_summary.md
+++ b/data/scenarios/generated/first_review_20260502/validation_summary.md
@@ -1,0 +1,70 @@
+# Validation Summary
+
+Batch: `first_review_20260502`
+Generated: 2026-05-03 03:26 UTC
+Issue: #2
+Model: `watsonx/meta-llama/llama-3-3-70b-instruct`
+Prompt version: `v0.1`
+Knowledge/plugin hash: `0eacec24441e`
+
+## Batch Contents
+
+| Scenario | Family | Type | Structural status | Notes for #53 |
+|---|---|---|---|---|
+| `SGT-GEN-001` | `FMSR_DGA_DIAGNOSIS` | `FMSR` | PASS | Manually cleaned up after review: the original raw response contradicted the stable-normal template by labelling the profile `T3`; committed JSON now records `N` / no active fault. |
+| `SGT-GEN-002` | `TSFM_RUL_FORECAST` | `TSFM` | PASS | Manually cleaned up after review: prompt now asks for long-term RUL plus explicit 60-day operability, matching the 420-day ground truth. |
+| `SGT-GEN-003` | `WO_CREATION` | `WO` | PASS | Manually cleaned up after review: WO-only ground truth no longer requires unsupported hidden FMSR fault code / condition tier evidence. |
+| `SGT-GEN-004` | `IOT_SENSOR_ANALYSIS` | `IoT` | PASS | No obvious structural issue. |
+| `SGT-GEN-005` | `MULTI_DOMAIN_INCIDENT` | `Multi` | PASS | Manually cleaned up after review: D2 ratios now match the repo-standard representative profile (`R1=0.40`, `R2=1.20`, `R3=3.33`). Prompt mentions gas names but no concentrations/codes/methods; #53 should decide if this is acceptable or too leading. |
+
+## Cleanup After v1 Review
+
+The raw responses remain committed unchanged as generation evidence. The committed
+`SGT-GEN-*.json` files are the reviewable candidate artifacts. Four candidates
+have `provenance.manual_cleanup=true` because the v1 file review found content
+bugs in the raw model output:
+
+- `SGT-GEN-001`: corrected `T3` to `N` / normal based on the committed
+  `stable_normal` prompt template and final-sample `R1=0.056`.
+- `SGT-GEN-002`: aligned prompt and ground-truth horizon.
+- `SGT-GEN-003`: removed unsupported diagnostic ground truth from the WO-only
+  scenario; after v2 review, removed the non-contract `must_not_include` field
+  and kept the same intent in `acceptance_criteria`.
+- `SGT-GEN-005`: corrected D2 Rogers-ratio values to match
+  `data/knowledge/transformer_standards.json`.
+
+Known remaining human-review items:
+
+- All five candidates still use asset `T-005`; this weakens batch diversity but
+  does not affect structural validity.
+- The nearest-handcrafted comparator is based on type/tool overlap, so #53
+  should still perform an explicit novelty check.
+- Raw responses show the model sometimes emitted markdown fences despite the
+  prompt; the parser stripped them before writing the committed JSON.
+
+## Checks Run
+
+```bash
+uv run --with jsonschema python data/scenarios/validate_scenarios.py
+```
+
+Result: `Validation passed for 11 scenario files and 5 negative fixtures.`
+
+```bash
+uv run --with litellm==1.81.13 --with python-dotenv --with ibm-watsonx-ai python - <<'PY'
+import json, pathlib
+import scripts.generate_scenarios as gen
+valid_asset_ids = gen._validator.load_valid_asset_ids(gen.ASSET_CSV)
+root = pathlib.Path('data/scenarios/generated/first_review_20260502')
+for p in sorted(root.glob('SGT-GEN-*.json')):
+    d = json.loads(p.read_text())
+    errors = gen.validate_scenario(d, valid_asset_ids)
+    print(f"{d['id']}\t{'PASS' if not errors else 'FAIL'}\t{'; '.join(errors)}")
+PY
+```
+
+Result: all five generated candidates passed the canonical schema plus generated-scenario provenance/comparator contract.
+
+## Handoff
+
+This batch is ready for #53-style human validation. Do not promote any file from this directory into top-level `data/scenarios/` until #53 assigns a disposition (`accept`, `accept_with_edits`, `reject_duplicate`, or `reject_unusable`).


### PR DESCRIPTION
## Summary

- Adds the first reviewable WatsonX-generated SmartGridBench scenario batch under `data/scenarios/generated/first_review_20260502/`.
- Includes five `SGT-GEN-*` candidates, one per configured family, plus prompts, raw responses, manifest, provenance/comparator metadata, and a validation summary.
- Records manual cleanup from the in-session file review and keeps the #53 validation handoff explicit.

Closes #2.
Refs #53.

## Validation

- `git diff --check`
- `uv run --with jsonschema python data/scenarios/validate_scenarios.py`
- Generator contract revalidation for `SGT-GEN-001` through `SGT-GEN-005`

## Review

In-session independent file review completed before PR:

- v1: 1 Critical, 3 High found and fixed.
- v2/v3: remaining Medium/Low polish fixed or explicitly deferred.
- v4 final: LGTM for PR; 0 Critical, 0 High, 0 Medium, 0 new Low.
