### PR TITLE
Update IEEE report back-port readiness (#40, #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@
   and `results/metrics/experiment_matrix_summary.csv`, while
   `notebook03_pe_family_follow_on.csv` should not be treated as their source
   unless regenerated.
+- Updated the `#40` / `#78` IEEE report back-port surfaces so the checklist is
+  marked as created, the Markdown draft is positioned as a working conversion
+  surface rather than a submitted report, and final IEEE export remains gated on
+  NeurIPS compile/checklist/source freeze.
+- Corrected the IEEE report's Experiment 2 source notes so `YS` / `ZS`
+  Self-Ask rows cite `results/metrics/notebook03_self_ask_ablation.csv` and
+  `results/metrics/experiment_matrix_summary.csv`, not
+  `notebook03_pe_family_follow_on.csv`.
 - Added the first editable final-presentation PPTX draft at
   `reports/2026-05-03_final_presentation_smartgridbench_draft.pptx`
   plus a `reports/build_notes/` provenance note, and refreshed the #44 deck

--- a/docs/final_report_backport_scaffold.md
+++ b/docs/final_report_backport_scaffold.md
@@ -1,8 +1,8 @@
 # Final Report Back-Port Scaffold
 
-*Last updated: 2026-05-02*
+*Last updated: 2026-05-03*
 *Owner: Alex Xin*
-*Issues: `#40`, with source draft tracked by `#5` / `#39`*
+*Issues: `#40`, `#78`, with source draft tracked by `#5` / `#39`*
 
 This is the control surface for turning the NeurIPS Evaluations & Datasets draft
 (formerly Datasets & Benchmarks) into the class IEEE-format final report without
@@ -12,6 +12,25 @@ content-bearing class report drafting surface is now
 `reports/final_report_ieee_draft.md`.
 
 Overleaf transfer surface: `docs/neurips_overleaf_transfer_plan.md`.
+
+## May 3 readiness status
+
+The back-port checklist and the first content-bearing IEEE Markdown report
+draft now exist. `#78` is therefore no longer blocked on checklist creation;
+its remaining value is to make sure the checklist is used during the final
+IEEE LaTeX transfer. `#40` remains open until the class-report template is
+actually populated, compiled/exported, and checked against the final NeurIPS
+source.
+
+Current source posture:
+
+- NeurIPS Overleaf has a first real draft at commit `4a85633`.
+- The NeurIPS source is not yet frozen because compile proof, checklist
+  answers, final references, scenario-count wording, and mitigation-rerun
+  disposition remain open.
+- The IEEE Markdown draft can keep improving now, but final IEEE export should
+  wait until the NeurIPS source text is coherent enough to avoid a divergent
+  second paper.
 
 ## Source-of-truth order
 
@@ -46,6 +65,11 @@ Minimum report-ready set:
 
 - Experiment 1 latency comparison from Notebook 02.
 - Experiment 2 orchestration comparison from Notebook 03.
+- PE-family Self-Ask rows from
+  `results/metrics/notebook03_self_ask_ablation.csv` and
+  `results/metrics/experiment_matrix_summary.csv`; do not cite
+  `notebook03_pe_family_follow_on.csv` as the source for `YS` / `ZS` unless it
+  is regenerated.
 - Failure taxonomy count figure from `results/figures/failure_taxonomy_counts.svg`,
   backed by `results/metrics/failure_taxonomy_counts.csv`.
 - Failure stage-by-cell heatmap from
@@ -60,13 +84,15 @@ Optional if evidence lands in time:
 - PE-family optimized-serving ablation table.
 - Scenario-realism / generated-scenario validation figure.
 
-## May 2 draft status
+## May 3 draft status
 
 `reports/final_report_ieee_draft.md` now contains the first full IEEE-section
 draft with current evidence tables for:
 
 - Experiment 1 A/B/C transport latency.
-- Experiment 2 B/Y/Z and PE-family Self-Ask quality.
+- Experiment 2 B/Y/Z and PE-family Self-Ask quality, with source separation
+  between `notebook03_orchestration_comparison.csv` and
+  `notebook03_self_ask_ablation.csv`.
 - Failure taxonomy class counts.
 - Figure and artifact checklist.
 
@@ -75,9 +101,10 @@ pending deadline work. In particular, it does not claim the 30-scenario floor is
 complete until PR #156 plus generator-accepted scenarios are merged and
 validated.
 
-The next useful scaffolding step is to populate the NeurIPS Overleaf source
-first, then back-port from that source into the IEEE template. This keeps #40
-and #78 aligned with #5/#39 instead of creating a second independent paper.
+The next useful report step is to re-check this Markdown draft against the
+populated NeurIPS Overleaf source, then copy into the IEEE template only after
+the NeurIPS source compiles and its TODO markers are under control. This keeps
+#40 and #78 aligned with #5/#39 instead of creating a second independent paper.
 Until the NeurIPS source is compiled, the Markdown report draft should remain a
 working conversion surface rather than the class-submission artifact.
 

--- a/reports/final_report_ieee_draft.md
+++ b/reports/final_report_ieee_draft.md
@@ -1,6 +1,6 @@
 # IEEE Class Final Report Draft
 
-*Created: 2026-05-02*
+*Last updated: 2026-05-03*
 *Owner: Alex Xin*
 *Issues: #40, #78; source paper lane: #5, #39*
 
@@ -8,6 +8,23 @@ This is the first content-bearing IEEE report draft. It is intentionally a
 Markdown drafting surface, not the final LaTeX artifact. The final report should
 be transferred into the class IEEE Overleaf template after the NeurIPS source is
 stable, with this file used as the section-by-section content and claim ledger.
+
+## May 3 Report Readiness
+
+This draft is useful now as the IEEE back-port source, but it is not yet the
+submission artifact. The NeurIPS Overleaf source has been populated with a first
+real draft, so the next report work is a drift check against that source plus
+final LaTeX transfer once the NeurIPS compile/checklist gates clear.
+
+Open report gates:
+
+- Re-check the abstract and result paragraphs against the final NeurIPS source.
+- Insert final figures in the IEEE template with run IDs and CSV/source paths.
+- Verify every numeric claim against `results/metrics/` and
+  `docs/validation_log.md`.
+- Export/compile the IEEE report and record proof in `#40`.
+- Use the `#78` checklist during transfer; do not close `#40` from this
+  Markdown draft alone.
 
 ## Abstract
 
@@ -157,6 +174,13 @@ The current first-capture orchestration table is:
 | YS / PE-S-M | Plan-Execute + Self-Ask | `8998341_exp2_cell_Y_pe_self_ask_mcp_baseline` | 1.0 | 59.00s | 0.444 | 3/6 |
 | ZS / V-S-M | Verified PE + Self-Ask | `8998343_exp2_cell_Z_verified_pe_self_ask_mcp_baseline` | 1.0 | 33.78s | 0.833 | 5/6 |
 
+Source note: `B/Y/Z` rows trace to
+`results/metrics/notebook03_orchestration_comparison.csv`; `YS/ZS` Self-Ask
+rows trace to `results/metrics/notebook03_self_ask_ablation.csv` and
+`results/metrics/experiment_matrix_summary.csv`. Do not cite
+`results/metrics/notebook03_pe_family_follow_on.csv` as the source for the
+Self-Ask rows unless that file is regenerated.
+
 Vanilla Plan-Execute is weak in this first capture, but the PE-family rows are
 scientifically useful because they show how clarification and verification
 change outcomes. The strongest current row is Verified PE + Self-Ask, with mean
@@ -204,7 +228,10 @@ paper-grade, and transfer the final content into the IEEE LaTeX template.
 
 - [ ] Experiment 1 latency chart: `results/figures/notebook02_latency_comparison.png`.
 - [ ] Experiment 2 orchestration chart: `results/figures/notebook03_orchestration_comparison.png`.
-- [ ] PE-family follow-on chart, if space permits: `results/figures/notebook03_pe_family_follow_on.png`.
+- [ ] PE-family follow-on chart, if space permits:
+      `results/figures/notebook03_pe_family_follow_on.png`; cite `YS/ZS`
+      table rows from `results/metrics/notebook03_self_ask_ablation.csv` and
+      `results/metrics/experiment_matrix_summary.csv`.
 - [ ] Failure taxonomy counts: `results/figures/failure_taxonomy_counts.svg`.
 - [ ] Failure stage heatmap: `results/figures/failure_stage_cell_heatmap.svg`.
 - [ ] Artifact ledger table from `docs/validation_log.md` and `results/metrics/experiment_matrix_summary.csv`.


### PR DESCRIPTION
## Summary

- Updates the #40 / #78 back-port scaffold so the checklist is marked as created and the remaining gate is use during final IEEE LaTeX transfer.
- Adds May 3 readiness notes to the IEEE Markdown report draft so it is clearly a working conversion surface, not the submitted report artifact.
- Corrects Experiment 2 source notes so `YS` / `ZS` Self-Ask rows cite `notebook03_self_ask_ablation.csv` and `experiment_matrix_summary.csv`.

## Scope

Stage: report readiness. Refs #40, #78; #78 is close to done after this, but #40 remains open until the IEEE template is populated, compiled/exported, and checked against the final NeurIPS source.

## Test Plan

- `rg -n "notebook03_pe_family_follow_on\\.csv|notebook03_self_ask_ablation|May 3|4a85633|#78" docs/final_report_backport_scaffold.md reports/final_report_ieee_draft.md CHANGELOG.md`
- `git diff --check`
