### PR TITLE
Type-specific JSON encoder + token-usage capture (#131, #133)

### DIFF
--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import datetime as _dt
 import json
 import logging
 import os
@@ -49,6 +50,61 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 _LOG = logging.getLogger("aat_runner")
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON encoder for trial output payloads. Type-specific, fail-closed.
+
+    Replaces the prior `default=str` which silently stringified anything —
+    fine for `pandas.Timestamp`/`datetime` (roundtrippable ISO-8601) but
+    lossy for `numpy.ndarray` (str() truncates above ~1000 elements per
+    `numpy.set_printoptions`) and outright wrong for `pandas.DataFrame`
+    (str() is the human-readable table). #131 / PR #130 review Medium 5.
+
+    Accept: stdlib datetime + date, plus pandas.Timestamp and
+    numpy.datetime64 if those packages are importable. Anything else
+    raises TypeError so the caller sees the failure instead of a
+    silently-corrupted artifact downstream.
+    """
+    if isinstance(obj, (_dt.datetime, _dt.date)):
+        return obj.isoformat()
+
+    # pandas / numpy are optional dependencies — import lazily and fall
+    # through to TypeError if absent so we don't pretend to handle them.
+    try:
+        import pandas as _pd  # type: ignore
+
+        if isinstance(obj, _pd.Timestamp):
+            # pandas.Timestamp.isoformat() is roundtrippable.
+            return obj.isoformat()
+    except ImportError:
+        pass
+    try:
+        import numpy as _np  # type: ignore
+
+        if isinstance(obj, _np.datetime64):
+            # `_np.datetime64` doesn't have isoformat(); cast through pandas
+            # if available for an ISO string, else emit the str() form which
+            # IS roundtrippable for datetime64 specifically (e.g.
+            # '2026-04-28T17:00:00.000000000').
+            try:
+                import pandas as _pd  # type: ignore
+
+                return _pd.Timestamp(obj).isoformat()
+            except ImportError:
+                return str(obj)
+    except ImportError:
+        pass
+
+    raise TypeError(
+        f"unserializable type {type(obj).__module__}.{type(obj).__name__!r}: "
+        f"{_json_default.__module__} only handles datetime / date / "
+        f"pandas.Timestamp / numpy.datetime64. If a tool is returning a "
+        f"numpy array or pandas DataFrame, convert it inside the tool to a "
+        f"plain list/dict before returning, since str() on those types is "
+        f"silently lossy."
+    )
+
 
 # Importable without the SDK installed, so unit tests can patch before import.
 # Real imports happen lazily inside _main().
@@ -289,6 +345,26 @@ def _serialize_run_result(
     except Exception:
         sdk_version = "unknown"
 
+    # Token usage — pulled from the OpenAI Agents SDK's
+    # RunContextWrapper.usage. The SDK accumulates per-LLM-call counters
+    # across the run loop, so this single read covers every turn the
+    # agent took. Missing on stubbed test results / older SDKs; fall
+    # through to None values so summary aggregation can detect missing
+    # data instead of treating it as zero. (#133 / PR #130 review Low 9)
+    usage_block: dict[str, Any] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "requests": None,
+    }
+    ctx_wrapper = getattr(result, "context_wrapper", None)
+    sdk_usage = getattr(ctx_wrapper, "usage", None) if ctx_wrapper else None
+    if sdk_usage is not None:
+        for field_name in ("input_tokens", "output_tokens", "total_tokens", "requests"):
+            value = getattr(sdk_usage, field_name, None)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                usage_block[field_name] = value
+
     return {
         "question": prompt,
         "answer": answer,
@@ -297,6 +373,7 @@ def _serialize_run_result(
         "max_turns_exhausted": max_turns_reached,
         "turn_count": turn,
         "tool_call_count": tool_call_count,
+        "usage": usage_block,
         "history": history,
         "runner_meta": {
             "model_id": args.model_id,
@@ -313,7 +390,10 @@ def _serialize_run_result(
 
 def _write_output(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, default=_json_default) + "\n",
+        encoding="utf-8",
+    )
 
 
 @dataclass

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -1357,11 +1357,42 @@ wall_clock_seconds_total = sum(latencies) + (mcp_setup_seconds or 0)
 
 tool_call_total = 0
 tool_call_trials = 0
+# Per-trial token usage, aggregated for summary.json (#133). Tokens are
+# captured by aat_runner.py from the Agents SDK RunContextWrapper.usage and
+# written into payload["usage"] on each trial JSON. Trials with missing /
+# null usage are excluded from the totals so the summary distinguishes
+# "no data" (None) from "zero tokens" (0).
+input_tokens_total = 0
+output_tokens_total = 0
+total_tokens_total = 0
+usage_trials = 0
 for output_path in sorted(pathlib.Path(run_dir).glob("*_run[0-9][0-9].json")):
     try:
         payload = json.loads(output_path.read_text(encoding="utf-8"))
     except Exception:
         continue
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        i_t = usage.get("input_tokens")
+        o_t = usage.get("output_tokens")
+        t_t = usage.get("total_tokens")
+        # Only count trials that report at least input + output. Treat
+        # explicit None as missing (not zero).
+        if (
+            isinstance(i_t, int)
+            and not isinstance(i_t, bool)
+            and i_t >= 0
+            and isinstance(o_t, int)
+            and not isinstance(o_t, bool)
+            and o_t >= 0
+        ):
+            input_tokens_total += i_t
+            output_tokens_total += o_t
+            if isinstance(t_t, int) and not isinstance(t_t, bool) and t_t >= 0:
+                total_tokens_total += t_t
+            else:
+                total_tokens_total += i_t + o_t
+            usage_trials += 1
     explicit_tool_calls = payload.get("tool_call_count")
     if (
         isinstance(explicit_tool_calls, int)
@@ -1435,9 +1466,21 @@ summary = {
     "latency_seconds_p50": percentile(latencies, 50),
     "latency_seconds_p95": percentile(latencies, 95),
     "mcp_setup_seconds": mcp_setup_seconds,
-    "tokens_per_second_mean": None,
-    "input_tokens_total": None,
-    "output_tokens_total": None,
+    # End-to-end agent throughput. Denominator is wall_clock_seconds_total
+    # which includes tool-call round-trips, MCP serialization, and
+    # orchestration time — NOT just model decode. Per #133 / Alex's review:
+    # label this "end-to-end agent throughput", not "model decode tok/s".
+    # Null when no trial reported usage (e.g. older runs predating the
+    # aat_runner.py usage capture in #131/#133 PR).
+    "tokens_per_second_mean": (
+        (output_tokens_total / wall_clock_seconds_total)
+        if usage_trials and wall_clock_seconds_total
+        else None
+    ),
+    "input_tokens_total": input_tokens_total if usage_trials else None,
+    "output_tokens_total": output_tokens_total if usage_trials else None,
+    "total_tokens_total": total_tokens_total if usage_trials else None,
+    "tokens_usage_trial_count": usage_trials,
     "tool_call_count_total": tool_call_total if tool_call_trials else None,
     "tool_call_count_mean": (tool_call_total / tool_call_trials) if tool_call_trials else None,
     "mcp_latency_seconds_mean": None,

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -142,6 +142,184 @@ def test_serialize_run_result_max_turns_exhausted():
     assert out["max_turns_exhausted"] is True
 
 
+# ---------------------------------------------------------------------------
+# #133 — token usage capture from the Agents SDK RunContextWrapper.usage
+# ---------------------------------------------------------------------------
+
+
+def _stub_run_result_with_usage(
+    *,
+    input_tokens: int | None = 1234,
+    output_tokens: int | None = 567,
+    total_tokens: int | None = 1801,
+    requests: int | None = 5,
+):
+    """Stub RunResult with a context_wrapper.usage that mirrors the SDK shape."""
+    return SimpleNamespace(
+        new_items=[_msg_item("answer")],
+        final_output="answer",
+        max_turns_reached=False,
+        raw_responses=[],
+        context_wrapper=SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+                requests=requests,
+            )
+        ),
+    )
+
+
+def test_serialize_usage_captured_when_present():
+    """Trial JSON should carry the usage block from RunContextWrapper.usage."""
+    from scripts.aat_runner import _serialize_run_result
+
+    out = _serialize_run_result(
+        _stub_args(), "p", _stub_run_result_with_usage(), duration_seconds=1.0
+    )
+
+    assert out["usage"] == {
+        "input_tokens": 1234,
+        "output_tokens": 567,
+        "total_tokens": 1801,
+        "requests": 5,
+    }
+
+
+def test_serialize_usage_missing_yields_null_block():
+    """Older SDK / stubbed result without context_wrapper -> all-null usage block.
+
+    summary.json's aggregator distinguishes None (no data) from 0 (zero
+    tokens), so we deliberately don't fall back to zeros here.
+    """
+    from scripts.aat_runner import _serialize_run_result
+
+    out = _serialize_run_result(
+        _stub_args(), "p", _stub_run_result(), duration_seconds=1.0
+    )
+
+    assert out["usage"] == {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "requests": None,
+    }
+
+
+def test_serialize_usage_negative_or_non_int_treated_as_missing():
+    """A malformed SDK Usage with strings / negatives shouldn't poison the block."""
+    from scripts.aat_runner import _serialize_run_result
+
+    out = _serialize_run_result(
+        _stub_args(),
+        "p",
+        _stub_run_result_with_usage(
+            input_tokens="not-an-int",
+            output_tokens=-1,
+            total_tokens=None,
+            requests=True,  # bool is technically int subclass; explicitly excluded.
+        ),
+        duration_seconds=1.0,
+    )
+
+    assert out["usage"] == {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "requests": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# #131 — type-specific JSON encoder (replaces default=str)
+# ---------------------------------------------------------------------------
+
+
+def test_json_default_serializes_datetime_and_date():
+    """stdlib datetime + date land as ISO-8601 strings, matching the prior behavior."""
+    import datetime as dt
+
+    from scripts.aat_runner import _json_default
+
+    assert _json_default(dt.datetime(2026, 4, 28, 17, 0, 0)) == "2026-04-28T17:00:00"
+    assert _json_default(dt.date(2026, 4, 28)) == "2026-04-28"
+
+
+def test_json_default_serializes_pandas_timestamp_when_available():
+    """pandas.Timestamp -> isoformat. Skip cleanly if pandas isn't installed."""
+    pd = pytest.importorskip("pandas")
+    from scripts.aat_runner import _json_default
+
+    ts = pd.Timestamp("2026-04-28T17:00:00")
+    assert _json_default(ts) == ts.isoformat()
+
+
+def test_json_default_serializes_numpy_datetime64_when_available():
+    """numpy.datetime64 -> ISO string via pandas if both installed."""
+    np = pytest.importorskip("numpy")
+    from scripts.aat_runner import _json_default
+
+    out = _json_default(np.datetime64("2026-04-28T17:00:00"))
+    # Accept either pandas-routed isoformat or the raw datetime64 str()
+    # (which is also roundtrippable for this type specifically).
+    assert "2026-04-28" in out
+
+
+def test_json_default_rejects_numpy_array():
+    """numpy.ndarray must raise TypeError, not silently stringify (Alex's M5)."""
+    np = pytest.importorskip("numpy")
+    from scripts.aat_runner import _json_default
+
+    with pytest.raises(TypeError, match="numpy"):
+        _json_default(np.array([1, 2, 3]))
+
+
+def test_json_default_rejects_pandas_dataframe():
+    """pandas.DataFrame must raise TypeError, not write the human-readable table."""
+    pd = pytest.importorskip("pandas")
+    from scripts.aat_runner import _json_default
+
+    with pytest.raises(TypeError, match="pandas"):
+        _json_default(pd.DataFrame({"a": [1, 2, 3]}))
+
+
+def test_json_default_rejects_arbitrary_object():
+    """Anything outside the allow-list must raise TypeError, not stringify."""
+    from scripts.aat_runner import _json_default
+
+    class Unhandled:
+        pass
+
+    with pytest.raises(TypeError, match="unserializable"):
+        _json_default(Unhandled())
+
+
+def test_write_output_uses_type_specific_encoder(tmp_path):
+    """End-to-end: _write_output rejects a payload containing a numpy array.
+
+    The prior code would silently write '[1 2 3]'; the new code fails closed.
+    """
+    np = pytest.importorskip("numpy")
+    from scripts.aat_runner import _write_output
+
+    bad_payload = {"answer": "ok", "rogue": np.array([1, 2, 3])}
+    with pytest.raises(TypeError, match="numpy"):
+        _write_output(tmp_path / "out.json", bad_payload)
+
+
+def test_write_output_serializes_timestamp_payload(tmp_path):
+    """The Timestamp case PR #130 originally fixed must still work."""
+    pd = pytest.importorskip("pandas")
+    from scripts.aat_runner import _write_output
+
+    payload = {"answer": "ok", "ts": pd.Timestamp("2026-04-28T17:00:00")}
+    out = tmp_path / "trial.json"
+    _write_output(out, payload)
+    loaded = json.loads(out.read_text())
+    assert loaded["ts"] == "2026-04-28T17:00:00"
+
+
 def test_cli_parses_required_args():
     from scripts.aat_runner import build_parser
 

--- a/tests/test_run_experiment_summary.py
+++ b/tests/test_run_experiment_summary.py
@@ -152,6 +152,171 @@ def test_summary_records_null_mcp_setup_when_absent(tmp_path):
     assert meta["mcp_setup_seconds"] is None
 
 
+def _write_trial(
+    run_dir: Path,
+    *,
+    name: str,
+    success: bool = True,
+    tool_call_count: int = 1,
+    usage: dict | None = None,
+) -> None:
+    """Write a per-trial JSON shaped like the aat_runner output."""
+    payload = {
+        "question": "test",
+        "answer": "ok",
+        "success": success,
+        "max_turns_exhausted": False,
+        "turn_count": 1,
+        "tool_call_count": tool_call_count,
+        "usage": usage if usage is not None else {},
+        "history": [
+            {"turn": 1, "role": "assistant", "content": "ok", "tool_calls": []}
+        ],
+        "runner_meta": {"duration_seconds": 1.0},
+    }
+    (run_dir / name).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def test_summary_aggregates_token_usage_when_trials_report_it(tmp_path):
+    """#133: per-trial usage blocks roll up into summary token totals + tok/s."""
+    repo_root = Path(__file__).resolve().parent.parent
+    summary_py = _extract_summary_python(repo_root)
+
+    summary_path = tmp_path / "summary.json"
+    config_path = tmp_path / "config.json"
+    meta_path = tmp_path / "meta.json"
+    latency_path = tmp_path / "latencies.jsonl"
+    run_dir = tmp_path / "raw" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    config_path.write_text(
+        json.dumps(_base_config(summary_path), indent=2) + "\n", encoding="utf-8"
+    )
+    meta_path.write_text(json.dumps({"started_at": "now"}) + "\n", encoding="utf-8")
+    # Two trials, 5s wall-clock each → 10s total in the throughput denominator.
+    latency_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"latency_seconds": 5.0}),
+                json.dumps({"latency_seconds": 5.0}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _write_trial(
+        run_dir,
+        name="2026-04-28_C_llama_agent_as_tool_optimized_scenA_run01.json",
+        usage={
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "total_tokens": 300,
+            "requests": 3,
+        },
+    )
+    _write_trial(
+        run_dir,
+        name="2026-04-28_C_llama_agent_as_tool_optimized_scenA_run02.json",
+        usage={
+            "input_tokens": 150,
+            "output_tokens": 250,
+            "total_tokens": 400,
+            "requests": 4,
+        },
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            summary_py,
+            str(summary_path),
+            str(config_path),
+            str(meta_path),
+            str(latency_path),
+            str(run_dir),
+            "2",
+            "0",
+            "2",
+            "0",
+            "0",
+        ],
+        check=True,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["input_tokens_total"] == 250
+    assert summary["output_tokens_total"] == 450
+    assert summary["total_tokens_total"] == 700
+    assert summary["tokens_usage_trial_count"] == 2
+    # End-to-end agent throughput = output_tokens_total / wall_clock_seconds_total
+    # = 450 / 10.0 = 45.0 tok/s. (Includes tool-call + MCP time in denominator
+    # per Alex's review note — this is NOT pure model-decode tok/s.)
+    assert summary["tokens_per_second_mean"] == 45.0
+
+
+def test_summary_token_fields_null_when_no_trial_reports_usage(tmp_path):
+    """Older trials predating the usage capture stay null in summary."""
+    repo_root = Path(__file__).resolve().parent.parent
+    summary_py = _extract_summary_python(repo_root)
+
+    summary_path = tmp_path / "summary.json"
+    config_path = tmp_path / "config.json"
+    meta_path = tmp_path / "meta.json"
+    latency_path = tmp_path / "latencies.jsonl"
+    run_dir = tmp_path / "raw" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    config_path.write_text(
+        json.dumps(_base_config(summary_path), indent=2) + "\n", encoding="utf-8"
+    )
+    meta_path.write_text(json.dumps({"started_at": "now"}) + "\n", encoding="utf-8")
+    latency_path.write_text(
+        json.dumps({"latency_seconds": 1.0}) + "\n", encoding="utf-8"
+    )
+    # Trial omits usage entirely (older artifact shape).
+    payload = {
+        "question": "p",
+        "answer": "a",
+        "success": True,
+        "max_turns_exhausted": False,
+        "turn_count": 1,
+        "tool_call_count": 0,
+        "history": [],
+        "runner_meta": {},
+    }
+    (run_dir / "2026-04-28_legacy_run01.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            summary_py,
+            str(summary_path),
+            str(config_path),
+            str(meta_path),
+            str(latency_path),
+            str(run_dir),
+            "1",
+            "0",
+            "1",
+            "0",
+            "0",
+        ],
+        check=True,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["input_tokens_total"] is None
+    assert summary["output_tokens_total"] is None
+    assert summary["total_tokens_total"] is None
+    assert summary["tokens_per_second_mean"] is None
+    assert summary["tokens_usage_trial_count"] == 0
+
+
 def test_summary_records_resume_skip_and_rerun_counts(tmp_path):
     """Resume summaries expose skipped/rerun counts without changing pass math."""
     repo_root = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

Two bundled cleanups from PR #130's review fall-out, both labeled `cut-plan-core`. Same review surface (`scripts/aat_runner.py` + `scripts/run_experiment.sh`), so combined into one PR.

## #131 — type-specific JSON encoder (replaces `default=str`)

`scripts/aat_runner.py:_write_output` now routes through a new `_json_default()` helper instead of `default=str`. Encoder accepts:

- `datetime.datetime`, `datetime.date` → `.isoformat()`
- `pandas.Timestamp` (when pandas installed) → `.isoformat()`
- `numpy.datetime64` (when numpy installed) → ISO string via pandas, or `str()` fallback (roundtrippable for this type specifically)

Anything else — `numpy.ndarray`, `pandas.DataFrame`, arbitrary object — raises `TypeError` with a message naming the offending type and pointing at the right fix (convert inside the tool). Per Alex's PR #130 review M5: a tool returning `np.array([1, 2, 3])` previously silently landed as the string `'[1 2 3]'` in the trial JSON, which broke Notebook 02 parsing downstream.

## #133 — vLLM token throughput in `summary.json`

**Per-trial capture (`scripts/aat_runner.py`):** `_serialize_run_result` reads `result.context_wrapper.usage` from the OpenAI Agents SDK `RunContextWrapper` (which accumulates `input_tokens`, `output_tokens`, `total_tokens`, `requests` across every LLM call in the run loop) and writes them into a new top-level `usage` dict on each trial JSON. Missing / malformed values are explicitly preserved as `None` so the aggregator distinguishes "no data" from "zero tokens."

**Cell aggregation (`scripts/run_experiment.sh`):** the summary builder walks each per-trial JSON in the same loop that already counts tool calls, sums input/output/total tokens across trials that report them, and writes the totals + end-to-end agent throughput into `summary.json`:

```python
input_tokens_total          # sum across trials w/ usage
output_tokens_total
total_tokens_total
tokens_per_second_mean      # output_tokens_total / wall_clock_total
tokens_usage_trial_count    # how many trials contributed
```

**Per Alex's review note**, the summary's `tokens_per_second_mean` is **end-to-end agent throughput** (denominator includes tool calls + MCP serialization + orchestration time), NOT pure model decode tok/s. The inline comment in `run_experiment.sh` calls this out so paper readers and notebook consumers don't misread the metric. Older trials predating the usage capture stay `null`.

## Tests

`tests/test_aat_runner.py` (+11 cases):

- `usage` block populated from `RunContextWrapper.usage` when present
- `usage` all-null when `context_wrapper` is missing (older / stubbed runs)
- Malformed usage values (string, negative, bool) treated as missing
- `_json_default` round-trips `datetime` / `date` / `pandas.Timestamp`
- `_json_default` ISO-strings `numpy.datetime64`
- `_json_default` raises `TypeError` for `numpy.ndarray` + `pandas.DataFrame` + arbitrary object — the silent-data-loss cases #131 specifically addresses
- `_write_output` end-to-end fails closed on a numpy-array payload
- `_write_output` end-to-end still serializes the `Timestamp` case PR #130 originally fixed

`tests/test_run_experiment_summary.py` (+2 cases):

- Per-trial usage rolls up into `summary.json` totals + `tokens_per_second_mean = 45.0` on a 250-input/450-output, 10-second-wall-clock fixture
- Trials predating the usage capture leave the summary token fields `null` without erroring

```
python -m pytest tests/test_aat_runner.py tests/test_run_experiment_summary.py -q
  -> 30 passed
python -m pytest tests/ -q --deselect tests/test_aat_tools_direct.py::test_direct_and_mcp_tool_schemas_match
  -> 205 passed (deselected test is a pre-existing infra failure on main:
     `uv` binary not on local PATH for the MCP launch path)
python -m black --check scripts/aat_runner.py tests/test_aat_runner.py tests/test_run_experiment_summary.py
  -> 3 files, all clean
```

## Test plan

- [x] All 30 new tests + 175 pre-existing tests pass; black clean.
- [ ] **(Reviewer)** Spot-check `_json_default` accepts the datetime types and rejects numpy arrays per the inline test cases.
- [ ] **(Reviewer)** Spot-check the new `summary.json` fields (`input_tokens_total`, `output_tokens_total`, `total_tokens_total`, `tokens_per_second_mean`, `tokens_usage_trial_count`) and confirm the comment about end-to-end vs decode is clear enough for paper readers.
- [ ] **(Insomnia, when CVE-fix downtime ends)** First W5 capture under this branch produces non-null token fields in `summary.json` with sane numbers (~30-100 tok/s for Llama-3.1-8B on A6000).

## Closes

- `#131` — JSON encoder
- `#133` — token throughput

## Notes for review

- Insomnia is currently down for CVE-fix maintenance per the team thread — the live capture acceptance check (sane tok/s on A6000) will land once the cluster is back. Meanwhile the unit tests cover the round-trip from `RunContextWrapper.usage` shape → trial JSON → summary aggregation, so the wiring is verified offline.
- Did not touch `scripts/run_experiment.sh` outside the summary builder — `EXTRA_VLLM_ARGS`, `gpu_type` (PR #145), and the meta classifier fields (PR #144) are all unaffected.