### PR TITLE
Harden mitigation ladder after A100 results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
 - Clarified in `docs/experiment_matrix.md` that mitigation is a sparse overlay
   dimension on selected PE-family lanes, while the core experiment matrix
   remains focused on method cells and non-mitigation ablations.
+- Hardened the mitigation ladder after the first GCP A100 four-tier evidence
+  pass: repaired same-step same-tool retries now clear stale missing-evidence
+  hits, explicit fault/risk adjudication skips monitoring-only IoT/TSFM tasks,
+  and adjudicated summaries are constrained to preserve the original task
+  requirements. Refs #35, #64, #66.
 
 ## 2026-05-02
 

--- a/docs/mitigation_recovery_adjudication.md
+++ b/docs/mitigation_recovery_adjudication.md
@@ -33,7 +33,9 @@ question:
 ## Rung 2: missing-evidence retry/replan guard
 
 Status: implemented for `Y + Self-Ask` and `Z + Self-Ask`,
-pending Insomnia reruns and judge rows.
+with first GCP A100 diagnostic evidence captured. The first cohort exposed a
+repair bookkeeping overblock, so claims about repair lift should wait for a
+patched matched rerun.
 
 ### Intent
 
@@ -179,8 +181,10 @@ is not a mitigation win.
 
 ## Rung 3: explicit fault/risk adjudication step
 
-Status: implemented on this branch for `Y + Self-Ask` and `Z + Self-Ask`,
-pending matched reruns and judge rows.
+Status: implemented for `Y + Self-Ask` and `Z + Self-Ask`, with first GCP A100
+diagnostic evidence captured. The first cohort exposed adjudication
+applicability and summarization overreach, so claims about adjudication lift
+should wait for a patched matched rerun.
 
 ### Intent
 
@@ -207,6 +211,11 @@ Run adjudication before final answer or work-order emission when any are true:
 If deciding evidence is missing, adjudication should not invent an answer. It
 should return `refuse_due_missing_evidence` and rely on rung 1 or rung 2 to
 record the missing-evidence failure.
+
+Do not run this rung for monitoring-only IoT/TSFM tasks that ask for readings,
+baselines, peaks, or anomaly counts without asking for a fault, risk,
+maintenance, or work-order decision. Generic anomaly evidence is not by itself a
+maintenance adjudication trigger.
 
 ### Output contract
 

--- a/docs/mitigation_rerun_operator_plan.md
+++ b/docs/mitigation_rerun_operator_plan.md
@@ -30,6 +30,27 @@ Status as of 2026-05-03: the GCP A100 four-tier cohort
 interpretation table remains a deliberate follow-up, not an automatic copy of
 the raw cohort summary.
 
+Post-cohort interpretation: the first four-tier A100 run does **not** show a
+blanket mitigation lift. Guard and repair reduce measured pass rate in aggregate,
+and adjudication is sharply worse before the runtime fixes below. Treat that
+cohort as diagnostic evidence for the ladder implementation, not as final
+mitigation-outcome evidence.
+
+## Post-cohort diagnosis
+
+The initial A100 cohort surfaced three concrete issues:
+
+| Issue | Symptom | Fix direction |
+|---|---|---|
+| Repair bookkeeping overblocked corrected retries | `SGT-014` / `SGT-018` repair rows could retry the same step with corrected evidence arguments, yet the final guard still blocked the stale failed target. | Clear unresolved hits when a later same-step same-tool retry succeeds, even if the corrected target differs from the original bad argument. |
+| Adjudication over-triggered on monitoring-only tasks | `SGT-012` IoT load-current monitoring failed under adjudication even though the scenario asks for baseline/peak/elevated-current assessment, not a fault/risk or maintenance decision. | Run explicit fault/risk adjudication only for fault/risk/maintenance/work-order tasks. Do not treat generic anomaly detection alone as a maintenance adjudication trigger. |
+| Adjudication summaries became too narrow | `SGT-010` baseline/repair answers passed, but adjudication summaries sometimes dropped outage/defer and thermal-trend context while focusing on the adjudication block. | Treat adjudication as a constraint on fault/risk claims, not a replacement for the original task; summaries must still answer every requested part. |
+
+After these fixes, rerun the same four-tier cohort before making any paper claim
+about mitigation lift. The current v1 evidence is still useful: it says the
+ladder needs precise applicability and repair bookkeeping, and that truthful
+guards can lower apparent success when they block unsupported answers.
+
 ## Current anchors
 
 | Family lane | Baseline config | Detection config | Recovery config | Adjudication config |

--- a/scripts/mitigation_guards.py
+++ b/scripts/mitigation_guards.py
@@ -44,6 +44,8 @@ FAULT_RISK_EVIDENCE_TOOLS = {
 }
 
 ADJUDICATION_TRIGGER_TOOLS = {
+    # Generic anomaly/trend tools also support monitoring tasks, so they should
+    # not trigger maintenance adjudication without task text or domain support.
     "analyze_dga",
     "get_dga_record",
     "get_sensor_correlation",
@@ -486,8 +488,8 @@ def _fault_risk_adjudication_applies(payload: dict[str, Any]) -> bool:
                 scenario.get("characteristic_form"),
             ]
         )
-        tags = " ".join(str(tag).lower() for tag in scenario.get("domain_tags") or [])
-        if any(tag in tags for tag in ("fmsr", "wo", "multi")):
+        tags = {str(tag).lower() for tag in scenario.get("domain_tags") or []}
+        if tags.intersection({"fmsr", "wo", "multi"}):
             return True
 
     text = " ".join(str(part or "").lower() for part in text_parts)
@@ -840,6 +842,7 @@ def _clear_repaired_hit(
     if record_step is None:
         return
     for key, hit in list(unresolved_hits.items()):
+        # Corrected retries can change args; same step/tool identifies repair.
         if (
             str(hit.get("tool") or "").lower() == record_tool
             and hit.get("step") == record_step

--- a/scripts/mitigation_guards.py
+++ b/scripts/mitigation_guards.py
@@ -43,6 +43,16 @@ FAULT_RISK_EVIDENCE_TOOLS = {
     "get_fault_record",
 }
 
+ADJUDICATION_TRIGGER_TOOLS = {
+    "analyze_dga",
+    "get_dga_record",
+    "get_sensor_correlation",
+    "get_rul",
+    "forecast_rul",
+    "list_fault_records",
+    "get_fault_record",
+}
+
 FAULT_FIELD_KEYS = {
     "diagnosis",
     "diagnostic",
@@ -207,6 +217,23 @@ def build_explicit_fault_risk_adjudication(
             "name": EXPLICIT_FAULT_RISK_ADJUDICATION_NAME,
             "enabled": False,
             "decision": "disabled",
+        }
+
+    if not _fault_risk_adjudication_applies(payload):
+        return {
+            "name": EXPLICIT_FAULT_RISK_ADJUDICATION_NAME,
+            "enabled": True,
+            "decision": "not_applicable",
+            "selected_fault_id": None,
+            "selected_fault_label": None,
+            "selected_risk_level": None,
+            "deciding_evidence": [],
+            "alternatives_considered": [],
+            "missing_evidence": [],
+            "reason": (
+                "Fault/risk adjudication skipped because the task does not "
+                "ask for a fault, risk, maintenance, or work-order decision."
+            ),
         }
 
     missing_scan = scan_missing_evidence(payload)
@@ -446,6 +473,38 @@ def _collect_fault_risk_evidence(payload: dict[str, Any]) -> list[dict[str, Any]
                 }
             )
     return _dedupe_evidence(evidence)[:8]
+
+
+def _fault_risk_adjudication_applies(payload: dict[str, Any]) -> bool:
+    text_parts = [payload.get("question"), payload.get("effective_question")]
+    scenario = payload.get("scenario")
+    if isinstance(scenario, dict):
+        text_parts.extend(
+            [
+                scenario.get("text"),
+                scenario.get("category"),
+                scenario.get("characteristic_form"),
+            ]
+        )
+        tags = " ".join(str(tag).lower() for tag in scenario.get("domain_tags") or [])
+        if any(tag in tags for tag in ("fmsr", "wo", "multi")):
+            return True
+
+    text = " ".join(str(part or "").lower() for part in text_parts)
+    if re.search(
+        r"\b("
+        r"fault|failure|risk|rul|remaining useful life|maintenance|work[- ]?order|"
+        r"outage|defer|inspection|inspect|repair|diagnos(?:e|is|tic)"
+        r")\b",
+        text,
+    ):
+        return True
+
+    for record in _iter_tool_records(payload):
+        tool = str(record.get("tool") or "").lower()
+        if tool in ADJUDICATION_TRIGGER_TOOLS or tool in WORK_ORDER_TOOLS:
+            return True
+    return False
 
 
 def _iter_named_values(value: Any, prefix: str = ""):
@@ -776,6 +835,16 @@ def _clear_repaired_hit(
     exact_key = _evidence_key(record)
     unresolved_hits.pop(exact_key, None)
     unresolved_hits.pop((exact_key[0], UNKNOWN_TARGET), None)
+    record_tool = str(record.get("tool") or "").lower()
+    record_step = record.get("step")
+    if record_step is None:
+        return
+    for key, hit in list(unresolved_hits.items()):
+        if (
+            str(hit.get("tool") or "").lower() == record_tool
+            and hit.get("step") == record_step
+        ):
+            unresolved_hits.pop(key, None)
 
 
 def _dedupe_hits(hits: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/scripts/orchestration_utils.py
+++ b/scripts/orchestration_utils.py
@@ -42,9 +42,12 @@ Explicit fault/risk adjudication:
 {adjudication}
 
 If the adjudication decision is "finalize", cite the deciding evidence in the
-final answer and do not introduce a different fault or risk choice. If the
-decision is "refuse_due_missing_evidence", refuse to finalize the maintenance
-recommendation and state what evidence is missing.
+final answer and do not introduce a different fault or risk choice. This block
+is only a constraint on fault/risk claims, not a replacement for the original
+task. Still answer every requested part of the original question using the
+other execution results. If the decision is "refuse_due_missing_evidence",
+refuse to finalize only the unsupported maintenance recommendation and state
+what evidence is missing.
 """
 
 SELF_ASK_PROMPT = """\
@@ -1174,7 +1177,10 @@ def summarize_answer(
         )
         for entry in final_history
     )
-    if fault_risk_adjudication and fault_risk_adjudication.get("enabled"):
+    if fault_risk_adjudication and fault_risk_adjudication.get("decision") in {
+        "finalize",
+        "refuse_due_missing_evidence",
+    }:
         results_text += SUMMARIZE_ADJUDICATION_BLOCK.format(
             adjudication=json.dumps(fault_risk_adjudication, indent=2)
         )

--- a/scripts/orchestration_utils.py
+++ b/scripts/orchestration_utils.py
@@ -1177,10 +1177,10 @@ def summarize_answer(
         )
         for entry in final_history
     )
-    if fault_risk_adjudication and fault_risk_adjudication.get("decision") in {
-        "finalize",
-        "refuse_due_missing_evidence",
-    }:
+    if (
+        fault_risk_adjudication
+        and fault_risk_adjudication.get("decision") == "finalize"
+    ):
         results_text += SUMMARIZE_ADJUDICATION_BLOCK.format(
             adjudication=json.dumps(fault_risk_adjudication, indent=2)
         )

--- a/tests/test_orchestration_utils.py
+++ b/tests/test_orchestration_utils.py
@@ -55,6 +55,7 @@ from orchestration_utils import (  # noqa: E402
 from mitigation_guards import (  # noqa: E402
     EXPLICIT_FAULT_RISK_ADJUDICATION_NAME,
     MISSING_EVIDENCE_REPAIR_NAME,
+    _fault_risk_adjudication_applies,
     apply_explicit_fault_risk_adjudication,
     apply_missing_evidence_final_answer_guard,
     build_explicit_fault_risk_adjudication,
@@ -957,6 +958,24 @@ class OrchestrationUtilsTests(unittest.TestCase):
             "Peak load current was 520 A at 2024-01-07T12:00:00.",
         )
         self.assertNotIn("failed_steps", guarded)
+
+    def test_fault_risk_adjudication_domain_tags_are_exact(self):
+        monitoring_payload = {
+            "question": "Retrieve recent load current readings for T-005.",
+            "scenario": {
+                "domain_tags": ["wood", "multimedia"],
+                "text": "Retrieve current readings and report the peak value.",
+            },
+            "history": [],
+        }
+        work_order_payload = {
+            "question": "Summarize the current transformer status.",
+            "scenario": {"domain_tags": ["wo"]},
+            "history": [],
+        }
+
+        self.assertFalse(_fault_risk_adjudication_applies(monitoring_payload))
+        self.assertTrue(_fault_risk_adjudication_applies(work_order_payload))
 
     def test_build_fault_risk_adjudication_state_uses_config(self):
         with patch.dict(

--- a/tests/test_orchestration_utils.py
+++ b/tests/test_orchestration_utils.py
@@ -902,6 +902,62 @@ class OrchestrationUtilsTests(unittest.TestCase):
             EXPLICIT_FAULT_RISK_ADJUDICATION_NAME,
         )
 
+    def test_fault_risk_adjudication_skips_iot_only_monitoring_task(self):
+        payload = {
+            "question": (
+                "Retrieve load current readings for T-005, compare them to the "
+                "recent baseline, and report the peak value."
+            ),
+            "answer": "Peak load current was 520 A at 2024-01-07T12:00:00.",
+            "success": True,
+            "scenario": {
+                "type": "IoT",
+                "domain_tags": ["IoT"],
+                "text": "T-005 has elevated load current readings.",
+            },
+            "history": [
+                {
+                    "step": 1,
+                    "task": "Read load current",
+                    "server": "iot",
+                    "tool": "get_sensor_readings",
+                    "tool_args": {
+                        "transformer_id": "T-005",
+                        "sensor_id": "load_current_a",
+                    },
+                    "response": '{"readings": [{"value": 520.0}]}',
+                    "error": None,
+                    "success": True,
+                },
+                {
+                    "step": 2,
+                    "task": "Check anomalous load-current readings",
+                    "server": "tsfm",
+                    "tool": "detect_anomalies",
+                    "tool_args": {
+                        "transformer_id": "T-005",
+                        "sensor_id": "load_current_a",
+                    },
+                    "response": '{"anomaly_count": 3, "anomaly_rate_pct": 2.5}',
+                    "error": None,
+                    "success": True,
+                },
+            ],
+        }
+
+        guarded = apply_explicit_fault_risk_adjudication(payload, enabled=True)
+
+        self.assertTrue(guarded["success"])
+        self.assertEqual(
+            guarded["fault_risk_adjudication"]["decision"],
+            "not_applicable",
+        )
+        self.assertEqual(
+            guarded["answer"],
+            "Peak load current was 520 A at 2024-01-07T12:00:00.",
+        )
+        self.assertNotIn("failed_steps", guarded)
+
     def test_build_fault_risk_adjudication_state_uses_config(self):
         with patch.dict(
             os.environ,
@@ -1103,6 +1159,47 @@ class OrchestrationUtilsTests(unittest.TestCase):
         self.assertTrue(guarded["success"])
         self.assertFalse(guarded["mitigation_guard"]["triggered"])
         self.assertEqual(guarded["failed_steps"], [])
+
+    def test_missing_evidence_guard_allows_same_step_retry_with_repaired_args(self):
+        payload = {
+            "answer": "Use FM-006 sensor correlations for ongoing monitoring.",
+            "success": True,
+            "failed_steps": [],
+            "history": [
+                {
+                    "step": 4,
+                    "task": "Fetch sensor correlations",
+                    "server": "fmsr",
+                    "tool": "get_sensor_correlation",
+                    "tool_args": {
+                        "failure_mode_id": "Low-temperature overheating",
+                    },
+                    "response": (
+                        '{"error": "Failure mode '
+                        "'Low-temperature overheating' not found.\"}"
+                    ),
+                    "error": "Failure mode 'Low-temperature overheating' not found.",
+                    "success": False,
+                },
+                {
+                    "step": 4,
+                    "task": "Retry sensor correlations",
+                    "server": "fmsr",
+                    "tool": "get_sensor_correlation",
+                    "tool_args": {"failure_mode_id": "FM-006"},
+                    "response": (
+                        '{"failure_mode_id": "FM-006", ' '"key_gases": ["C2H2", "H2"]}'
+                    ),
+                    "error": None,
+                    "success": True,
+                },
+            ],
+        }
+
+        guarded = apply_missing_evidence_final_answer_guard(payload, enabled=True)
+
+        self.assertTrue(guarded["success"])
+        self.assertFalse(guarded["mitigation_guard"]["triggered"])
 
     def test_missing_evidence_guard_blocks_work_order_before_retry(self):
         payload = {


### PR DESCRIPTION
## Summary

- tighten missing-evidence repair bookkeeping so corrected same-step same-tool retries clear stale failed evidence hits
- scope explicit fault/risk adjudication away from monitoring-only IoT/TSFM tasks and generic anomaly-only evidence
- constrain adjudicated summaries to preserve the original task while only adjudicating fault/risk claims
- document the first A100 four-tier cohort as diagnostic evidence, not a final mitigation-lift claim

## Test plan

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_orchestration_utils.py` -> `59 passed, 3 subtests passed`
- `python3 -m py_compile scripts/mitigation_guards.py scripts/orchestration_utils.py`
- `git diff --check`
- artifact replay checks against local GCP A100 pullback: SGT-014 repaired row no longer triggers the missing-evidence scan; SGT-012 adjudication is `not_applicable`; SGT-010 still adjudicates because it asks for outage/defer maintenance

Refs #35, #64, #66. Issues remain open; patched matched reruns and final before/after CSV interpretation are still pending.
