### PR TITLE
Harden GCP fallback resume workflow (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   Self-Ask rows cite `results/metrics/notebook03_self_ask_ablation.csv` and
   `results/metrics/experiment_matrix_summary.csv`, not
   `notebook03_pe_family_follow_on.csv`.
+- Added resumable GCP fallback execution: stable SmartGrid run IDs, resume/force
+  knobs, trial-level resume manifests, atomic per-trial finalization,
+  context-closeout batch manifests, and IAP artifact pullback with idempotent
+  judge score merging.
 - Added the first editable final-presentation PPTX draft at
   `reports/2026-05-03_final_presentation_smartgridbench_draft.pptx`
   plus a `reports/build_notes/` provenance note, and refreshed the #44 deck

--- a/configs/aat_mcp_model_optimized_16384.env
+++ b/configs/aat_mcp_model_optimized_16384.env
@@ -1,0 +1,13 @@
+# Experiment 1 exploratory Cell D16 — Cell D / AT-TPQ at 16K context.
+#
+# This is the midpoint context-window ablation for the local optimized-serving
+# stack. It keeps the Cell D transport/model knobs fixed while testing whether
+# 16K avoids 8K pressure without the latency/attention spread of 32K.
+
+source configs/aat_mcp_model_optimized.env
+
+EXPERIMENT_NAME="aat_mcp_model_optimized_16384"
+EXPERIMENT_CELL="D16"
+EXPERIMENT_FAMILY="context_window_ablation"
+CONTRIBUTING_EXPERIMENTS="exp1_model_optimization,context_length_ablation"
+MAX_MODEL_LEN=16384

--- a/configs/context_ablation/pe_m_16384.env
+++ b/configs/context_ablation/pe_m_16384.env
@@ -1,0 +1,9 @@
+# Context-window ablation — PE-M / Plan-Execute at 16K.
+
+source configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env
+
+EXPERIMENT_NAME="exp2_cell_Y_pe_mcp_baseline_16384"
+EXPERIMENT_CELL="Y16"
+EXPERIMENT_FAMILY="context_window_ablation"
+CONTRIBUTING_EXPERIMENTS="exp2_orchestration,context_length_ablation"
+MAX_MODEL_LEN=16384

--- a/configs/context_ablation/pe_m_8192.env
+++ b/configs/context_ablation/pe_m_8192.env
@@ -1,0 +1,8 @@
+# Context-window ablation — PE-M / Plan-Execute MCP baseline at 8K.
+
+source configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env
+
+EXPERIMENT_NAME="exp2_cell_Y_pe_mcp_baseline_8192"
+EXPERIMENT_CELL="Y8"
+EXPERIMENT_FAMILY="context_window_ablation"
+MAX_MODEL_LEN=8192

--- a/configs/context_ablation/pe_s_m_16384.env
+++ b/configs/context_ablation/pe_s_m_16384.env
@@ -1,0 +1,9 @@
+# Context-window ablation — PE-S-M / Plan-Execute + Self-Ask at 16K.
+
+source configs/experiment2/exp2_cell_Y_pe_self_ask_mcp_baseline.env
+
+EXPERIMENT_NAME="exp2_cell_Y_pe_self_ask_mcp_baseline_16384"
+EXPERIMENT_CELL="YS16"
+EXPERIMENT_FAMILY="context_window_ablation"
+CONTRIBUTING_EXPERIMENTS="exp2_orchestration,context_length_ablation"
+MAX_MODEL_LEN=16384

--- a/configs/context_ablation/v_s_m_16384.env
+++ b/configs/context_ablation/v_s_m_16384.env
@@ -1,0 +1,9 @@
+# Context-window ablation — V-S-M / Verified PE + Self-Ask at 16K.
+
+source configs/experiment2/exp2_cell_Z_verified_pe_self_ask_mcp_baseline.env
+
+EXPERIMENT_NAME="exp2_cell_Z_verified_pe_self_ask_mcp_baseline_16384"
+EXPERIMENT_CELL="ZS16"
+EXPERIMENT_FAMILY="context_window_ablation"
+CONTRIBUTING_EXPERIMENTS="exp2_orchestration,context_length_ablation"
+MAX_MODEL_LEN=16384

--- a/configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384.env
+++ b/configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384.env
@@ -1,0 +1,12 @@
+# Experiment 2 follow-on ablation — ZSD16 / V-S-TPQ at 16K context.
+#
+# Midpoint context-window ablation for the current "best engineered" local
+# stack: Verified PE + Self-Ask, optimized MCP sessions, prefix caching, and the
+# compressed INT8/BF16/fp8-KV serving profile.
+
+source configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_32768.env
+
+EXPERIMENT_NAME="exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384"
+EXPERIMENT_CELL="ZSD16"
+EXPERIMENT_FAMILY="context_window_ablation"
+MAX_MODEL_LEN=16384

--- a/configs/gcp_context_closeout.tsv
+++ b/configs/gcp_context_closeout.tsv
@@ -1,0 +1,8 @@
+label	config
+Y8	configs/context_ablation/pe_m_8192.env
+Y32	configs/experiment2/exp2_cell_Y_pe_mcp_baseline.env
+Y16	configs/context_ablation/pe_m_16384.env
+YS16	configs/context_ablation/pe_s_m_16384.env
+ZS16	configs/context_ablation/v_s_m_16384.env
+D16	configs/aat_mcp_model_optimized_16384.env
+ZSD16	configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384.env

--- a/docs/gcp_fallback.md
+++ b/docs/gcp_fallback.md
@@ -186,6 +186,44 @@ and writes the same `benchmarks/cell_<X>/raw/<run-id>/` layout.
 Because there's no queue on GCP, you can run cells back-to-back. The time
 budget becomes a cost question, not a scheduler one.
 
+Run provenance should be explicit when GCP artifacts enter the matrix. Current
+summaries stamp `host_name`, `gpu_type`, `slurm_job_id`, `git_sha`,
+`git_branch`, and `git_dirty`. Interpret GCP captures as `slurm_job_id=null`
+with a `smartgrid-*` host and `gpu_type` such as `NVIDIA A100-SXM4-40GB`
+or `NVIDIA L4`; Insomnia captures
+have numeric Slurm IDs and `ins###` hosts. Matrix rows should record the
+hardware/provider as separate row metadata or in an adjacent provenance column,
+not silently overwrite an Insomnia row with a GCP run.
+
+### Resumable GCP runs
+
+Use a stable run ID for any preemption-prone GCP capture:
+
+```bash
+SMARTGRID_RUN_ID=<stable-run-id> SMARTGRID_RESUME=1 \
+  bash scripts/run_experiment.sh configs/context_ablation/pe_m_8192.env
+```
+
+Resume mode inventories the existing run directory, skips terminal success and
+terminal failure JSONs that already have matching latency rows, reruns missing
+or incomplete trials, and appends trial decisions to
+`resume_manifest.jsonl`. Keep `SMARTGRID_RESUME_REQUIRE_LATENCY=1` for
+benchmark captures. Set `SMARTGRID_FORCE_RERUN=1` only when intentionally
+discarding prior evidence.
+
+For the May 2026 context closeout cohort, use the canonical batch wrapper:
+
+```bash
+SMARTGRID_COMPUTE_PROVIDER=gcp \
+SMARTGRID_COMPUTE_ZONE="$ZONE" \
+SMARTGRID_COMPUTE_INSTANCE="$INSTANCE" \
+  bash scripts/run_gcp_context_batch.sh --resume-batch <batch-id>
+```
+
+The wrapper reads `configs/gcp_context_closeout.tsv`, writes
+`logs/gcp_<batch-id>_state.tsv` plus TSV/JSONL manifests, reuses stable row run
+IDs, skips rows already marked complete, and judges rows idempotently.
+
 ### Profiling works unchanged
 
 ```bash
@@ -199,18 +237,61 @@ Insomnia.
 
 ## 8. Persisting artifacts off the instance
 
-Before shutting down, push benchmark + profiling outputs back to git or a
-shared bucket. **Spot instances get nuked on preemption** — anything left
-on local disk is gone.
+Before shutting down, copy benchmark outputs back to the local Mac or a shared
+bucket. The default should be: **pull from GCP over IAP, inspect locally, commit
+locally, then push to `team13` from the trusted local checkout.** Avoid putting
+GitHub credentials on a transient VM unless the deadline leaves no better
+option.
 
 ```bash
-# Commit benchmark artifacts
+# From the local Mac, after the run finishes:
+export PROJECT=fleet-garage-490218-c8
+export ZONE=us-central1-a
+export INSTANCE=smartgrid-a100-YYYYMMDD-HHMM
+export LOCAL_REPO=/Users/wax/coding/hpml-assetopsbench-smart-grid-mcp
+
+gcloud compute scp --project="$PROJECT" --zone="$ZONE" --tunnel-through-iap \
+    --recurse \
+    "$INSTANCE:~/hpml-assetopsbench-smart-grid-mcp/benchmarks/cell_<X>/raw/<run-id>" \
+    "$LOCAL_REPO/benchmarks/cell_<X>/raw/"
+
+# Then commit from the local repo/worktree after inspection.
+cd "$LOCAL_REPO"
+git status --porcelain --branch
+git add benchmarks/cell_<X>/raw/<run-id>/
+git commit -m "Add Cell <X> raw artifacts from GCP run <run-id>"
+git push team13 HEAD:<branch>
+```
+
+For a context-batch pullback, prefer the helper because it copies small manifests
+first, stages remote judge rows separately, dedupes local score rows, and bounds
+larger raw-directory copies:
+
+```bash
+bash scripts/gcp_pull_context_artifacts.sh \
+  --instance "$INSTANCE" \
+  --zone "$ZONE" \
+  --batch-id <batch-id> \
+  --parallel 2
+```
+
+Direct `git push` from the VM is possible, but it requires installing a GitHub
+token or SSH key on the VM. If you choose that path, push a feature branch only,
+remove the credential afterward, and check shell history before deleting or
+reusing the disk.
+
+```bash
+# On the VM only when direct push is intentionally chosen:
 cd hpml-assetopsbench-smart-grid-mcp
 git add benchmarks/cell_<X>/raw/<run-id>/
 git commit -m "Add Cell <X> raw artifacts from GCP run <run-id>"
 git push origin <branch>
+```
 
-# Profiling traces are larger and gitignored — upload to GCS
+Profiling traces are larger and gitignored; use GCS or `gcloud compute scp`
+instead of git:
+
+```bash
 gsutil -m cp -r profiling/traces/<run-id>/ \
     gs://<team-bucket>/profiling/traces/<run-id>/
 ```
@@ -249,18 +330,44 @@ Boot disks are normally deleted with the instance when
 
 When a spot instance is about to be reclaimed, GCP signals via the metadata
 server and gives you ~30 seconds before `SIGTERM`. A production-grade run
-would install a trap that pushes artifacts before the kill; for our purposes
-the more practical mitigation is:
+would add a metadata preemption watcher and shutdown hook. For our current
+deadline path, the practical mitigation is:
 
-1. **Don't run captures > 1 hour on spot.** Fall back to on-demand for long
-   runs, paying the 2× premium.
-2. **Checkpoint between trials.** The runner writes one JSON per scenario ×
-   trial incrementally, so a preemption mid-run loses only the in-flight
-   trial. Push artifacts after each cell, not after the whole run.
-3. **Watch the preemption API.** A 5-second polling loop against
-   `http://metadata.google.internal/computeMetadata/v1/instance/preempted`
-   (with `Metadata-Flavor: Google`) triggers a rapid push. Worth writing
-   later if GCP becomes our primary path, not worth writing for emergency use.
+1. **Prefer on-demand for canonical captures.** Spot is fine for setup and
+   shakedowns; on-demand avoids restarting vLLM and repeating a partially run
+   cell.
+2. **Let persistent disk bound the loss, then resume with a stable run ID.** The
+   runner writes one JSON per scenario × trial incrementally. Completed trial
+   files survive on disk, and `SMARTGRID_RESUME=1` skips terminal successes and
+   terminal failures when their latency rows are present.
+3. **Treat the in-flight trial as suspect.** Delete or rerun the trial whose
+   JSON/latency record was being written at preemption time; completed earlier
+   trial JSONs should be recoverable.
+4. **If capacity is unavailable on restart, keep the disk.** You can attach the
+   zonal persistent disk to another VM in the same zone, or snapshot it if you
+   need to move zones:
+   ```bash
+   gcloud compute disks snapshot "$DISK" \
+       --project="$PROJECT" --zone="$OLD_ZONE" \
+       --snapshot-names="$DISK-$(date +%Y%m%d-%H%M)"
+
+   gcloud compute disks create "$NEW_DISK" \
+       --project="$PROJECT" --zone="$NEW_ZONE" \
+       --source-snapshot="$SNAPSHOT" \
+       --type=pd-ssd
+   ```
+   Cross-region resume is artifact-first: copy completed run directories back to
+   the local Mac or GCS, recreate a VM in the stocked region, restore artifacts,
+   then resume with the same `SMARTGRID_RUN_ID`.
+
+Tracked hardening items live in GitHub Issue #91. The implemented safe path now
+covers resume/skip, same-zone restart, snapshot-to-new-zone recovery, and
+artifact return over IAP. Remaining production-hardening items:
+
+- A launcher/helper that tries zones first, then regions, and writes the chosen
+  project/zone/instance/run directory into a handoff file.
+- A cleanup/audit helper that lists instances, disks, snapshots, routers/NATs,
+  static IPs, and active quota preferences before the fallback lane is closed.
 
 ## 11. Budget tracking
 

--- a/docs/plans/gcp-fallback-resume.md
+++ b/docs/plans/gcp-fallback-resume.md
@@ -1,0 +1,298 @@
+# Plan: harden GCP fallback resume and artifact recovery
+
+*Plan for Alex Xin (eggrollofchaos). Companion spec at
+[gcp-fallback-resume_spec.md](gcp-fallback-resume_spec.md).*
+
+## Origin
+
+This plan was triggered by the May 2-3, 2026 GCP fallback shakedown for Issue
+#91, after Insomnia's seven-job PE/context-window closeout queue stayed pending
+for roughly a day and the GCP L4 lane produced six clean 6/6 captures plus one
+terminal model/tool partial. The first A100 Spot attempt then proved both sides
+of the fallback story: a Spot preemption stopped the VM during vLLM warmup, but
+the retained boot disk preserved the runtime, model cache, and partial run
+state. The seed artifacts are Issue #91, `docs/gcp_fallback.md`, the local A100
+batch manifest `logs/gcp_a100_context_20260503T063343Z_manifest.tsv`, and the
+GCP provenance patch in `scripts/run_experiment.sh`. Backlog lineage is Issue
+#91's planned work: auto-resume / skip completed trial files, recovery when a
+disk is zonal but capacity moves elsewhere, zone/region fallback, artifact
+return, and cleanup audit. Reference context is `docs/gcp_fallback.md`,
+`docs/insomnia_runbook.md`, `docs/validation_log.md`, and the current
+benchmark artifact contract in `benchmarks/README.md`.
+
+## Goals
+
+1. Make `scripts/run_experiment.sh` safely resumable for preempted GCP captures
+   without changing the default clean-start behavior.
+2. Add a canonical GCP context-batch launcher that can restart the seven-row
+   cohort and skip rows/trials that already completed.
+3. Make judge scoring idempotent so restart or artifact-pull workflows do not
+   duplicate `(run_name, scenario_id, trial_index)` rows.
+4. Define the cross-zone/cross-region recovery path for retained disks,
+   snapshots, and artifact return to the local/team canonical repo.
+5. Preserve current evidence semantics: a completed failed model trajectory is
+   evidence and must not be silently rerun into a success.
+
+## Non-Goals
+
+- Do not replace Insomnia as the canonical preferred runtime. GCP remains a
+  fallback lane.
+- Do not rebuild a full generic cloud orchestrator for this repo. Reuse the
+  small, battle-tested patterns we need: manifest/status files, heartbeat,
+  preemption detection, restart arguments, and artifact pull/merge behavior.
+- Do not make GCS mandatory for the current no-external-IP/IAP VM workflow.
+  Persistent boot disk plus IAP SCP is enough for the immediate paper deadline;
+  GCS remains an optional durability layer.
+- Do not rerun completed terminal failures by default. Rerun only missing,
+  invalid, or incomplete trials unless an operator explicitly forces a clean
+  rerun.
+
+## Design Summary
+
+Resume is keyed by stable run identity and deterministic trial identity, not by
+process lifetime. A GCP restart reuses a `SMARTGRID_RUN_ID`, enters the same
+`benchmarks/cell_*/raw/<run-id>` directory, inventories existing
+`*_runNN.json` files, verifies that each terminal trial has a matching latency
+record, and only executes missing or incomplete trials.
+
+The implementation should keep the shell runner thin. Any JSON validation,
+latency-row dedupe, and manifest manipulation should move into a testable Python
+helper so the next agent can add unit tests without launching vLLM or touching
+GCP.
+
+## Phases
+
+### Phase 0 - Protect the Live A100 Run
+
+The current A100 batch is operator-owned by the runner agent. The build agent
+must not kill the `a100_batch` tmux session, stop the A100 VM, overwrite
+`logs/run_a100_batch.sh`, or change files on the VM without explicit handoff
+from the runner.
+
+Acceptance gate: runner confirms whether the current A100 batch is still active,
+preempted, or complete before any deployment to that VM.
+
+### Phase 1 - Resumable Trial Semantics
+
+Add explicit resume knobs to `scripts/run_experiment.sh`:
+
+- `SMARTGRID_RUN_ID`: optional full run ID override. Required for restart-safe
+  GCP relaunches.
+- `SMARTGRID_RESUME=1`: inventory existing run-dir contents and skip completed
+  terminal trials.
+- `SMARTGRID_FORCE_RERUN=1`: ignore existing trial artifacts and rerun.
+- `SMARTGRID_RESUME_REQUIRE_LATENCY=1` by default: a trial is complete only when
+  the JSON is valid and the matching latency row exists.
+
+Completion definition:
+
+- `complete_success`: valid terminal JSON, postprocessed scenario payload,
+  explicit or derivable `success=true`, latency row present.
+- `complete_failure`: valid terminal JSON, postprocessed scenario payload,
+  explicit or derivable `success=false`, latency row present.
+- `incomplete`: missing JSON, zero-byte JSON, invalid JSON, dangling `.stdout`,
+  or valid JSON without latency when latency is required.
+
+Acceptance gate: local tests prove completed failures are skipped in resume mode
+by the trial-status decision helper without launching a runner. The
+`summary.json` accounting proof is a Phase 2 gate because it depends on the
+manifest and summary inventory stream.
+
+### Phase 2 - Atomic Trial Writes and Resume Manifest
+
+Make trial output writes preemption-safe:
+
+- Write runner stdout and trial JSON through temporary files in the run dir.
+- Atomically rename final JSON into place only after parse/postprocess succeeds.
+- Record one JSONL manifest event per trial with state, scenario file, trial
+  index, output path, started/finished timestamps, run/skip reason, and return
+  code.
+
+Acceptance gate: a synthetic interrupted run with a partial temp/stdout file is
+resumed by rerunning only that trial, not by counting it as evidence. The same
+fixture proves `summary.json` reports attempted, completed, failed, skipped,
+and rerun counts from the merged executed-plus-skipped inventory.
+
+### Phase 3 - Canonical GCP Context Batch Launcher
+
+Replace the ad hoc VM-local batch script with a repo script, for example
+`scripts/run_gcp_context_batch.sh`, that:
+
+- Runs the current seven-row cohort in order: Y8, Y32, Y16, YS16, ZS16, D16,
+  ZSD16.
+- Sets GCP provenance env vars and `SMARTGRID_RESUME=1`.
+- Reuses `SMARTGRID_RUN_ID`s from a batch state file on restart.
+- Writes a batch manifest with label, config, run dir, run rc, judge rc,
+  started/finished timestamps, and provider/hardware fields.
+- Judges each successful or partial terminal run once.
+
+Acceptance gate: the launcher can be killed after Y8, restarted, and it skips
+Y8 while continuing at Y32.
+
+### Phase 4 - Idempotent Judge and Score Merge
+
+Make scoring restart-safe:
+
+- Add a `--skip-existing` or equivalent resume mode to
+  `scripts/judge_trajectory.py`, or add a small score-merge helper that filters
+  duplicate rows by `(run_name, scenario_id, trial_index, judge_model)`.
+- Ensure GCP artifact pullback appends only new score rows to the local
+  `results/metrics/scenario_scores.jsonl`.
+- Preserve judge logs under `results/judge_logs/<run_name>/` and treat existing
+  logs as reusable unless `--force` is supplied.
+
+Acceptance gate: running judge twice on the same run dir leaves score-row counts
+unchanged unless forced.
+
+### Phase 5 - Artifact Pullback and Disk Recovery
+
+Add the operator path for getting data back:
+
+- Pull raw run dirs, batch logs, judge logs, and score rows from a no-external-IP
+  VM over IAP.
+- Merge score rows locally with dedupe.
+- Pull small manifests/logs before raw run dirs, and expose a bounded
+  parallelism knob for larger artifact trees so IAP tunnel throughput or
+  terminal timeouts do not hide partial pull failures.
+- Stop the VM after artifact pullback; retain disk only while it is still useful.
+- Document the zonal-disk boundary: same-zone restart is cheapest; if the zone
+  is full, either attach the disk to a same-zone helper VM to copy artifacts, or
+  snapshot the boot disk and create a new disk/VM in the target zone or region.
+
+Acceptance gate: docs and helper commands cover same-zone restart, same-zone
+helper attach, snapshot-to-new-zone, and local artifact pullback.
+
+### Phase 6 - Zone/Region and Quota Ladder
+
+Codify the operational ladder already discovered live:
+
+- Try other zones in the same region before crossing regions.
+- Try each in-region zone with bounded retries and backoff before crossing
+  regions, and record why each zone was skipped.
+- Check regional GPU quota and `GPUS_ALL_REGIONS` before create attempts.
+- For A100, distinguish standard quota from Spot/preemptible quota.
+- Keep `autoDelete=false` for capture VM boot disks by default.
+- Have the launcher or preflight fail loudly when the active capture VM boot
+  disk is still set to auto-delete.
+- Record capacity/stockout/preemption outcomes in Issue #91 and the GCP runbook.
+
+Acceptance gate: one command or documented checklist produces the next VM-create
+attempt order and the reason a region/zone was skipped.
+
+## Verification
+
+Run these without GPUs:
+
+```bash
+bash -n scripts/run_experiment.sh scripts/run_gcp_context_batch.sh
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q \
+  tests/test_run_experiment_summary.py \
+  tests/test_gcp_resume_state.py
+DRY_RUN=1 SMARTGRID_RESUME=1 SMARTGRID_RUN_ID=resume-smoke \
+  bash scripts/run_experiment.sh configs/context_ablation/pe_m_8192.env
+```
+
+Run these only on the GCP VM or another approved GPU node:
+
+```bash
+SMARTGRID_RUN_ID=<existing-y8-run-id> SMARTGRID_RESUME=1 \
+  bash scripts/run_experiment.sh configs/context_ablation/pe_m_8192.env
+
+bash scripts/run_gcp_context_batch.sh --resume-batch <batch-id>
+```
+
+Expected proof:
+
+- Existing completed trials are skipped and logged as skipped.
+- Missing/incomplete trials rerun.
+- `summary.json` counts skipped terminal failures as failures, not as passes.
+- `latencies.jsonl` has no duplicate scenario/trial rows.
+- judge score rows are deduped.
+
+## Implementation-Ready Checklist
+
+### Phase 1-2: Runner Resume Core
+
+- [ ] `scripts/run_experiment.sh`
+  - **Task:** Add `SMARTGRID_RUN_ID`, `SMARTGRID_RESUME`,
+    `SMARTGRID_FORCE_RERUN`, and `SMARTGRID_RESUME_REQUIRE_LATENCY`; use the
+    Python helper for trial status and latency-row writes; skip completed
+    trials in resume mode; write atomic temp outputs before final rename.
+  - **Acceptance:** a local synthetic run dir with one complete success, one
+    complete failure, and one partial stdout causes exactly two skips and one
+    rerun; summary counts match terminal JSON state.
+
+- [ ] `scripts/gcp_resume_state.py`
+  - **Task:** New testable helper for trial identity resolution, valid JSON
+    detection, latency-row lookup/dedupe, manifest event writes, and summary
+    inventory support.
+  - **Acceptance:** unit tests cover complete success, complete failure,
+    missing latency, invalid JSON, dangling stdout, duplicate latency rows, and
+    date-prefix changes across restarts.
+
+- [ ] `tests/test_gcp_resume_state.py`
+  - **Task:** Cover the Python helper with temporary run dirs and JSONL sidecars.
+  - **Acceptance:** tests pass without importing torch, vLLM, or external SDKs.
+
+- [ ] `tests/test_run_experiment_summary.py`
+  - **Task:** Extend the existing summary-generation tests for resume-mode
+    fields (`resume_skipped_count`, `resume_rerun_count`) and partial/failure
+    status semantics.
+  - **Acceptance:** summary tests prove skipped terminal failures remain counted
+    as failures and skipped successful trials remain counted as completed.
+
+### Phase 3: GCP Batch Launcher
+
+- [ ] `scripts/run_gcp_context_batch.sh`
+  - **Task:** Add canonical seven-row GCP batch launcher with restart-safe batch
+    state, GCP provenance env, compiler/runtime preflight, resume mode, per-row
+    judge, retained-disk auto-delete preflight, and TSV/JSON manifest.
+  - **Acceptance:** shellcheck/bash syntax passes; dry-run mode writes stable
+    batch state; restart after a completed mock row skips that row.
+
+- [ ] `configs/gcp_context_closeout.tsv`
+  - **Task:** Store the row label/config mapping consumed by the batch launcher
+    instead of hard-coding arrays in multiple places.
+  - **Acceptance:** launcher rejects unknown labels and fails fast if any config
+    path is missing.
+
+### Phase 4: Judge and Score Dedupe
+
+- [ ] `scripts/judge_trajectory.py`
+  - **Task:** Add idempotent `--skip-existing` behavior keyed by
+    `(run_name, scenario_id, trial_index, judge_model)` or delegate that
+    filtering to a shared helper.
+  - **Acceptance:** rerunning judge on the same run dir does not append
+    duplicates by default.
+
+- [ ] `tests/test_judge_trajectory.py`
+  - **Task:** Add focused tests for duplicate score-row detection and forced
+    rejudge behavior.
+  - **Acceptance:** test uses local temp JSONL files and does not call WatsonX.
+
+### Phase 5-6: Artifact Recovery and Docs
+
+- [ ] `scripts/gcp_pull_context_artifacts.sh`
+  - **Task:** Pull run dirs/logs/judge logs from a no-external-IP VM over IAP,
+    stage remote score rows to a temp file, merge only new rows locally, and
+    expose a bounded parallelism flag for larger artifact trees.
+  - **Acceptance:** dry-run prints the exact gcloud scp commands; merge mode
+    dedupes a fixture score file.
+
+- [ ] `docs/gcp_fallback.md`
+  - **Task:** Document resume flags, batch launcher, A100 Spot behavior,
+    `autoDelete=false`, same-zone restart, snapshot/cross-region recovery, and
+    artifact pullback.
+  - **Acceptance:** runbook has one clear operator path for preemption,
+    stockout, cross-region move, and final cleanup.
+
+- [ ] `docs/validation_log.md`
+  - **Task:** After the A100 batch finishes, record the A100 run IDs, provider,
+    zone, hardware, run statuses, and judge outcomes.
+  - **Acceptance:** validation evidence distinguishes Insomnia, L4, and A100
+    captures by provider/hardware metadata.
+
+- [ ] `CHANGELOG.md`
+  - **Task:** Add one bullet for resumable GCP fallback execution and one bullet
+    for idempotent GCP artifact/judge recovery.
+  - **Acceptance:** changelog names behavior, not private tooling.

--- a/docs/plans/gcp-fallback-resume.md
+++ b/docs/plans/gcp-fallback-resume.md
@@ -213,7 +213,7 @@ Expected proof:
 
 ### Phase 1-2: Runner Resume Core
 
-- [ ] `scripts/run_experiment.sh`
+- [x] `scripts/run_experiment.sh`
   - **Task:** Add `SMARTGRID_RUN_ID`, `SMARTGRID_RESUME`,
     `SMARTGRID_FORCE_RERUN`, and `SMARTGRID_RESUME_REQUIRE_LATENCY`; use the
     Python helper for trial status and latency-row writes; skip completed
@@ -222,7 +222,7 @@ Expected proof:
     complete failure, and one partial stdout causes exactly two skips and one
     rerun; summary counts match terminal JSON state.
 
-- [ ] `scripts/gcp_resume_state.py`
+- [x] `scripts/gcp_resume_state.py`
   - **Task:** New testable helper for trial identity resolution, valid JSON
     detection, latency-row lookup/dedupe, manifest event writes, and summary
     inventory support.
@@ -230,11 +230,11 @@ Expected proof:
     missing latency, invalid JSON, dangling stdout, duplicate latency rows, and
     date-prefix changes across restarts.
 
-- [ ] `tests/test_gcp_resume_state.py`
+- [x] `tests/test_gcp_resume_state.py`
   - **Task:** Cover the Python helper with temporary run dirs and JSONL sidecars.
   - **Acceptance:** tests pass without importing torch, vLLM, or external SDKs.
 
-- [ ] `tests/test_run_experiment_summary.py`
+- [x] `tests/test_run_experiment_summary.py`
   - **Task:** Extend the existing summary-generation tests for resume-mode
     fields (`resume_skipped_count`, `resume_rerun_count`) and partial/failure
     status semantics.
@@ -243,14 +243,14 @@ Expected proof:
 
 ### Phase 3: GCP Batch Launcher
 
-- [ ] `scripts/run_gcp_context_batch.sh`
+- [x] `scripts/run_gcp_context_batch.sh`
   - **Task:** Add canonical seven-row GCP batch launcher with restart-safe batch
     state, GCP provenance env, compiler/runtime preflight, resume mode, per-row
     judge, retained-disk auto-delete preflight, and TSV/JSON manifest.
   - **Acceptance:** shellcheck/bash syntax passes; dry-run mode writes stable
     batch state; restart after a completed mock row skips that row.
 
-- [ ] `configs/gcp_context_closeout.tsv`
+- [x] `configs/gcp_context_closeout.tsv`
   - **Task:** Store the row label/config mapping consumed by the batch launcher
     instead of hard-coding arrays in multiple places.
   - **Acceptance:** launcher rejects unknown labels and fails fast if any config
@@ -258,28 +258,28 @@ Expected proof:
 
 ### Phase 4: Judge and Score Dedupe
 
-- [ ] `scripts/judge_trajectory.py`
+- [x] `scripts/judge_trajectory.py`
   - **Task:** Add idempotent `--skip-existing` behavior keyed by
     `(run_name, scenario_id, trial_index, judge_model)` or delegate that
     filtering to a shared helper.
   - **Acceptance:** rerunning judge on the same run dir does not append
     duplicates by default.
 
-- [ ] `tests/test_judge_trajectory.py`
+- [x] `tests/test_judge_trajectory.py`
   - **Task:** Add focused tests for duplicate score-row detection and forced
     rejudge behavior.
   - **Acceptance:** test uses local temp JSONL files and does not call WatsonX.
 
 ### Phase 5-6: Artifact Recovery and Docs
 
-- [ ] `scripts/gcp_pull_context_artifacts.sh`
+- [x] `scripts/gcp_pull_context_artifacts.sh`
   - **Task:** Pull run dirs/logs/judge logs from a no-external-IP VM over IAP,
     stage remote score rows to a temp file, merge only new rows locally, and
     expose a bounded parallelism flag for larger artifact trees.
   - **Acceptance:** dry-run prints the exact gcloud scp commands; merge mode
     dedupes a fixture score file.
 
-- [ ] `docs/gcp_fallback.md`
+- [x] `docs/gcp_fallback.md`
   - **Task:** Document resume flags, batch launcher, A100 Spot behavior,
     `autoDelete=false`, same-zone restart, snapshot/cross-region recovery, and
     artifact pullback.
@@ -292,7 +292,7 @@ Expected proof:
   - **Acceptance:** validation evidence distinguishes Insomnia, L4, and A100
     captures by provider/hardware metadata.
 
-- [ ] `CHANGELOG.md`
+- [x] `CHANGELOG.md`
   - **Task:** Add one bullet for resumable GCP fallback execution and one bullet
     for idempotent GCP artifact/judge recovery.
   - **Acceptance:** changelog names behavior, not private tooling.

--- a/docs/plans/gcp-fallback-resume_spec.md
+++ b/docs/plans/gcp-fallback-resume_spec.md
@@ -1,0 +1,251 @@
+# Spec: GCP fallback resume and artifact recovery
+
+Companion to [gcp-fallback-resume.md](gcp-fallback-resume.md).
+
+## Operating Model
+
+There are two cooperating roles:
+
+- **Runner agent:** owns live cloud resources, monitors active captures, decides
+  whether to restart/stop/move a VM, and pulls artifacts after completion.
+- **Build agent:** implements repo changes and tests. It must not mutate live VM
+  state unless the runner hands over that specific action.
+
+This split matters because a working A100 batch can be more valuable than a tidy
+deployment. Code should land locally first, then the runner decides whether it is
+worth copying to the active VM.
+
+## Resume Contract
+
+### Inputs
+
+`scripts/run_experiment.sh` should accept:
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `SMARTGRID_RUN_ID` | unset | Full run ID to use instead of `${SLURM_JOB_ID:-local-...}_${EXPERIMENT_NAME}`. |
+| `SMARTGRID_RESUME` | `0` | When `1`, inventory existing trial artifacts and skip terminal completed trials. |
+| `SMARTGRID_FORCE_RERUN` | `0` | When `1`, ignore existing artifacts and rerun all trials. |
+| `SMARTGRID_RESUME_REQUIRE_LATENCY` | `1` | Require matching latency row before a trial is considered complete. |
+| `SMARTGRID_BATCH_ID` | unset | Optional outer GCP batch id for manifest grouping. |
+
+Default behavior must remain clean-start compatible with Insomnia Slurm jobs.
+
+### Trial Identity
+
+Canonical identity is:
+
+```text
+(scenario_file, scenario_basename, trial_index)
+```
+
+The current filename contains a date prefix via `RUN_BASENAME`. Resume must not
+depend on that date prefix. If an old completed file matches:
+
+```text
+*_<scenario_basename>_runNN.json
+```
+
+then resume should reuse that path instead of creating a new date-prefixed file.
+Only create a new path when no terminal file for that scenario/trial exists.
+
+### Terminal Trial Definition
+
+A terminal trial JSON is valid when:
+
+1. The file exists and is non-empty.
+2. It parses as a JSON object.
+3. It either already has `scenario`, or can be postprocessed with the scenario
+   payload.
+4. `success` is a bool or can be derived from history/trajectory/answer using
+   the same precedence as the existing runner.
+5. If `SMARTGRID_RESUME_REQUIRE_LATENCY=1`, `latencies.jsonl` contains exactly
+   one matching row for that scenario/trial/output path, or a row can be safely
+   repaired from a stored manifest event.
+
+Both `success=true` and `success=false` are terminal. A failed terminal
+trajectory is not an incomplete trial.
+
+### Incomplete Artifacts
+
+Treat these as incomplete:
+
+- missing trial JSON;
+- zero-byte trial JSON;
+- invalid JSON;
+- dangling `.stdout` without a sibling valid terminal JSON;
+- `.tmp` files;
+- valid JSON with no latency row when latency is required;
+- duplicate conflicting latency rows;
+- output JSON whose scenario/trial identity conflicts with the expected loop
+  identity.
+
+Incomplete artifacts should be preserved for diagnosis and recorded in
+`resume_manifest.jsonl` with `state: "incomplete"`. File renames such as
+`.incomplete.<timestamp>` are optional operator visibility aids; the manifest
+event is the source of truth.
+
+A legacy `.stdout` file beside a valid terminal JSON is not incomplete by
+itself. Older runner captures wrote `.stdout` non-atomically, so the resume
+helper should classify the JSON/latency pair first and only treat stdout as
+dangling when no valid terminal JSON exists for that trial.
+
+## Atomicity
+
+The trial write path should avoid counting half-written files after preemption.
+Recommended sequence:
+
+1. Runner writes raw stdout to `${TRIAL_OUT}.stdout.tmp`.
+2. JSON extractor writes `${TRIAL_OUT}.tmp`.
+3. Postprocess scenario/success into `${TRIAL_OUT}.tmp`.
+4. `mv "${TRIAL_OUT}.tmp" "$TRIAL_OUT"` atomically.
+5. Append/replace one latency row for the trial.
+6. Append manifest event `complete_success` or `complete_failure`.
+
+If preemption lands before step 4, the trial is incomplete. If it lands after
+step 4 but before step 5, the default latency-required policy reruns the trial
+so latency evidence stays usable for the paper. When the pre-latency output is
+recoverable, the manifest should record its content hash and the replacement
+output hash, plus `divergent: true|false|unknown`, so cross-VM or post-upgrade
+reruns remain auditable instead of implying deterministic replay.
+
+## Summary Semantics
+
+`summary.json` should report:
+
+- `scenarios_attempted`: expected scenario x trial count, including skipped
+  completed trials.
+- `scenarios_completed`: terminal trials whose success is true.
+- `failure_count`: terminal trials whose success is false plus missing trials
+  that remain after the run.
+- `resume_skipped_count`: number of terminal trials skipped because resume mode
+  found prior artifacts.
+- `resume_rerun_count`: number of incomplete trials rerun.
+- `run_status`: `success` if no failures, `partial` if at least one pass and at
+  least one failure, `failed` if no passes.
+
+Latency aggregates should be computed from available numeric latency rows only.
+Do not synthesize fake latency for skipped trials.
+
+## Manifest Schema
+
+Per-run manifest: `benchmarks/cell_*/raw/<run-id>/resume_manifest.jsonl`.
+
+Recommended fields:
+
+```json
+{
+  "schema_version": 1,
+  "batch_id": "a100_context_20260503T063343Z",
+  "run_name": "local-...",
+  "event": "trial_complete",
+  "state": "complete_success",
+  "scenario_file": "data/scenarios/multi_01_end_to_end_fault_response.json",
+  "scenario_basename": "multi_01_end_to_end_fault_response",
+  "trial_index": 1,
+  "output_path": "benchmarks/...run01.json",
+  "latency_seconds": 82.4,
+  "return_code": 0,
+  "started_at": "2026-05-03T06:33:55Z",
+  "finished_at": "2026-05-03T06:35:25Z",
+  "compute_provider": "gcp",
+  "compute_zone": "us-central1-a",
+  "compute_instance": "smartgrid-a100-spot-20260503-0217",
+  "gpu_type": "NVIDIA A100-SXM4-40GB"
+}
+```
+
+Outer batch manifest: `logs/gcp_<batch-id>_manifest.tsv` and optional
+`logs/gcp_<batch-id>_manifest.jsonl`.
+
+The TSV is for quick shell reading. JSONL is for reliable tooling.
+
+## Judge Idempotency
+
+Score-row identity:
+
+```text
+(run_name, scenario_id, trial_index, judge_model, judge_prompt_version)
+```
+
+Default rejudge behavior should skip existing identities. Score rows should
+carry `judge_prompt_version` so a stricter rubric or prompt update can coexist
+with the same `judge_model` name. Forced behavior should append replacement rows
+only if the output path or judge config changed, or it should write to a temp
+file and replace rows atomically.
+
+Never merge a remote VM `scenario_scores.jsonl` wholesale into local results
+without filtering by the batch run names and deduping identities.
+
+## Artifact Return
+
+Minimum pull set for each terminal GCP batch:
+
+- batch logs: `logs/gcp_<batch-id>*`;
+- batch launcher used: `logs/run_a100_batch.sh` or the canonical repo launcher;
+- raw run dirs from the batch manifest;
+- `results/judge_logs/<run_name>/`;
+- filtered score rows for run names in the batch manifest;
+- any VM-local setup manifest that records model revision, AOB snapshot, Python,
+  torch, vLLM, CUDA driver, compiler, zone, and GPU.
+
+The canonical source of truth stays the local/team repo. The VM is a worker and
+cache, not the final archive.
+
+## Disk and Region Recovery
+
+Persistent disks are zonal. Recovery options in preference order:
+
+1. **Same VM restart:** cheapest and fastest when Spot capacity returns.
+2. **Same-zone helper VM:** if GPU capacity is full but CPU capacity exists,
+   attach the retained disk read-only or read-write to a CPU helper and copy
+   artifacts out.
+3. **Snapshot to new zone/region:** create a snapshot from the boot disk, create
+   a new disk from that snapshot in the target zone, then create a new VM.
+4. **Local/GCS artifact-first recovery:** if the run has already been pulled
+   back, recreate from the canonical repo plus model cache instead of moving
+   the disk.
+
+Do not assume `autoDelete=false` makes cross-region recovery automatic. It only
+prevents the disk from disappearing when the VM is stopped/deleted.
+
+## Preemption and Health
+
+The immediate deadline path can rely on retained disk plus manual restart, but
+the implementation should leave room for:
+
+- metadata polling of `instance/preempted`;
+- a heartbeat JSON that records current row/scenario/trial;
+- status markers such as `RUNNING`, `PREEMPTED`, `FINISHED`, `FAILED`;
+- restart config with the same batch id and same run IDs;
+- stale heartbeat detection.
+
+These are proven patterns in our local cloud helper code. The public contract in
+this repo is the artifact/status shape, not the private implementation lineage.
+
+## Compiler and Runtime Preflight
+
+Every GCP GPU capture launcher should check:
+
+- `nvidia-smi` sees exactly one expected GPU;
+- Python is 3.11 through `.venv-insomnia`;
+- `torch.cuda.is_available()` is true;
+- `vllm` imports;
+- `g++` and `cc1plus` exist for FlashInfer JIT;
+- `HF_TOKEN`, `WANDB_API_KEY` when enabled, and WatsonX judge credentials when
+  judging are present through `.env` or environment;
+- model paths exist for FP16 and INT8 configs;
+- AOB sibling snapshot exists and is the intended commit/branch.
+
+Fail before launching vLLM when any of these are missing.
+
+## Open Decisions
+
+1. Whether to make `SMARTGRID_RESUME_REQUIRE_LATENCY=1` permanently strict or
+   allow a deadline override that skips completed JSON even without latency.
+2. Whether to introduce optional GCS artifact staging now or keep IAP SCP only
+   until after May 6.
+3. Whether A100 evidence should become a separate validation-log section or a
+   hardware-comparison subsection under the L4 GCP fallback closeout.
+4. Whether the seven-row context cohort should remain a hard-coded TSV or be
+   generated from the experiment matrix once the matrix is fully canonical.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # scripts/
 
-*Last updated: 2026-05-01*
+*Last updated: 2026-05-03*
 
 Executable entrypoints and helper utilities for the repo. If you know roughly
 what you want to do but not which command to run, start here.
@@ -10,6 +10,7 @@ what you want to do but not which command to run, start here.
 | Script | Use it when… | Notes |
 |---|---|---|
 | [run_experiment.sh](run_experiment.sh) | You want to run a benchmark cell or smoke config on the canonical SmartGridBench path | Main entrypoint for Plan-Execute, PE + Self-Ask, and Verified PE runs |
+| [run_gcp_context_batch.sh](run_gcp_context_batch.sh) | You need to resume or close out the GCP context-window cohort | Reads [../configs/gcp_context_closeout.tsv](../configs/gcp_context_closeout.tsv), sets stable run IDs, and writes batch manifests |
 | [setup_insomnia.sh](setup_insomnia.sh) | You need to bootstrap or refresh the shared Insomnia environment | Cluster-oriented setup script; read [../docs/insomnia_runbook.md](../docs/insomnia_runbook.md) first |
 | [vllm_serve.sh](vllm_serve.sh) | You want to launch the local vLLM server directly | Pairs with [test_inference.sh](test_inference.sh) |
 | [test_inference.sh](test_inference.sh) | You want a quick sanity check against a live vLLM endpoint | Useful after serving changes or model swaps |
@@ -37,6 +38,8 @@ what you want to do but not which command to run, start here.
 | Script | Purpose |
 |---|---|
 | [judge_trajectory.py](judge_trajectory.py) | LLM-as-Judge scoring helper for trajectory artifacts |
+| [gcp_resume_state.py](gcp_resume_state.py) | Resume-state helper used by `run_experiment.sh` for trial classification, manifest events, and latency-row upserts |
+| [gcp_pull_context_artifacts.sh](gcp_pull_context_artifacts.sh) | Pull GCP context-batch artifacts over IAP and merge judge score rows without duplicates |
 | [tmux_watch_run.sh](tmux_watch_run.sh) | Convenience watcher for long-running jobs or logs |
 
 ## Related indexes

--- a/scripts/gcp_pull_context_artifacts.sh
+++ b/scripts/gcp_pull_context_artifacts.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Pull GCP context-batch artifacts over IAP and merge judge score rows safely.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+INSTANCE="${SMARTGRID_COMPUTE_INSTANCE:-}"
+ZONE="${SMARTGRID_COMPUTE_ZONE:-}"
+BATCH_ID="${SMARTGRID_BATCH_ID:-}"
+REMOTE_ROOT="${REMOTE_ROOT:-~/hpml-assetopsbench-smart-grid-mcp}"
+DEST_ROOT="${DEST_ROOT:-gcp_artifacts}"
+PARALLEL="${PARALLEL:-2}"
+DRY_RUN="${DRY_RUN:-0}"
+MERGE_SCORES=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/gcp_pull_context_artifacts.sh --instance NAME --zone ZONE --batch-id ID [--dest DIR] [--parallel N] [--dry-run]
+       scripts/gcp_pull_context_artifacts.sh --merge-scores PATH
+
+Pull order is small-first: batch manifests/logs, score file, judge logs, then
+raw run directories listed in the batch manifest. Score rows merge by
+(run_name, scenario_id, trial_index, judge_model, judge_prompt_version).
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --instance) INSTANCE="$2"; shift 2 ;;
+    --zone) ZONE="$2"; shift 2 ;;
+    --batch-id) BATCH_ID="$2"; shift 2 ;;
+    --remote-root) REMOTE_ROOT="$2"; shift 2 ;;
+    --dest) DEST_ROOT="$2"; shift 2 ;;
+    --parallel) PARALLEL="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --merge-scores) MERGE_SCORES="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+merge_scores() {
+  local incoming="$1"
+  local target="${2:-results/metrics/scenario_scores.jsonl}"
+  python3 - "$incoming" "$target" <<'PY'
+import json
+import pathlib
+import sys
+
+incoming = pathlib.Path(sys.argv[1])
+target = pathlib.Path(sys.argv[2])
+prompt_default = "assetopsbench-6d-v1"
+
+def key(row):
+    return (
+        row.get("run_name"),
+        row.get("scenario_id"),
+        row.get("trial_index"),
+        row.get("judge_model"),
+        row.get("judge_prompt_version") or prompt_default,
+    )
+
+rows = []
+seen = set()
+if target.exists():
+    for line in target.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        rows.append(row)
+        seen.add(key(row))
+added = 0
+for line in incoming.read_text(encoding="utf-8").splitlines():
+    if not line.strip():
+        continue
+    row = json.loads(line)
+    k = key(row)
+    if k in seen:
+        continue
+    rows.append(row)
+    seen.add(k)
+    added += 1
+target.parent.mkdir(parents=True, exist_ok=True)
+tmp = target.with_suffix(target.suffix + ".tmp")
+tmp.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+tmp.replace(target)
+print(f"merged {added} new score row(s) into {target}")
+PY
+}
+
+if [ -n "$MERGE_SCORES" ]; then
+  merge_scores "$MERGE_SCORES"
+  exit 0
+fi
+
+if [ -z "$INSTANCE" ] || [ -z "$ZONE" ] || [ -z "$BATCH_ID" ]; then
+  usage >&2
+  exit 2
+fi
+if ! [[ "$PARALLEL" =~ ^[0-9]+$ ]] || [ "$PARALLEL" -lt 1 ]; then
+  echo "ERROR: --parallel must be a positive integer" >&2
+  exit 2
+fi
+
+DEST_DIR="$DEST_ROOT/$BATCH_ID"
+mkdir -p "$DEST_DIR/logs" "$DEST_DIR/results"
+
+scp_cmd() {
+  printf 'gcloud compute scp --tunnel-through-iap --zone %q %q:%q %q\n' \
+    "$ZONE" "$INSTANCE" "$1" "$2"
+}
+
+run_scp() {
+  local remote="$1" dest="$2"
+  if [ "$DRY_RUN" = "1" ]; then
+    scp_cmd "$remote" "$dest"
+    return 0
+  fi
+  gcloud compute scp --tunnel-through-iap --zone "$ZONE" "$INSTANCE:$remote" "$dest"
+}
+
+# Small files first so operators quickly get enough state to make decisions.
+run_scp "$REMOTE_ROOT/logs/gcp_${BATCH_ID}_manifest.tsv" "$DEST_DIR/logs/" || true
+run_scp "$REMOTE_ROOT/logs/gcp_${BATCH_ID}_manifest.jsonl" "$DEST_DIR/logs/" || true
+run_scp "$REMOTE_ROOT/logs/gcp_${BATCH_ID}_state.tsv" "$DEST_DIR/logs/" || true
+run_scp "$REMOTE_ROOT/results/metrics/scenario_scores.jsonl" "$DEST_DIR/results/scenario_scores.remote.jsonl" || true
+
+manifest="$DEST_DIR/logs/gcp_${BATCH_ID}_manifest.tsv"
+if [ "$DRY_RUN" = "1" ]; then
+  if [ ! -s "$manifest" ]; then
+    echo "# Raw run dirs are read from $manifest when present."
+    exit 0
+  fi
+  awk -F'\t' 'NR > 1 && $4 { print $4 }' "$manifest" | sort -u | while IFS= read -r run_dir; do
+    [ -n "$run_dir" ] || continue
+    scp_cmd "$REMOTE_ROOT/$run_dir" "$DEST_DIR/"
+    scp_cmd "$REMOTE_ROOT/results/judge_logs/$(basename "$run_dir")" "$DEST_DIR/results/judge_logs/"
+  done
+  exit 0
+fi
+
+if [ -s "$DEST_DIR/results/scenario_scores.remote.jsonl" ]; then
+  merge_scores "$DEST_DIR/results/scenario_scores.remote.jsonl"
+fi
+
+if [ ! -s "$manifest" ]; then
+  echo "WARNING: manifest not found after pull: $manifest" >&2
+  exit 0
+fi
+
+export SMARTGRID_COMPUTE_ZONE="$ZONE"
+export SMARTGRID_COMPUTE_INSTANCE="$INSTANCE"
+
+awk -F'\t' 'NR > 1 && $4 { print $4 }' "$manifest" | sort -u | while IFS= read -r run_dir; do
+  [ -n "$run_dir" ] || continue
+  printf '%s\t%s\n' "$REMOTE_ROOT/$run_dir" "$DEST_DIR/"
+  printf '%s\t%s\n' "$REMOTE_ROOT/results/judge_logs/$(basename "$run_dir")" "$DEST_DIR/results/judge_logs/"
+done | xargs -n 2 -P "$PARALLEL" sh -c '
+  remote="$1"; dest="$2"
+  mkdir -p "$dest"
+  gcloud compute scp --recurse --tunnel-through-iap --zone "$SMARTGRID_COMPUTE_ZONE" "$SMARTGRID_COMPUTE_INSTANCE:$remote" "$dest" || true
+' sh

--- a/scripts/gcp_resume_state.py
+++ b/scripts/gcp_resume_state.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Resume-state helpers for SmartGridBench GCP fallback runs.
+
+The shell runner owns process orchestration. This helper owns the fiddly,
+testable parts of resume: trial classification, latency-row dedupe, atomic
+finalization, and manifest events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _posix(path: Path | str) -> str:
+    return Path(path).as_posix()
+
+
+def _norm(path: Path | str) -> str:
+    return os.path.normpath(_posix(path))
+
+
+def _shell_bool(value: bool) -> str:
+    return "1" if value else "0"
+
+
+def _emit_shell(values: dict[str, Any]) -> None:
+    for key, value in values.items():
+        print(f"{key}={shlex.quote(str(value))}")
+
+
+def _load_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return None, "missing_json"
+    try:
+        if path.stat().st_size == 0:
+            return None, "zero_byte_json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None, "invalid_json"
+    except OSError as exc:
+        return None, f"read_error:{exc}"
+    if not isinstance(payload, dict):
+        return None, "non_object_json"
+    return payload, None
+
+
+def _scenario_payload(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"scenario is not a JSON object: {path}")
+    return payload
+
+
+def _scenario_basename(path: Path) -> str:
+    return path.stem
+
+
+def _step_failed(step: dict[str, Any]) -> bool:
+    if step.get("success") is False:
+        return True
+    if step.get("error"):
+        return True
+    response = step.get("response")
+    return isinstance(response, dict) and bool(response.get("error"))
+
+
+def derive_success(data: dict[str, Any]) -> bool | None:
+    raw = data.get("success")
+    if isinstance(raw, bool):
+        return raw
+    steps = data.get("history") or data.get("trajectory") or []
+    if not steps and not data.get("answer"):
+        return None
+    for step in steps:
+        if isinstance(step, dict) and _step_failed(step):
+            return False
+    return bool(data.get("answer"))
+
+
+def _scenario_id_matches(
+    payload: dict[str, Any],
+    scenario: dict[str, Any],
+) -> bool:
+    embedded = payload.get("scenario")
+    if not isinstance(embedded, dict):
+        return True
+    expected_id = scenario.get("id")
+    actual_id = embedded.get("id")
+    return not expected_id or not actual_id or expected_id == actual_id
+
+
+def _latency_records(latency_file: Path) -> list[dict[str, Any]]:
+    if not latency_file.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in latency_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
+def _record_matches_identity(
+    record: dict[str, Any],
+    scenario_file: Path,
+    trial_index: int,
+    output_path: Path,
+) -> bool:
+    if int(record.get("trial_index", -1)) != int(trial_index):
+        return False
+    output = record.get("output_path")
+    if output and _norm(output) != _norm(output_path):
+        return False
+    scenario = record.get("scenario_file")
+    return not scenario or _norm(scenario) == _norm(scenario_file)
+
+
+def _matching_latency_rows(
+    records: list[dict[str, Any]],
+    scenario_file: Path,
+    trial_index: int,
+    output_path: Path,
+) -> list[dict[str, Any]]:
+    return [
+        record
+        for record in records
+        if _record_matches_identity(record, scenario_file, trial_index, output_path)
+    ]
+
+
+def _rows_conflict(rows: list[dict[str, Any]]) -> bool:
+    if len(rows) < 2:
+        return False
+    normalized = {
+        json.dumps(row, sort_keys=True, separators=(",", ":")) for row in rows
+    }
+    return len(normalized) > 1
+
+
+def _candidate_trial_paths(
+    run_dir: Path,
+    scenario_file: Path,
+    trial_index: int,
+    output_path: Path,
+) -> list[Path]:
+    run_label = f"{_scenario_basename(scenario_file)}_run{trial_index:02d}.json"
+    candidates = [output_path]
+    candidates.extend(sorted(run_dir.glob(f"*_{run_label}")))
+    seen: set[str] = set()
+    deduped: list[Path] = []
+    for candidate in candidates:
+        key = str(candidate)
+        if key not in seen:
+            deduped.append(candidate)
+            seen.add(key)
+    return deduped
+
+
+def classify_trial(
+    *,
+    run_dir: Path,
+    scenario_file: Path,
+    trial_index: int,
+    output_path: Path,
+    latency_file: Path,
+    require_latency: bool,
+) -> dict[str, Any]:
+    scenario = _scenario_payload(scenario_file)
+    latency_records = _latency_records(latency_file)
+    incomplete_reasons: list[str] = []
+    saw_candidate = False
+
+    for candidate in _candidate_trial_paths(
+        run_dir, scenario_file, trial_index, output_path
+    ):
+        if not candidate.exists():
+            continue
+        saw_candidate = True
+        payload, error = _load_json_object(candidate)
+        if error is not None or payload is None:
+            incomplete_reasons.append(error or "invalid_json")
+            continue
+        if not _scenario_id_matches(payload, scenario):
+            incomplete_reasons.append("scenario_identity_conflict")
+            continue
+        success = derive_success(payload)
+        if success is None:
+            incomplete_reasons.append("success_not_derivable")
+            continue
+        rows = _matching_latency_rows(
+            latency_records, scenario_file, trial_index, candidate
+        )
+        if require_latency:
+            if not rows:
+                incomplete_reasons.append("missing_latency")
+                continue
+            if _rows_conflict(rows):
+                incomplete_reasons.append("duplicate_conflicting_latency")
+                continue
+        return {
+            "state": "complete_success" if success else "complete_failure",
+            "complete": True,
+            "success": success,
+            "output_path": _posix(candidate),
+            "reason": "terminal_trial",
+            "latency_rows": len(rows),
+        }
+
+    stdout_candidates = [
+        path
+        for path in run_dir.glob(
+            f"*_{_scenario_basename(scenario_file)}_run{trial_index:02d}.json.stdout"
+        )
+        if path.exists()
+    ]
+    if stdout_candidates and not saw_candidate:
+        incomplete_reasons.append("dangling_stdout")
+
+    return {
+        "state": "incomplete",
+        "complete": False,
+        "success": False,
+        "output_path": _posix(output_path),
+        "reason": ",".join(sorted(set(incomplete_reasons))) or "missing_json",
+        "latency_rows": 0,
+    }
+
+
+def _sha256(path: Path) -> str | None:
+    if not path.exists() or not path.is_file():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_manifest_event(
+    *,
+    manifest_file: Path,
+    state: str,
+    scenario_file: Path,
+    trial_index: int,
+    output_path: Path,
+    run_name: str,
+    reason: str = "",
+    batch_id: str = "",
+    latency_seconds: float | None = None,
+    return_code: int | None = None,
+    started_at: str = "",
+    finished_at: str = "",
+    extra: dict[str, Any] | None = None,
+) -> None:
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "batch_id": batch_id or None,
+        "run_name": run_name,
+        "event": "trial_resume_state",
+        "state": state,
+        "reason": reason or None,
+        "scenario_file": _posix(scenario_file),
+        "scenario_basename": _scenario_basename(scenario_file),
+        "trial_index": int(trial_index),
+        "output_path": _posix(output_path),
+        "latency_seconds": latency_seconds,
+        "return_code": return_code,
+        "started_at": started_at or None,
+        "finished_at": finished_at or _now_iso(),
+        "compute_provider": os.environ.get("SMARTGRID_COMPUTE_PROVIDER"),
+        "compute_zone": os.environ.get("SMARTGRID_COMPUTE_ZONE"),
+        "compute_instance": os.environ.get("SMARTGRID_COMPUTE_INSTANCE"),
+        "gpu_type": os.environ.get("GPU_TYPE"),
+    }
+    if extra:
+        payload.update(extra)
+    with manifest_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def preserve_incomplete_output(output_path: Path) -> Path | None:
+    if not output_path.exists():
+        return None
+    suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    preserved = output_path.with_name(f"{output_path.name}.incomplete.{suffix}")
+    output_path.replace(preserved)
+    return preserved
+
+
+def _apply_final_answer_guards(payload: dict[str, Any]) -> None:
+    try:
+        from scripts.mitigation_guards import (  # type: ignore
+            apply_explicit_fault_risk_adjudication,
+            apply_missing_evidence_final_answer_guard,
+            env_flag_enabled,
+        )
+    except ImportError:
+        return
+    apply_missing_evidence_final_answer_guard(
+        payload,
+        enabled=env_flag_enabled(os.environ.get("ENABLE_MISSING_EVIDENCE_GUARD")),
+    )
+    if "fault_risk_adjudication" not in payload:
+        apply_explicit_fault_risk_adjudication(
+            payload,
+            enabled=env_flag_enabled(
+                os.environ.get("ENABLE_EXPLICIT_FAULT_RISK_ADJUDICATION")
+            ),
+        )
+
+
+def _upsert_latency_row(
+    *,
+    latency_file: Path,
+    scenario_file: Path,
+    trial_index: int,
+    output_path: Path,
+    latency_seconds: float,
+) -> None:
+    records = [
+        row
+        for row in _latency_records(latency_file)
+        if not _record_matches_identity(row, scenario_file, trial_index, output_path)
+    ]
+    records.append(
+        {
+            "scenario_file": _posix(scenario_file),
+            "trial_index": int(trial_index),
+            "latency_seconds": latency_seconds,
+            "output_path": _posix(output_path),
+        }
+    )
+    latency_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = latency_file.with_suffix(latency_file.suffix + ".tmp")
+    tmp.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    tmp.replace(latency_file)
+
+
+def finalize_trial(
+    *,
+    scenario_file: Path,
+    trial_index: int,
+    temp_output: Path,
+    output_path: Path,
+    latency_file: Path,
+    manifest_file: Path,
+    run_name: str,
+    batch_id: str,
+    start_epoch: float,
+    end_epoch: float,
+    return_code: int,
+) -> dict[str, Any]:
+    payload, error = _load_json_object(temp_output)
+    if error is not None or payload is None:
+        write_manifest_event(
+            manifest_file=manifest_file,
+            state="incomplete",
+            scenario_file=scenario_file,
+            trial_index=trial_index,
+            output_path=output_path,
+            run_name=run_name,
+            reason=error or "invalid_json",
+            batch_id=batch_id,
+            return_code=return_code,
+        )
+        return {
+            "state": "incomplete",
+            "success": False,
+            "reason": error or "invalid_json",
+        }
+
+    scenario = _scenario_payload(scenario_file)
+    payload["scenario"] = scenario
+    _apply_final_answer_guards(payload)
+    success = derive_success(payload)
+    if success is None:
+        write_manifest_event(
+            manifest_file=manifest_file,
+            state="incomplete",
+            scenario_file=scenario_file,
+            trial_index=trial_index,
+            output_path=output_path,
+            run_name=run_name,
+            reason="success_not_derivable",
+            batch_id=batch_id,
+            return_code=return_code,
+        )
+        return {
+            "state": "incomplete",
+            "success": False,
+            "reason": "success_not_derivable",
+        }
+    payload["success"] = success
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_output.write_text(
+        json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8"
+    )
+    original_hash = _sha256(output_path)
+    temp_hash = _sha256(temp_output)
+    temp_output.replace(output_path)
+    divergent: bool | None
+    if original_hash is None:
+        divergent = None
+    else:
+        divergent = original_hash != temp_hash
+    latency_seconds = float(end_epoch) - float(start_epoch)
+    _upsert_latency_row(
+        latency_file=latency_file,
+        scenario_file=scenario_file,
+        trial_index=trial_index,
+        output_path=output_path,
+        latency_seconds=latency_seconds,
+    )
+    state = "complete_success" if success else "complete_failure"
+    write_manifest_event(
+        manifest_file=manifest_file,
+        state=state,
+        scenario_file=scenario_file,
+        trial_index=trial_index,
+        output_path=output_path,
+        run_name=run_name,
+        reason="trial_executed",
+        batch_id=batch_id,
+        latency_seconds=latency_seconds,
+        return_code=return_code,
+        extra={
+            "original_output_sha256": original_hash,
+            "final_output_sha256": temp_hash,
+            "divergent": divergent,
+        },
+    )
+    return {"state": state, "success": success, "reason": "trial_executed"}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("trial-status-shell")
+    status.add_argument("--run-dir", required=True, type=Path)
+    status.add_argument("--scenario-file", required=True, type=Path)
+    status.add_argument("--trial-index", required=True, type=int)
+    status.add_argument("--output-path", required=True, type=Path)
+    status.add_argument("--latency-file", required=True, type=Path)
+    status.add_argument("--require-latency", action="store_true")
+
+    preserve = sub.add_parser("preserve-incomplete")
+    preserve.add_argument("--output-path", required=True, type=Path)
+    preserve.add_argument("--manifest-file", required=True, type=Path)
+    preserve.add_argument("--scenario-file", required=True, type=Path)
+    preserve.add_argument("--trial-index", required=True, type=int)
+    preserve.add_argument("--run-name", required=True)
+    preserve.add_argument("--batch-id", default="")
+    preserve.add_argument("--reason", default="rerun_preserved_incomplete")
+
+    finalize = sub.add_parser("finalize-trial-shell")
+    finalize.add_argument("--scenario-file", required=True, type=Path)
+    finalize.add_argument("--trial-index", required=True, type=int)
+    finalize.add_argument("--temp-output", required=True, type=Path)
+    finalize.add_argument("--output-path", required=True, type=Path)
+    finalize.add_argument("--latency-file", required=True, type=Path)
+    finalize.add_argument("--manifest-file", required=True, type=Path)
+    finalize.add_argument("--run-name", required=True)
+    finalize.add_argument("--batch-id", default="")
+    finalize.add_argument("--start-epoch", required=True, type=float)
+    finalize.add_argument("--end-epoch", required=True, type=float)
+    finalize.add_argument("--return-code", required=True, type=int)
+
+    event = sub.add_parser("manifest-event")
+    event.add_argument("--manifest-file", required=True, type=Path)
+    event.add_argument("--state", required=True)
+    event.add_argument("--scenario-file", required=True, type=Path)
+    event.add_argument("--trial-index", required=True, type=int)
+    event.add_argument("--output-path", required=True, type=Path)
+    event.add_argument("--run-name", required=True)
+    event.add_argument("--reason", default="")
+    event.add_argument("--batch-id", default="")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    if args.command == "trial-status-shell":
+        result = classify_trial(
+            run_dir=args.run_dir,
+            scenario_file=args.scenario_file,
+            trial_index=args.trial_index,
+            output_path=args.output_path,
+            latency_file=args.latency_file,
+            require_latency=args.require_latency,
+        )
+        _emit_shell(
+            {
+                "RESUME_STATE": result["state"],
+                "RESUME_COMPLETE": _shell_bool(bool(result["complete"])),
+                "RESUME_SUCCESS": _shell_bool(bool(result["success"])),
+                "RESUME_OUTPUT_PATH": result["output_path"],
+                "RESUME_REASON": result["reason"],
+            }
+        )
+        return
+    if args.command == "preserve-incomplete":
+        preserved = preserve_incomplete_output(args.output_path)
+        if preserved is not None:
+            write_manifest_event(
+                manifest_file=args.manifest_file,
+                state="incomplete",
+                scenario_file=args.scenario_file,
+                trial_index=args.trial_index,
+                output_path=preserved,
+                run_name=args.run_name,
+                reason=args.reason,
+                batch_id=args.batch_id,
+            )
+        return
+    if args.command == "finalize-trial-shell":
+        result = finalize_trial(
+            scenario_file=args.scenario_file,
+            trial_index=args.trial_index,
+            temp_output=args.temp_output,
+            output_path=args.output_path,
+            latency_file=args.latency_file,
+            manifest_file=args.manifest_file,
+            run_name=args.run_name,
+            batch_id=args.batch_id,
+            start_epoch=args.start_epoch,
+            end_epoch=args.end_epoch,
+            return_code=args.return_code,
+        )
+        _emit_shell(
+            {
+                "FINAL_STATE": result["state"],
+                "FINAL_SUCCESS": _shell_bool(bool(result["success"])),
+                "FINAL_REASON": result["reason"],
+            }
+        )
+        return
+    if args.command == "manifest-event":
+        write_manifest_event(
+            manifest_file=args.manifest_file,
+            state=args.state,
+            scenario_file=args.scenario_file,
+            trial_index=args.trial_index,
+            output_path=args.output_path,
+            run_name=args.run_name,
+            reason=args.reason,
+            batch_id=args.batch_id,
+        )
+        return
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"gcp_resume_state: ERROR: {exc}", file=sys.stderr)
+        raise

--- a/scripts/gcp_resume_state.py
+++ b/scripts/gcp_resume_state.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.metadata
 import json
 import os
+import re
 import shlex
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -42,6 +45,72 @@ def _shell_bool(value: bool) -> str:
 def _emit_shell(values: dict[str, Any]) -> None:
     for key, value in values.items():
         print(f"{key}={shlex.quote(str(value))}")
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _command_output(args: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(
+            args,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+        ).strip()
+    except Exception:
+        return None
+
+
+def collect_runtime_versions() -> dict[str, Any]:
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    gpu_id = (cuda_visible or "0").split(",")[0].strip() or "0"
+    versions: dict[str, Any] = {
+        "vllm_version": _package_version("vllm"),
+        "torch_version": _package_version("torch"),
+        "cuda_visible_devices": cuda_visible,
+        "nvidia_driver_version": None,
+        "cuda_version": None,
+        "nvidia_smi_query": None,
+    }
+    raw = _command_output(
+        [
+            "nvidia-smi",
+            f"--id={gpu_id}",
+            "--query-gpu=driver_version,cuda_version",
+            "--format=csv,noheader",
+        ]
+    )
+    if raw:
+        versions["nvidia_smi_query"] = raw
+        first_row = raw.splitlines()[0]
+        parts = [part.strip() for part in first_row.split(",")]
+        if parts:
+            versions["nvidia_driver_version"] = parts[0] or None
+        if len(parts) > 1:
+            versions["cuda_version"] = parts[1] or None
+    if versions["nvidia_driver_version"] is None:
+        driver = _command_output(
+            [
+                "nvidia-smi",
+                f"--id={gpu_id}",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader",
+            ]
+        )
+        if driver:
+            versions["nvidia_driver_version"] = driver.splitlines()[0].strip() or None
+    if versions["cuda_version"] is None:
+        smi = _command_output(["nvidia-smi"])
+        if smi:
+            match = re.search(r"CUDA Version:\s*([0-9.]+)", smi)
+            if match:
+                versions["cuda_version"] = match.group(1)
+    return versions
 
 
 def _load_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
@@ -293,6 +362,7 @@ def write_manifest_event(
         "compute_zone": os.environ.get("SMARTGRID_COMPUTE_ZONE"),
         "compute_instance": os.environ.get("SMARTGRID_COMPUTE_INSTANCE"),
         "gpu_type": os.environ.get("GPU_TYPE"),
+        "runtime_versions": collect_runtime_versions(),
     }
     if extra:
         payload.update(extra)

--- a/scripts/judge_trajectory.py
+++ b/scripts/judge_trajectory.py
@@ -140,6 +140,8 @@ _BOOLEAN_DIMS = [
 
 _DEFAULT_JUDGE_MODEL = "watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
 _PASS_THRESHOLD = 0.6  # 4 out of 6 dimensions
+# Bump whenever the judge rubric, prompt template, or scoring dimensions change.
+# Existing rows dedupe by this value unless callers pass --force.
 _JUDGE_PROMPT_VERSION = "assetopsbench-6d-v1"
 
 

--- a/scripts/judge_trajectory.py
+++ b/scripts/judge_trajectory.py
@@ -140,6 +140,7 @@ _BOOLEAN_DIMS = [
 
 _DEFAULT_JUDGE_MODEL = "watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
 _PASS_THRESHOLD = 0.6  # 4 out of 6 dimensions
+_JUDGE_PROMPT_VERSION = "assetopsbench-6d-v1"
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +438,7 @@ def score_trajectory(
         "mcp_mode": _classifier("mcp_mode", "baseline"),
         "model_id": _classifier("model_id", ""),
         "judge_model": judge_model,
+        "judge_prompt_version": _JUDGE_PROMPT_VERSION,
         # 6 rubric dimensions (from AssetOpsBench evaluation_agent)
         "dim_task_completion": dims["task_completion"],
         "dim_data_retrieval_accuracy": dims["data_retrieval_accuracy"],
@@ -484,6 +486,53 @@ def score_trajectory(
         print(f"  Judge log saved → {log_file}", file=sys.stderr)
 
     return record
+
+
+def _score_identity(
+    trajectory_path: Path,
+    scenario_path: Path,
+    meta_path: Path | None,
+    judge_model: str,
+) -> tuple[str, str, int, str, str]:
+    """Return the idempotency key for a would-be score row."""
+    meta_data = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path else {}
+    scenario_data = json.loads(scenario_path.read_text(encoding="utf-8"))
+    return (
+        meta_data.get("run_name", trajectory_path.parent.name),
+        scenario_data.get("id", ""),
+        _extract_trial_index(trajectory_path),
+        judge_model,
+        _JUDGE_PROMPT_VERSION,
+    )
+
+
+def _existing_score_keys(out_path: Path) -> set[tuple[str, str, int, str, str]]:
+    """Load existing judge-row identities, tolerating legacy rows."""
+    if not out_path.exists():
+        return set()
+    keys: set[tuple[str, str, int, str, str]] = set()
+    for line in out_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        try:
+            keys.add(
+                (
+                    str(row.get("run_name", "")),
+                    str(row.get("scenario_id", "")),
+                    int(row.get("trial_index", 0)),
+                    str(row.get("judge_model", "")),
+                    str(row.get("judge_prompt_version") or _JUDGE_PROMPT_VERSION),
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return keys
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +608,11 @@ def _build_parser() -> argparse.ArgumentParser:
             "If set, save a full judge audit log (prompt + raw response + dims) to "
             "LOG_DIR/<run_name>/<scenario_id>_runNN_judge_log.json"
         ),
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-score rows even when the idempotency key already exists.",
     )
     return p
 
@@ -658,6 +712,24 @@ def main() -> None:
         # Single-file mode
         if not args.scenario:
             sys.exit("--scenario is required when using --trajectory")
+        identity = _score_identity(
+            args.trajectory,
+            args.scenario,
+            args.run_meta,
+            args.judge_model,
+        )
+        if not args.force and identity in _existing_score_keys(args.out):
+            print(
+                json.dumps(
+                    {
+                        "skipped": True,
+                        "reason": "existing_score",
+                        "identity": identity,
+                    },
+                    indent=2,
+                )
+            )
+            return
         record = score_trajectory(
             trajectory_path=args.trajectory,
             scenario_path=args.scenario,
@@ -676,6 +748,8 @@ def main() -> None:
             meta_path = None
 
         scored = 0
+        skipped = 0
+        existing_keys = _existing_score_keys(args.out)
         for traj_file in sorted(args.run_dir.glob("*.json")):
             if not _is_trajectory_file(traj_file):
                 continue
@@ -685,6 +759,16 @@ def main() -> None:
                     f"  [warn] could not find scenario for {traj_file.name}, skipping",
                     file=sys.stderr,
                 )
+                continue
+            identity = _score_identity(
+                traj_file,
+                scenario_path,
+                meta_path,
+                args.judge_model,
+            )
+            if not args.force and identity in existing_keys:
+                print(f"Skipping {traj_file.name}: existing score row")
+                skipped += 1
                 continue
             print(
                 f"Scoring {traj_file.name} against {scenario_path.name}...",
@@ -699,9 +783,12 @@ def main() -> None:
                 log_dir=args.log_dir,
             )
             print(f"  score_6d={record['score_6d']}  pass={record['pass']}")
+            existing_keys.add(identity)
             scored += 1
 
-        print(f"\nScored {scored} trajectory file(s). Output: {args.out}")
+        print(
+            f"\nScored {scored} trajectory file(s), skipped {skipped}. Output: {args.out}"
+        )
         return
 
     _build_parser().print_help()

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -83,6 +83,13 @@ ENABLE_WANDB="${ENABLE_WANDB:-0}"
 WANDB_PROJECT="${WANDB_PROJECT:-assetopsbench-smartgrid}"
 WANDB_ENTITY="${WANDB_ENTITY:-assetopsbench-smartgrid}"
 WANDB_MODE="${WANDB_MODE:-online}"
+SMARTGRID_RUN_ID="${SMARTGRID_RUN_ID:-}"
+SMARTGRID_RESUME="${SMARTGRID_RESUME:-0}"
+SMARTGRID_FORCE_RERUN="${SMARTGRID_FORCE_RERUN:-0}"
+SMARTGRID_RESUME_REQUIRE_LATENCY="${SMARTGRID_RESUME_REQUIRE_LATENCY:-1}"
+SMARTGRID_BATCH_ID="${SMARTGRID_BATCH_ID:-}"
+export SMARTGRID_RUN_ID SMARTGRID_RESUME SMARTGRID_FORCE_RERUN
+export SMARTGRID_RESUME_REQUIRE_LATENCY SMARTGRID_BATCH_ID
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-32768}"
 VLLM_PORT="${VLLM_PORT:-8000}"
 VLLM_MODEL_PATH="${VLLM_MODEL_PATH:-models/Llama-3.1-8B-Instruct}"
@@ -194,7 +201,7 @@ PY
 DATE_TAG="$(date +%Y-%m-%d)"
 MODEL_SHORT="$(model_short_name "$MODEL_ID")"
 RUN_BASENAME="${DATE_TAG}_${EXPERIMENT_CELL}_${MODEL_SHORT}_${ORCHESTRATION}_${MCP_MODE}"
-RUN_ID="${SLURM_JOB_ID:-local-$(date +%Y%m%d-%H%M%S)}_${EXPERIMENT_NAME}"
+RUN_ID="${SMARTGRID_RUN_ID:-${SLURM_JOB_ID:-local-$(date +%Y%m%d-%H%M%S)}_${EXPERIMENT_NAME}}"
 CELL_DIR="benchmarks/$(cell_dir_name "$EXPERIMENT_CELL")"
 RAW_DIR="$CELL_DIR/raw"
 RUN_DIR="$RAW_DIR/$RUN_ID"
@@ -206,6 +213,7 @@ META_FILE="$RUN_DIR/meta.json"
 VLLM_LOG="$RUN_DIR/vllm.log"
 HARNESS_LOG="$RUN_DIR/harness.log"
 LATENCY_FILE="$RUN_DIR/latencies.jsonl"
+RESUME_MANIFEST_FILE="$RUN_DIR/resume_manifest.jsonl"
 : >"$HARNESS_LOG"
 VLLM_PGID=""
 
@@ -223,6 +231,8 @@ echo "Node:          $(hostname)"
 echo "Job ID:        ${SLURM_JOB_ID:-N/A}"
 echo "Cell dir:      $CELL_DIR"
 echo "Run dir:       $RUN_DIR"
+echo "Resume:        $SMARTGRID_RESUME"
+echo "Force rerun:   $SMARTGRID_FORCE_RERUN"
 echo ""
 
 PYTHON_BIN="python3"
@@ -375,6 +385,14 @@ payload = {
     "gpu_count": int(os.environ.get("SLURM_GPUS_ON_NODE", "1") or "1"),
     "runtime_owner": os.environ.get("USER"),
     "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+    "smartgrid_batch_id": os.environ.get("SMARTGRID_BATCH_ID"),
+    "smartgrid_resume": os.environ.get("SMARTGRID_RESUME", "0") == "1",
+    "smartgrid_force_rerun": os.environ.get("SMARTGRID_FORCE_RERUN", "0") == "1",
+    "smartgrid_resume_require_latency": os.environ.get(
+        "SMARTGRID_RESUME_REQUIRE_LATENCY",
+        "1",
+    )
+    == "1",
 }
 
 if os.environ.get("CONTRIBUTING_EXPERIMENTS"):
@@ -450,6 +468,15 @@ pathlib.Path(meta_path).write_text(
             "vllm_dtype": payload["vllm_dtype"],
             "vllm_extra_args": payload["vllm_extra_args"],
             "vllm_extra_args_list": payload["vllm_extra_args_list"],
+            "git_sha": payload["git_sha"],
+            "git_branch": payload["git_branch"],
+            "git_dirty": payload["git_dirty"],
+            "smartgrid_batch_id": payload["smartgrid_batch_id"],
+            "smartgrid_resume": payload["smartgrid_resume"],
+            "smartgrid_force_rerun": payload["smartgrid_force_rerun"],
+            "smartgrid_resume_require_latency": payload[
+                "smartgrid_resume_require_latency"
+            ],
         },
         indent=2,
     )
@@ -555,7 +582,7 @@ run_json_stdout_trial() {
   local cwd="$2"
   shift 2
 
-  local raw_path="${out_path}.stdout"
+  local raw_path="${out_path}.stdout.tmp"
   local rc=0
   (cd "$cwd" && "$@") >"$raw_path" 2>>"$HARNESS_LOG" || rc=$?
   if "$PYTHON_BIN" - "$raw_path" "$out_path" >>"$HARNESS_LOG" 2>&1 <<'PY'
@@ -1040,11 +1067,18 @@ fi
 PASS=0
 FAIL=0
 TOTAL=0
-: >"$LATENCY_FILE"
+RESUME_SKIPPED=0
+RESUME_RERUN=0
+if [ "$SMARTGRID_RESUME" = "1" ] && [ "$SMARTGRID_FORCE_RERUN" != "1" ]; then
+  touch "$LATENCY_FILE"
+else
+  : >"$LATENCY_FILE"
+  : >"$RESUME_MANIFEST_FILE"
+fi
 
 # Cell C optimized: run all scenarios in a single aat_runner.py call so MCP
 # subprocesses are reused across trials (reuse_mcp_connections).
-if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ]; then
+if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ] && [ "$SMARTGRID_RESUME" != "1" ]; then
   if [ -n "${AAT_RUNNER_TEMPLATE:-}" ]; then
     echo "ERROR: AAT_RUNNER_TEMPLATE is not supported with MCP_MODE=optimized batch mode." >&2
     exit 1
@@ -1089,25 +1123,81 @@ PY
     TOTAL=$((TOTAL + 1))
     TRIAL_ID="${SCENARIO_BASENAME}_run$(printf '%02d' "$TRIAL")"
     TRIAL_OUT="$RUN_DIR/${RUN_BASENAME}_${TRIAL_ID}.json"
+    TRIAL_TMP="${TRIAL_OUT}.tmp"
+    RESUME_REASON="fresh_run"
+
+    if [ "$SMARTGRID_RESUME" = "1" ] && [ "$SMARTGRID_FORCE_RERUN" != "1" ]; then
+      REQUIRE_LATENCY_ARGS=()
+      if [ "$SMARTGRID_RESUME_REQUIRE_LATENCY" = "1" ]; then
+        REQUIRE_LATENCY_ARGS+=(--require-latency)
+      fi
+      eval "$("$PYTHON_BIN" scripts/gcp_resume_state.py trial-status-shell \
+        --run-dir "$RUN_DIR" \
+        --scenario-file "$SCENARIO_FILE" \
+        --trial-index "$TRIAL" \
+        --output-path "$TRIAL_OUT" \
+        --latency-file "$LATENCY_FILE" \
+        "${REQUIRE_LATENCY_ARGS[@]}")"
+      TRIAL_OUT="$RESUME_OUTPUT_PATH"
+      TRIAL_TMP="${TRIAL_OUT}.tmp"
+      if [ "$RESUME_COMPLETE" = "1" ]; then
+        RESUME_SKIPPED=$((RESUME_SKIPPED + 1))
+        if [ "$RESUME_SUCCESS" = "1" ]; then
+          PASS=$((PASS + 1))
+        else
+          FAIL=$((FAIL + 1))
+        fi
+        "$PYTHON_BIN" scripts/gcp_resume_state.py manifest-event \
+          --manifest-file "$RESUME_MANIFEST_FILE" \
+          --state "$RESUME_STATE" \
+          --scenario-file "$SCENARIO_FILE" \
+          --trial-index "$TRIAL" \
+          --output-path "$TRIAL_OUT" \
+          --run-name "$RUN_ID" \
+          --reason "resume_skip:$RESUME_REASON" \
+          --batch-id "$SMARTGRID_BATCH_ID"
+        echo "Resume skip: $TRIAL_ID ($RESUME_STATE)"
+        continue
+      fi
+      RESUME_RERUN=$((RESUME_RERUN + 1))
+    fi
+
+    "$PYTHON_BIN" scripts/gcp_resume_state.py preserve-incomplete \
+      --output-path "$TRIAL_OUT" \
+      --manifest-file "$RESUME_MANIFEST_FILE" \
+      --scenario-file "$SCENARIO_FILE" \
+      --trial-index "$TRIAL" \
+      --run-name "$RUN_ID" \
+      --batch-id "$SMARTGRID_BATCH_ID" \
+      --reason "pre_rerun_incomplete:$RESUME_REASON" || true
+    "$PYTHON_BIN" scripts/gcp_resume_state.py preserve-incomplete \
+      --output-path "$TRIAL_TMP" \
+      --manifest-file "$RESUME_MANIFEST_FILE" \
+      --scenario-file "$SCENARIO_FILE" \
+      --trial-index "$TRIAL" \
+      --run-name "$RUN_ID" \
+      --batch-id "$SMARTGRID_BATCH_ID" \
+      --reason "pre_rerun_tmp" || true
 
     START_EPOCH="$("$PYTHON_BIN" - <<'PY'
 import time
 print(time.time())
 PY
 )"
+    TRIAL_RC=0
 
     case "$ORCHESTRATION" in
       plan_execute)
-        run_plan_execute_trial "$PROMPT" "$TRIAL_OUT" || true
+        run_plan_execute_trial "$PROMPT" "$TRIAL_TMP" || TRIAL_RC=$?
         ;;
       agent_as_tool)
-        run_agent_as_tool_trial "$PROMPT" "$TRIAL_OUT" || true
+        run_agent_as_tool_trial "$PROMPT" "$TRIAL_TMP" || TRIAL_RC=$?
         ;;
       hybrid)
-        run_external_orchestration_trial "$PROMPT" "$TRIAL_OUT" "HYBRID_RUNNER_TEMPLATE" || true
+        run_external_orchestration_trial "$PROMPT" "$TRIAL_TMP" "HYBRID_RUNNER_TEMPLATE" || TRIAL_RC=$?
         ;;
       verified_pe)
-        run_verified_pe_trial "$PROMPT" "$TRIAL_OUT" || true
+        run_verified_pe_trial "$PROMPT" "$TRIAL_TMP" || TRIAL_RC=$?
         ;;
       *)
         echo "ERROR: unknown ORCHESTRATION=$ORCHESTRATION" >&2
@@ -1121,131 +1211,48 @@ print(time.time())
 PY
 )"
 
-    # Inject canonical scenario field + derive top-level success into the
-    # trial output JSON BEFORE the pass/fail counter runs. Notebook 03 expects
-    # each per-trial JSON to carry data["scenario"] = <input scenario object>
-    # AND a bool data["success"], so it can match on scenario.id and aggregate
-    # over canonical records. trial_succeeded() reads payload["success"] and
-    # treats a missing field as a pass — running the post-process AFTER the
-    # counter would split summary.json (run-level pass count) from the per-
-    # trial JSON (canonical success), which Notebook 03 would then read in two
-    # different truths. Order: case ⇒ END_EPOCH ⇒ post-process ⇒ counter.
-    # This is uniform across every orchestration path (plan_execute,
-    # agent_as_tool, hybrid, verified_pe) and any upstream-only runner whose
-    # output we cannot directly modify (e.g. AOB plan-execute CLI for Cell Y
-    # baseline, which writes per-step success in history/trajectory but no
-    # top-level success field).
-    "$PYTHON_BIN" - "$SCENARIO_FILE" "$TRIAL_OUT" <<'PY'
-import json
-import os
-import pathlib
-import sys
+    eval "$("$PYTHON_BIN" scripts/gcp_resume_state.py finalize-trial-shell \
+      --scenario-file "$SCENARIO_FILE" \
+      --trial-index "$TRIAL" \
+      --temp-output "$TRIAL_TMP" \
+      --output-path "$TRIAL_OUT" \
+      --latency-file "$LATENCY_FILE" \
+      --manifest-file "$RESUME_MANIFEST_FILE" \
+      --run-name "$RUN_ID" \
+      --batch-id "$SMARTGRID_BATCH_ID" \
+      --start-epoch "$START_EPOCH" \
+      --end-epoch "$END_EPOCH" \
+      --return-code "$TRIAL_RC")"
 
-from scripts.mitigation_guards import (
-    apply_missing_evidence_final_answer_guard,
-    apply_explicit_fault_risk_adjudication,
-    env_flag_enabled,
-)
-
-
-def _step_failed(step: dict) -> bool:
-    if not isinstance(step, dict):
-        return False
-    if step.get("success") is False:
-        return True
-    if step.get("error"):
-        return True
-    resp = step.get("response")
-    if isinstance(resp, dict) and resp.get("error"):
-        return True
-    return False
-
-
-def _derive_success(data: dict) -> bool | None:
-    raw = data.get("success")
-    if isinstance(raw, bool):
-        return raw
-    # Match Notebook 03's history-first precedence so all three call sites
-    # (run_experiment.sh, backfill_canonical_scenario.py, notebook
-    # load_*_records) walk the same step array.
-    steps = data.get("history") or data.get("trajectory") or []
-    if not steps and not data.get("answer"):
-        return None
-    for step in steps:
-        if _step_failed(step):
-            return False
-    return bool(data.get("answer"))
-
-
-scenario_path, trial_path = sys.argv[1:]
-trial_file = pathlib.Path(trial_path)
-if not trial_file.exists() or trial_file.stat().st_size == 0:
-    sys.exit(0)
-try:
-    payload = json.loads(trial_file.read_text(encoding="utf-8"))
-except json.JSONDecodeError:
-    sys.exit(0)
-if not isinstance(payload, dict):
-    sys.exit(0)
-try:
-    scenario = json.loads(pathlib.Path(scenario_path).read_text(encoding="utf-8"))
-except (OSError, json.JSONDecodeError):
-    sys.exit(0)
-payload["scenario"] = scenario
-apply_missing_evidence_final_answer_guard(
-    payload,
-    enabled=env_flag_enabled(os.environ.get("ENABLE_MISSING_EVIDENCE_GUARD")),
-)
-if "fault_risk_adjudication" not in payload:
-    apply_explicit_fault_risk_adjudication(
-        payload,
-        enabled=env_flag_enabled(
-            os.environ.get("ENABLE_EXPLICIT_FAULT_RISK_ADJUDICATION")
-        ),
-    )
-derived = _derive_success(payload)
-if derived is not None and not isinstance(payload.get("success"), bool):
-    payload["success"] = derived
-trial_file.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
-PY
-
-    # Now count pass/fail using the canonical, post-processed success field.
-    # trial_succeeded reads payload["success"]; for upstream AOB plan-execute
-    # output it is now populated by the derive-success block above.
-    if trial_succeeded "$TRIAL_OUT"; then
+    if [ "$FINAL_SUCCESS" = "1" ]; then
       PASS=$((PASS + 1))
     else
       FAIL=$((FAIL + 1))
     fi
-
-    "$PYTHON_BIN" - "$LATENCY_FILE" "$SCENARIO_FILE" "$TRIAL" "$START_EPOCH" "$END_EPOCH" "$TRIAL_OUT" <<'PY'
-import json
-import pathlib
-import sys
-
-latency_file, scenario_file, trial_index, start_epoch, end_epoch, output_path = sys.argv[1:]
-record = {
-    "scenario_file": pathlib.Path(scenario_file).as_posix(),
-    "trial_index": int(trial_index),
-    "latency_seconds": float(end_epoch) - float(start_epoch),
-    "output_path": pathlib.Path(output_path).as_posix(),
-}
-with open(latency_file, "a", encoding="utf-8") as fh:
-    fh.write(json.dumps(record) + "\n")
-PY
   done
 done
 
 fi  # end of per-scenario/per-trial loop (skipped for MCP_MODE=optimized batch path)
 
-"$PYTHON_BIN" - "$SUMMARY_FILE" "$CONFIG_FILE" "$META_FILE" "$LATENCY_FILE" "$RUN_DIR" "$PASS" "$FAIL" "$TOTAL" <<'PY'
+"$PYTHON_BIN" - "$SUMMARY_FILE" "$CONFIG_FILE" "$META_FILE" "$LATENCY_FILE" "$RUN_DIR" "$PASS" "$FAIL" "$TOTAL" "$RESUME_SKIPPED" "$RESUME_RERUN" <<'PY'
 import json
 import pathlib
 import statistics
 import sys
 from datetime import datetime, timezone
 
-summary_path, config_path, meta_path, latency_path, run_dir, passed, failed, total = sys.argv[1:]
+(
+    summary_path,
+    config_path,
+    meta_path,
+    latency_path,
+    run_dir,
+    passed,
+    failed,
+    total,
+    resume_skipped,
+    resume_rerun,
+) = sys.argv[1:]
 config = json.loads(pathlib.Path(config_path).read_text(encoding="utf-8"))
 meta = json.loads(pathlib.Path(meta_path).read_text(encoding="utf-8"))
 latency_records = [
@@ -1338,6 +1345,8 @@ summary = {
     "run_status": "success" if int(failed) == 0 else ("partial" if int(passed) > 0 else "failed"),
     "scenarios_attempted": int(total),
     "scenarios_completed": int(passed),
+    "resume_skipped_count": int(resume_skipped),
+    "resume_rerun_count": int(resume_rerun),
     "success_rate": (int(passed) / int(total)) if int(total) else 0.0,
     "failure_count": int(failed),
     "wall_clock_seconds_total": wall_clock_seconds_total,
@@ -1368,6 +1377,8 @@ meta["fail"] = int(failed)
 meta["total_runs"] = int(total)
 meta["run_status"] = summary["run_status"]
 meta["mcp_setup_seconds"] = summary["mcp_setup_seconds"]
+meta["resume_skipped_count"] = summary["resume_skipped_count"]
+meta["resume_rerun_count"] = summary["resume_rerun_count"]
 pathlib.Path(meta_path).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 PY
 

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -309,9 +309,11 @@ if [ "$DRY_RUN" = "1" ]; then
 fi
 
 "$PYTHON_BIN" - "$CONFIG_FILE" "$SUMMARY_FILE" "$META_FILE" "$CONFIG_PATH" "$RUN_ID" "$WANDB_ENTITY" "$WANDB_PROJECT" "$EXPERIMENT_FAMILY" "$EXPERIMENT_CELL" "$ORCHESTRATION" "$MCP_MODE" "$TRIALS" "${#SCENARIO_FILES[@]}" "$SCENARIO_SET_NAME" "$SCENARIO_SET_HASH" "$SCENARIO_DOMAIN_SCOPE" "$MODEL_ID" "$MODEL_PROVIDER" "$SERVING_STACK" "$QUANTIZATION_MODE" "$MAX_MODEL_LEN" "$TEMPERATURE" "$MAX_TOKENS" "$JUDGE_MODEL" <<'PY'
+import importlib.metadata
 import json
 import os
 import pathlib
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -349,6 +351,82 @@ def git_value(args, default="unknown"):
     except Exception:
         return default
 
+def git_dirty():
+    try:
+        subprocess.check_call(
+            ["git", "diff-index", "--quiet", "HEAD", "--"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return True
+    except Exception:
+        return None
+    return False
+
+def package_version(name):
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+def command_output(args):
+    try:
+        return subprocess.check_output(
+            args,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+        ).strip()
+    except Exception:
+        return None
+
+def runtime_versions():
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    gpu_id = (cuda_visible or "0").split(",")[0].strip() or "0"
+    versions = {
+        "vllm_version": package_version("vllm"),
+        "torch_version": package_version("torch"),
+        "cuda_visible_devices": cuda_visible,
+        "nvidia_driver_version": None,
+        "cuda_version": None,
+        "nvidia_smi_query": None,
+    }
+    raw = command_output(
+        [
+            "nvidia-smi",
+            f"--id={gpu_id}",
+            "--query-gpu=driver_version,cuda_version",
+            "--format=csv,noheader",
+        ]
+    )
+    if raw:
+        versions["nvidia_smi_query"] = raw
+        first_row = raw.splitlines()[0]
+        parts = [part.strip() for part in first_row.split(",")]
+        if parts:
+            versions["nvidia_driver_version"] = parts[0] or None
+        if len(parts) > 1:
+            versions["cuda_version"] = parts[1] or None
+    if versions["nvidia_driver_version"] is None:
+        driver = command_output(
+            [
+                "nvidia-smi",
+                f"--id={gpu_id}",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader",
+            ]
+        )
+        if driver:
+            versions["nvidia_driver_version"] = driver.splitlines()[0].strip() or None
+    if versions["cuda_version"] is None:
+        smi = command_output(["nvidia-smi"])
+        if smi:
+            match = re.search(r"CUDA Version:\s*([0-9.]+)", smi)
+            if match:
+                versions["cuda_version"] = match.group(1)
+    return versions
+
 payload = {
     "schema_version": "v1",
     "wandb_entity": wandb_entity,
@@ -356,6 +434,7 @@ payload = {
     "run_name": run_name,
     "git_sha": git_value(["git", "rev-parse", "HEAD"]),
     "git_branch": git_value(["git", "branch", "--show-current"]),
+    "git_dirty": git_dirty(),
     "run_timestamp": datetime.now(timezone.utc).isoformat(),
     "benchmark_config_path": pathlib.Path(benchmark_config_path).as_posix(),
     "benchmark_summary_path": pathlib.Path(summary_path).as_posix(),
@@ -430,6 +509,7 @@ extra_vllm_args = os.environ.get("EXTRA_VLLM_ARGS", "").strip()
 payload["vllm_dtype"] = os.environ.get("VLLM_DTYPE", "float16")
 payload["vllm_extra_args"] = extra_vllm_args
 payload["vllm_extra_args_list"] = extra_vllm_args.split() if extra_vllm_args else []
+payload["runtime_versions"] = runtime_versions()
 
 pathlib.Path(config_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 pathlib.Path(meta_path).write_text(
@@ -468,6 +548,7 @@ pathlib.Path(meta_path).write_text(
             "vllm_dtype": payload["vllm_dtype"],
             "vllm_extra_args": payload["vllm_extra_args"],
             "vllm_extra_args_list": payload["vllm_extra_args_list"],
+            "runtime_versions": payload["runtime_versions"],
             "git_sha": payload["git_sha"],
             "git_branch": payload["git_branch"],
             "git_dirty": payload["git_dirty"],

--- a/scripts/run_gcp_context_batch.sh
+++ b/scripts/run_gcp_context_batch.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Canonical GCP context-window closeout launcher.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COHORT_TSV="${COHORT_TSV:-configs/gcp_context_closeout.tsv}"
+BATCH_ID="${SMARTGRID_BATCH_ID:-gcp_context_$(date -u +%Y%m%dT%H%M%SZ)}"
+STATE_FILE="${STATE_FILE:-}"
+MANIFEST_TSV="${MANIFEST_TSV:-}"
+MANIFEST_JSONL="${MANIFEST_JSONL:-}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+DRY_RUN="${DRY_RUN:-0}"
+RUN_JUDGE=1
+ROWS_FILTER=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run_gcp_context_batch.sh [--batch-id ID|--resume-batch ID] [--rows A,B] [--dry-run] [--no-judge]
+
+Runs the canonical seven-row GCP context closeout cohort with stable run IDs,
+SMARTGRID_RESUME=1, per-row manifest/state files, and idempotent judge scoring.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --batch-id)
+      BATCH_ID="$2"; shift 2 ;;
+    --resume-batch)
+      BATCH_ID="$2"; shift 2 ;;
+    --rows)
+      ROWS_FILTER=",$2,"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=1; shift ;;
+    --no-judge)
+      RUN_JUDGE=0; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2 ;;
+  esac
+done
+
+[ -n "$STATE_FILE" ] || STATE_FILE="logs/gcp_${BATCH_ID}_state.tsv"
+[ -n "$MANIFEST_TSV" ] || MANIFEST_TSV="logs/gcp_${BATCH_ID}_manifest.tsv"
+[ -n "$MANIFEST_JSONL" ] || MANIFEST_JSONL="logs/gcp_${BATCH_ID}_manifest.jsonl"
+mkdir -p logs results/metrics results/judge_logs
+
+cell_dir_name() {
+  case "$1" in
+    A) echo "cell_A_direct" ;;
+    B) echo "cell_B_mcp_baseline" ;;
+    C) echo "cell_C_mcp_optimized" ;;
+    Y) echo "cell_Y_plan_execute" ;;
+    Z) echo "cell_Z_hybrid" ;;
+    *) echo "cell_${1}" ;;
+  esac
+}
+
+state_value() {
+  local label="$1" field="$2"
+  [ -f "$STATE_FILE" ] || return 0
+  awk -F'\t' -v label="$label" -v field="$field" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) idx[$i] = i
+      next
+    }
+    $1 == label && idx[field] { value = $idx[field] }
+    END {
+      if (value != "") print value
+    }
+  ' "$STATE_FILE"
+}
+
+append_state() {
+  if [ ! -f "$STATE_FILE" ]; then
+    printf 'label\tconfig\trun_id\tstatus\tstarted_at\tfinished_at\n' >"$STATE_FILE"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" >>"$STATE_FILE"
+}
+
+append_manifest() {
+  local label="$1" config="$2" run_id="$3" run_dir="$4" run_rc="$5" judge_rc="$6" status="$7" started="$8" finished="$9"
+  if [ ! -f "$MANIFEST_TSV" ]; then
+    printf 'label\tconfig\trun_id\trun_dir\trun_rc\tjudge_rc\tstatus\tstarted_at\tfinished_at\tprovider\tzone\tinstance\tgpu_type\n' >"$MANIFEST_TSV"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$label" "$config" "$run_id" "$run_dir" "$run_rc" "$judge_rc" "$status" "$started" "$finished" \
+    "${SMARTGRID_COMPUTE_PROVIDER:-gcp}" "${SMARTGRID_COMPUTE_ZONE:-}" "${SMARTGRID_COMPUTE_INSTANCE:-$(hostname)}" "${GPU_TYPE:-}" \
+    >>"$MANIFEST_TSV"
+  "$PYTHON_BIN" - "$MANIFEST_JSONL" "$label" "$config" "$run_id" "$run_dir" "$run_rc" "$judge_rc" "$status" "$started" "$finished" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+path, label, config, run_id, run_dir, run_rc, judge_rc, status, started, finished = sys.argv[1:]
+payload = {
+    "schema_version": 1,
+    "label": label,
+    "config": config,
+    "run_id": run_id,
+    "run_dir": run_dir,
+    "run_rc": None if run_rc == "" else int(run_rc),
+    "judge_rc": None if judge_rc == "" else int(judge_rc),
+    "status": status,
+    "started_at": started,
+    "finished_at": finished,
+    "compute_provider": os.environ.get("SMARTGRID_COMPUTE_PROVIDER", "gcp"),
+    "compute_zone": os.environ.get("SMARTGRID_COMPUTE_ZONE"),
+    "compute_instance": os.environ.get("SMARTGRID_COMPUTE_INSTANCE") or os.uname().nodename,
+    "gpu_type": os.environ.get("GPU_TYPE"),
+}
+pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+with pathlib.Path(path).open("a", encoding="utf-8") as fh:
+    fh.write(json.dumps(payload, sort_keys=True) + "\n")
+PY
+}
+
+preflight_runtime() {
+  [ "$DRY_RUN" = "1" ] && return 0
+  command -v "$PYTHON_BIN" >/dev/null
+  command -v g++ >/dev/null
+  command -v cc1plus >/dev/null
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi -L >/dev/null
+  fi
+  "$PYTHON_BIN" - <<'PY'
+import importlib.util
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit("Python >=3.11 required")
+for module in ("torch", "vllm"):
+    if importlib.util.find_spec(module) is None:
+        raise SystemExit(f"{module} is not importable")
+PY
+}
+
+preflight_boot_disk_autodelete() {
+  [ "$DRY_RUN" = "1" ] && return 0
+  [ -n "${SMARTGRID_COMPUTE_INSTANCE:-}" ] || return 0
+  [ -n "${SMARTGRID_COMPUTE_ZONE:-}" ] || return 0
+  command -v gcloud >/dev/null 2>&1 || return 0
+  local autodelete
+  autodelete="$(
+    gcloud compute instances describe "$SMARTGRID_COMPUTE_INSTANCE" \
+      --zone "$SMARTGRID_COMPUTE_ZONE" \
+      --format='value(disks[0].autoDelete)' 2>/dev/null || true
+  )"
+  if [ "$autodelete" = "True" ] || [ "$autodelete" = "true" ]; then
+    echo "ERROR: boot disk autoDelete=true for $SMARTGRID_COMPUTE_INSTANCE; set autoDelete=false before capture." >&2
+    return 1
+  fi
+}
+
+preflight_runtime
+preflight_boot_disk_autodelete
+
+tail -n +2 "$COHORT_TSV" | while IFS=$'\t' read -r label config; do
+  [ -n "$label" ] || continue
+  if [ -n "$ROWS_FILTER" ] && [[ "$ROWS_FILTER" != *",$label,"* ]]; then
+    continue
+  fi
+  if [ ! -f "$config" ]; then
+    echo "ERROR: config missing for $label: $config" >&2
+    exit 1
+  fi
+  existing_run_id="$(state_value "$label" run_id || true)"
+  existing_status="$(state_value "$label" status || true)"
+  # shellcheck disable=SC1090
+  source "$config"
+  run_id="${existing_run_id:-${BATCH_ID}_${label}_${EXPERIMENT_NAME}}"
+  run_dir="benchmarks/$(cell_dir_name "$EXPERIMENT_CELL")/raw/$run_id"
+  started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  if [ "$existing_status" = "complete" ]; then
+    echo "Skipping $label: already complete in $STATE_FILE"
+    append_manifest "$label" "$config" "$run_id" "$run_dir" "" "" "skipped_complete" "$started" "$started"
+    continue
+  fi
+
+  append_state "$label" "$config" "$run_id" "started" "$started" ""
+
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "DRY_RUN $label: SMARTGRID_RUN_ID=$run_id bash scripts/run_experiment.sh $config"
+    append_state "$label" "$config" "$run_id" "dry_run" "$started" "$started"
+    append_manifest "$label" "$config" "$run_id" "$run_dir" "" "" "dry_run" "$started" "$started"
+    continue
+  fi
+
+  run_rc=0
+  SMARTGRID_BATCH_ID="$BATCH_ID" \
+  SMARTGRID_RUN_ID="$run_id" \
+  SMARTGRID_RESUME=1 \
+  SMARTGRID_COMPUTE_PROVIDER="${SMARTGRID_COMPUTE_PROVIDER:-gcp}" \
+  SMARTGRID_COMPUTE_INSTANCE="${SMARTGRID_COMPUTE_INSTANCE:-$(hostname)}" \
+    bash scripts/run_experiment.sh "$config" || run_rc=$?
+
+  judge_rc=0
+  if [ "$RUN_JUDGE" = "1" ]; then
+    "$PYTHON_BIN" scripts/judge_trajectory.py \
+      --run-dir "$run_dir" \
+      --scenario-dir data/scenarios \
+      --out results/metrics/scenario_scores.jsonl \
+      --log-dir results/judge_logs || judge_rc=$?
+  fi
+  finished="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  status="complete"
+  [ "$run_rc" -ne 0 ] && status="run_failed"
+  [ "$judge_rc" -ne 0 ] && status="judge_failed"
+  append_state "$label" "$config" "$run_id" "$status" "$started" "$finished"
+  append_manifest "$label" "$config" "$run_id" "$run_dir" "$run_rc" "$judge_rc" "$status" "$started" "$finished"
+done

--- a/tests/test_gcp_resume_state.py
+++ b/tests/test_gcp_resume_state.py
@@ -189,3 +189,49 @@ def test_finalize_trial_writes_atomic_output_latency_and_manifest(
     ]
     assert manifest_rows[-1]["state"] == "complete_success"
     assert manifest_rows[-1]["batch_id"] == "batch-1"
+    assert "runtime_versions" in manifest_rows[-1]
+
+
+def test_finalize_trial_marks_divergent_rerun(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = tmp_path / "run" / "trial.json"
+    latency_file = tmp_path / "run" / "latencies.jsonl"
+    manifest_file = tmp_path / "run" / "resume_manifest.jsonl"
+    first_temp = _trial(tmp_path / "run" / "trial-first.json.tmp", answer="first")
+    second_temp = _trial(tmp_path / "run" / "trial-second.json.tmp", answer="second")
+
+    gcp_resume_state.finalize_trial(
+        scenario_file=scenario_file,
+        trial_index=1,
+        temp_output=first_temp,
+        output_path=output,
+        latency_file=latency_file,
+        manifest_file=manifest_file,
+        run_name="resume-smoke",
+        batch_id="batch-1",
+        start_epoch=10.0,
+        end_epoch=12.5,
+        return_code=0,
+    )
+
+    gcp_resume_state.finalize_trial(
+        scenario_file=scenario_file,
+        trial_index=1,
+        temp_output=second_temp,
+        output_path=output,
+        latency_file=latency_file,
+        manifest_file=manifest_file,
+        run_name="resume-smoke",
+        batch_id="batch-1",
+        start_epoch=20.0,
+        end_epoch=23.0,
+        return_code=0,
+    )
+
+    manifest_rows = [
+        json.loads(line)
+        for line in manifest_file.read_text(encoding="utf-8").splitlines()
+    ]
+    rerun = manifest_rows[-1]
+    assert rerun["divergent"] is True
+    assert rerun["original_output_sha256"] != rerun["final_output_sha256"]

--- a/tests/test_gcp_resume_state.py
+++ b/tests/test_gcp_resume_state.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import gcp_resume_state
+
+
+def _scenario(path: Path, scenario_id: str = "SGT-001") -> Path:
+    path.write_text(
+        json.dumps({"id": scenario_id, "text": "test prompt"}) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _trial(path: Path, *, success: bool | None = True, answer: str = "done") -> Path:
+    payload = {"answer": answer, "history": []}
+    if success is not None:
+        payload["success"] = success
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    return path
+
+
+def _latency(
+    path: Path, scenario_file: Path, trial_index: int, output_path: Path
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "scenario_file": scenario_file.as_posix(),
+                "trial_index": trial_index,
+                "latency_seconds": 1.25,
+                "output_path": output_path.as_posix(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _classify(
+    tmp_path: Path,
+    scenario_file: Path,
+    output_path: Path,
+    *,
+    require_latency: bool = True,
+) -> dict:
+    return gcp_resume_state.classify_trial(
+        run_dir=tmp_path,
+        scenario_file=scenario_file,
+        trial_index=1,
+        output_path=output_path,
+        latency_file=tmp_path / "latencies.jsonl",
+        require_latency=require_latency,
+    )
+
+
+def test_completed_success_is_terminal_with_latency(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = _trial(tmp_path / "2026-05-03_Y_multi_01_run01.json", success=True)
+    _latency(tmp_path / "latencies.jsonl", scenario_file, 1, output)
+
+    result = _classify(tmp_path, scenario_file, output)
+
+    assert result["state"] == "complete_success"
+    assert result["complete"] is True
+    assert result["success"] is True
+
+
+def test_completed_failure_is_terminal_and_skippable(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = _trial(tmp_path / "2026-05-03_Y_multi_01_run01.json", success=False)
+    _latency(tmp_path / "latencies.jsonl", scenario_file, 1, output)
+
+    result = _classify(tmp_path, scenario_file, output)
+
+    assert result["state"] == "complete_failure"
+    assert result["complete"] is True
+    assert result["success"] is False
+
+
+def test_missing_latency_keeps_valid_json_incomplete_by_default(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = _trial(tmp_path / "2026-05-03_Y_multi_01_run01.json", success=True)
+
+    result = _classify(tmp_path, scenario_file, output)
+
+    assert result["state"] == "incomplete"
+    assert "missing_latency" in result["reason"]
+
+
+def test_invalid_json_is_incomplete(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = tmp_path / "2026-05-03_Y_multi_01_run01.json"
+    output.write_text("{not-json", encoding="utf-8")
+
+    result = _classify(tmp_path, scenario_file, output, require_latency=False)
+
+    assert result["state"] == "incomplete"
+    assert "invalid_json" in result["reason"]
+
+
+def test_legacy_stdout_next_to_terminal_json_is_not_dangling(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = _trial(tmp_path / "legacy_multi_01_run01.json", success=True)
+    output.with_suffix(output.suffix + ".stdout").write_text(
+        "legacy log\n", encoding="utf-8"
+    )
+    _latency(tmp_path / "latencies.jsonl", scenario_file, 1, output)
+    newer_name = tmp_path / "2026-05-04_Y_multi_01_run01.json"
+
+    result = _classify(tmp_path, scenario_file, newer_name)
+
+    assert result["state"] == "complete_success"
+    assert result["output_path"] == output.as_posix()
+
+
+def test_conflicting_duplicate_latency_rows_are_incomplete(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    output = _trial(tmp_path / "2026-05-03_Y_multi_01_run01.json", success=True)
+    rows = [
+        {
+            "scenario_file": scenario_file.as_posix(),
+            "trial_index": 1,
+            "latency_seconds": 1.0,
+            "output_path": output.as_posix(),
+        },
+        {
+            "scenario_file": scenario_file.as_posix(),
+            "trial_index": 1,
+            "latency_seconds": 2.0,
+            "output_path": output.as_posix(),
+        },
+    ]
+    (tmp_path / "latencies.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    result = _classify(tmp_path, scenario_file, output)
+
+    assert result["state"] == "incomplete"
+    assert "duplicate_conflicting_latency" in result["reason"]
+
+
+def test_finalize_trial_writes_atomic_output_latency_and_manifest(
+    tmp_path: Path,
+) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+    temp_output = _trial(tmp_path / "run" / "trial.json.tmp", success=None)
+    output = tmp_path / "run" / "trial.json"
+    latency_file = tmp_path / "run" / "latencies.jsonl"
+    manifest_file = tmp_path / "run" / "resume_manifest.jsonl"
+
+    result = gcp_resume_state.finalize_trial(
+        scenario_file=scenario_file,
+        trial_index=1,
+        temp_output=temp_output,
+        output_path=output,
+        latency_file=latency_file,
+        manifest_file=manifest_file,
+        run_name="resume-smoke",
+        batch_id="batch-1",
+        start_epoch=10.0,
+        end_epoch=12.5,
+        return_code=0,
+    )
+
+    assert result["state"] == "complete_success"
+    assert output.exists()
+    assert not temp_output.exists()
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["scenario"]["id"] == "SGT-001"
+    assert payload["success"] is True
+    latency_rows = [json.loads(line) for line in latency_file.read_text().splitlines()]
+    assert latency_rows == [
+        {
+            "latency_seconds": 2.5,
+            "output_path": output.as_posix(),
+            "scenario_file": scenario_file.as_posix(),
+            "trial_index": 1,
+        }
+    ]
+    manifest_rows = [
+        json.loads(line)
+        for line in manifest_file.read_text(encoding="utf-8").splitlines()
+    ]
+    assert manifest_rows[-1]["state"] == "complete_success"
+    assert manifest_rows[-1]["batch_id"] == "batch-1"

--- a/tests/test_judge_trajectory.py
+++ b/tests/test_judge_trajectory.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import judge_trajectory
+
+
+def test_existing_score_keys_include_prompt_version_and_legacy_rows(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "scenario_scores.jsonl"
+    out.write_text(
+        json.dumps(
+            {
+                "run_name": "run-a",
+                "scenario_id": "SGT-001",
+                "trial_index": 1,
+                "judge_model": "watsonx/test",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    keys = judge_trajectory._existing_score_keys(out)
+
+    assert keys == {
+        (
+            "run-a",
+            "SGT-001",
+            1,
+            "watsonx/test",
+            judge_trajectory._JUDGE_PROMPT_VERSION,
+        )
+    }
+
+
+def test_score_identity_matches_existing_row_shape(tmp_path: Path) -> None:
+    run_dir = tmp_path / "raw" / "run-a"
+    run_dir.mkdir(parents=True)
+    trajectory = run_dir / "2026-05-03_Y_multi_01_run02.json"
+    trajectory.write_text(
+        json.dumps({"answer": "ok", "history": []}) + "\n",
+        encoding="utf-8",
+    )
+    scenario = tmp_path / "multi_01.json"
+    scenario.write_text(json.dumps({"id": "SGT-001", "text": "prompt"}) + "\n")
+    meta = run_dir / "meta.json"
+    meta.write_text(json.dumps({"run_name": "run-a"}) + "\n")
+
+    identity = judge_trajectory._score_identity(
+        trajectory,
+        scenario,
+        meta,
+        "watsonx/test",
+    )
+
+    assert identity == (
+        "run-a",
+        "SGT-001",
+        2,
+        "watsonx/test",
+        judge_trajectory._JUDGE_PROMPT_VERSION,
+    )

--- a/tests/test_run_experiment_summary.py
+++ b/tests/test_run_experiment_summary.py
@@ -36,6 +36,10 @@ def _base_config(summary_path: Path) -> dict:
         "scenario_set_hash": "test-hash",
         "model_id": "openai/Llama-3.1-8B-Instruct",
         "host_name": "test-host",
+        "compute_env": "local",
+        "compute_provider": None,
+        "compute_zone": None,
+        "compute_instance": None,
         "gpu_type": "test-gpu",
         "slurm_job_id": "test-job",
     }
@@ -82,6 +86,8 @@ def test_summary_includes_batch_mcp_setup_once(tmp_path):
             "2",
             "0",
             "2",
+            "0",
+            "0",
         ],
         check=True,
     )
@@ -132,6 +138,8 @@ def test_summary_records_null_mcp_setup_when_absent(tmp_path):
             "1",
             "0",
             "1",
+            "0",
+            "0",
         ],
         check=True,
     )
@@ -142,3 +150,54 @@ def test_summary_records_null_mcp_setup_when_absent(tmp_path):
     assert summary["wall_clock_seconds_total"] == 2.0
     assert summary["mcp_setup_seconds"] is None
     assert meta["mcp_setup_seconds"] is None
+
+
+def test_summary_records_resume_skip_and_rerun_counts(tmp_path):
+    """Resume summaries expose skipped/rerun counts without changing pass math."""
+    repo_root = Path(__file__).resolve().parent.parent
+    summary_py = _extract_summary_python(repo_root)
+
+    summary_path = tmp_path / "summary.json"
+    config_path = tmp_path / "config.json"
+    meta_path = tmp_path / "meta.json"
+    latency_path = tmp_path / "latencies.jsonl"
+    run_dir = tmp_path / "raw" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    config_path.write_text(
+        json.dumps(_base_config(summary_path), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    meta_path.write_text(json.dumps({"started_at": "now"}) + "\n", encoding="utf-8")
+    latency_path.write_text("", encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            summary_py,
+            str(summary_path),
+            str(config_path),
+            str(meta_path),
+            str(latency_path),
+            str(run_dir),
+            "1",
+            "2",
+            "3",
+            "2",
+            "1",
+        ],
+        check=True,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    assert summary["scenarios_attempted"] == 3
+    assert summary["scenarios_completed"] == 1
+    assert summary["failure_count"] == 2
+    assert summary["resume_skipped_count"] == 2
+    assert summary["resume_rerun_count"] == 1
+    assert summary["run_status"] == "partial"
+    assert meta["resume_skipped_count"] == 2
+    assert meta["resume_rerun_count"] == 1


### PR DESCRIPTION
## Summary

- Adds stable SmartGrid run IDs, explicit resume/force controls, trial-level resume classification, atomic per-trial finalization, and resume manifest events to the benchmark runner.
- Adds the canonical GCP context closeout TSV, resumable batch launcher, retained-disk/auto-delete preflight, and IAP artifact pullback helper with score-row dedupe.
- Adds idempotent judge score identity via judge prompt version and regression tests for resume/finalization behavior.

Refs #91; issue remains open pending final operator closeout/evidence decisions.

## Test plan

- `bash -n scripts/run_experiment.sh scripts/run_gcp_context_batch.sh scripts/gcp_pull_context_artifacts.sh`
- `python3 -m py_compile scripts/gcp_resume_state.py scripts/judge_trajectory.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_gcp_resume_state.py tests/test_run_experiment_summary.py tests/test_judge_trajectory.py tests/test_orchestration_utils.py` (`69 passed, 3 subtests`)
- `DRY_RUN=1 SMARTGRID_RESUME=1 SMARTGRID_RUN_ID=resume-smoke bash scripts/run_experiment.sh configs/context_ablation/pe_m_8192.env`
- `DRY_RUN=1 STATE_FILE=/tmp/gcp_resume_split_state_2.tsv MANIFEST_TSV=/tmp/gcp_resume_split_manifest_2.tsv MANIFEST_JSONL=/tmp/gcp_resume_split_manifest_2.jsonl scripts/run_gcp_context_batch.sh --rows Y8 --no-judge`
- `scripts/gcp_pull_context_artifacts.sh --instance smartgrid-a100 --zone us-central1-a --batch-id gcp_context_20260503T074525Z --dest /tmp/gcp_resume_split_artifacts_2 --dry-run`
