### PR TITLE
Document benchmark hardware provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Hardened future Insomnia/GCP vLLM evidence runs: Insomnia batch defaults now
+  request A6000 GPUs explicitly instead of generic GPUs, and vLLM launchers pass
+  `--generation-config vllm` while preserving caller-side `TEMPERATURE=0.0`
+  decoding intent.
 - Implemented the explicit fault/risk adjudication mitigation rung for #35 /
   #64 / #66. PE-family runners can now emit structured
   `fault_risk_adjudication` metadata, cite concrete deciding evidence when

--- a/docs/compute_environment_discrepancies.md
+++ b/docs/compute_environment_discrepancies.md
@@ -1,0 +1,82 @@
+# Compute Environment Discrepancies
+
+*Last updated: 2026-05-03*
+*Owner: Alex Xin*
+
+This note records the hardware/runtime discrepancy discovered while comparing
+the first Insomnia Experiment 2 captures against the GCP A100 final-six runs.
+It is an evidence-quality note, not a replacement for the current final matrix
+in `docs/experiment_matrix.md`.
+
+## Insomnia first-capture hardware
+
+The first Experiment 2 PE-family capture was not a single-hardware cohort. The
+Slurm wrapper at the time requested a generic GPU (`--gres=gpu:1`), so the
+scheduler was free to allocate any eligible GPU type on the `short` partition.
+
+| Cell | Run ID | Node | GPU | vLLM attention | KV cache |
+|---|---|---|---|---|---|
+| Y | `8998340_exp2_cell_Y_pe_mcp_baseline` | `ins083` | NVIDIA RTX A6000 | FlashAttention 2 | 221,824 tokens |
+| YS | `8998341_exp2_cell_Y_pe_self_ask_mcp_baseline` | `ins084` | NVIDIA RTX A6000 | FlashAttention 2 | 221,824 tokens |
+| Z | `8998342_exp2_cell_Z_verified_pe_mcp_baseline` | `ins084` | NVIDIA RTX A6000 | FlashAttention 2 | 221,824 tokens |
+| ZS | `8998343_exp2_cell_Z_verified_pe_self_ask_mcp_baseline` | `ins050` | NVIDIA H100 NVL | FlashAttention 3 | 545,456 tokens |
+
+This explains the otherwise surprising observation that the historical ZS 2x3
+run reported FlashAttention 3 while the nearby Insomnia rows reported
+FlashAttention 2. It was not a package downgrade or repo change; it was a
+different Slurm allocation.
+
+## GCP final-six hardware
+
+The final-six GCP matrix was a consistent A100 cohort. The summary pullback in
+`benchmarks/gcp_a100_final_20260503/summary/README.md` records an
+`a2-highgpu-1g` Spot VM with one NVIDIA A100-SXM4-40GB GPU. Those vLLM logs use
+FlashAttention 2 and report a smaller KV-cache pool, for example the ZS row:
+
+- run: `final5x6_a100_20260503T090200Z_ZS_final5x6_exp2_cell_Z_verified_pe_self_ask_mcp_baseline`
+- GPU: NVIDIA A100-SXM4-40GB
+- vLLM attention: FlashAttention 2
+- available KV cache memory: 19.92 GiB
+- GPU KV cache size: 163,168 tokens
+
+The final matrix should therefore be interpreted as GCP A100 evidence. The
+historical Insomnia first-capture table is useful for debugging and narrative
+context, but it should not be used as a same-hardware comparison against the
+GCP A100 matrix without explicit labels.
+
+## How to reproduce the 2x3 hardware comparison
+
+To compare the old Z and ZS behavior on Insomnia, run the same 2-scenario x
+3-trial slice on each requested GPU class:
+
+- Z and ZS on H100: submit with `--gres=gpu:h100:1`.
+- Z and ZS on A6000: submit with `--gres=gpu:A6000:1`.
+- Use a temporary config copy that pins `SCENARIOS_GLOB` to the original two
+  multi-domain scenarios, e.g. `data/scenarios/multi_0[12]_*.json`, because
+  the current `multi_*.json` glob now matches more than two files.
+- Keep `TRIALS=3`, `MAX_MODEL_LEN=32768`, `TEMPERATURE=0.0`, and the same
+  `openai/Llama-3.1-8B-Instruct` model path.
+
+For future evidence runs where hardware must be controlled, rely on typed GPU
+requests. As of 2026-05-03 the committed Insomnia batch defaults request
+A6000 explicitly; H100 or generic-GPU runs should be requested deliberately
+from the `sbatch` command line and labeled as hardware-comparison or
+hardware-flexible evidence.
+
+## Current Insomnia writable-path check
+
+On 2026-05-03, a login-node filesystem check found:
+
+- `/insomnia001` exists but is root-owned and not writable.
+- `/insomnia001/depts/edu/users/team13` was not present from the login node.
+- `/tmp`, `/dev/shm`, and `/run/user/43118` are writable tmpfs locations; use
+  only for ephemeral probes, not durable benchmark artifacts.
+- `/manitou-home/rcs` is writable and `mkdir` succeeded for a temporary probe,
+  but the mounted filesystem was 99% full (`8.0T` available of `581T`) and the
+  directory is world-writable rather than a clean team scratch area.
+
+Recommendation: ask RCS to restore or create an intended durable team scratch
+directory before launching new artifact-heavy Insomnia runs. If we must run
+before that is resolved, use a small explicitly named subdirectory under
+`/manitou-home/rcs` only after confirming it is acceptable for course-team
+work and keep large artifacts pruned or moved promptly.

--- a/docs/experiment2_capture_plan.md
+++ b/docs/experiment2_capture_plan.md
@@ -1,6 +1,6 @@
 # Experiment 2 Capture Plan
 
-*Last updated: 2026-04-27*
+*Last updated: 2026-05-03*
 *Owner: Wei Alexander Xin (wax1)*
 
 Plan for producing the raw benchmark + profiling artifacts for Experiment 2
@@ -75,6 +75,12 @@ the judge, or vice-versa.
 | Y + Self-Ask | Plan-Execute + Self-Ask | `8998341_exp2_cell_Y_pe_self_ask_mcp_baseline` | 6/6 | 3/6 | 0.444 |
 | Z | Verified PE | `8998342_exp2_cell_Z_verified_pe_mcp_baseline` | 6/6 | 4/6 | 0.639 |
 | Z + Self-Ask | Verified PE + Self-Ask | `8998343_exp2_cell_Z_verified_pe_self_ask_mcp_baseline` | 6/6 | **5/6** | **0.833** |
+
+Hardware caveat: this first PE-family capture was not a single-hardware
+cohort. Y/YS/Z landed on Insomnia A6000 nodes, while Z + Self-Ask landed on an
+H100 NVL node because the Slurm wrapper then requested generic `--gres=gpu:1`.
+Keep that in mind when interpreting the standout ZS 5/6 result; see
+`docs/compute_environment_discrepancies.md`.
 
 Pre-canonical smokes still on disk (kept as historical reference, not
 analysis sources):

--- a/docs/experiment_matrix.md
+++ b/docs/experiment_matrix.md
@@ -42,6 +42,12 @@ at `results/metrics/experiment_matrix_summary.csv`; the focused
 optimized-serving follow-on deltas live at
 `results/metrics/optimized_serving_ablation.csv`.
 
+Caveat: the historical PE-family rows below are not a single-hardware cohort.
+Y/YS/Z used Insomnia A6000 nodes, while ZS used an H100 NVL allocation because
+the Slurm request then was generic `--gres=gpu:1`. See
+`docs/compute_environment_discrepancies.md` before comparing those rows against
+the GCP A100 final-six matrix.
+
 | Legacy | Display code | Meaning | Run | Status | N | Canonical | Success | p50 latency | p95 latency | Judge score | Judge pass |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
 | A | AT-I | Agent-as-Tool direct Python tools | `8979314_aat_direct` | success | 6 | 6/6 | 1.00 | 12.15 | 17.29 | 0.167 | 1/6 (16.7%) |

--- a/docs/insomnia_runbook.md
+++ b/docs/insomnia_runbook.md
@@ -432,7 +432,7 @@ PY
 If you want to verify a real `import vllm` or `import torch`, do that only from a
 compute node:
 ```bash
-srun --account=edu --partition=short --qos=short --gres=gpu:1 \
+srun --account=edu --partition=short --qos=short --gres=gpu:A6000:1 \
      --mem=64G --time=01:00:00 --pty bash
 cd /insomnia001/depts/edu/users/team13/hpml-assetopsbench-smart-grid-mcp
 source .venv-insomnia/bin/activate
@@ -459,7 +459,7 @@ running.
 Always grab a compute node first:
 
 ```bash
-srun --account=edu --partition=short --qos=short --gres=gpu:1 \
+srun --account=edu --partition=short --qos=short --gres=gpu:A6000:1 \
      --mem=64G --time=01:00:00 --pty bash
 ```
 
@@ -474,7 +474,7 @@ Grab an interactive shell and run vLLM in the foreground so you see all output
 live:
 
 ```bash
-srun --account=edu --partition=short --qos=short --gres=gpu:1 \
+srun --account=edu --partition=short --qos=short --gres=gpu:A6000:1 \
      --mem=64G --time=01:00:00 --pty bash
 
 # Once you're on the compute node:
@@ -491,7 +491,8 @@ python -c "import vllm; print(vllm.__version__)"
 python -u -m vllm.entrypoints.openai.api_server \
     --model models/Llama-3.1-8B-Instruct \
     --served-model-name Llama-3.1-8B-Instruct \
-    --port 8000 --max-model-len 8192 --dtype float16
+    --port 8000 --max-model-len 8192 --dtype float16 \
+    --generation-config vllm
 ```
 
 **Use the tool-call serve for any benchmark / AaT / PE reproduction.** As of
@@ -688,14 +689,16 @@ expect queue waits during weekday business hours. Some heuristics:
 - **Off-peak (evenings, weekends):** jobs typically start within minutes
 - **Peak (weekday afternoons):** can be 30 min to several hours
 - **`ReqNodeNotAvail`** in `squeue` reason column means the requested nodes
-  are reserved — try a different GPU type (`--gres=gpu:1` instead of
-  `--gres=gpu:A6000:1`) to give the scheduler more flexibility
+  are reserved. For evidence runs, wait for an A6000 slot or explicitly choose
+  a named comparison GPU such as H100. Use generic `--gres=gpu:1` only for
+  hardware-flexible exploratory work, and record the allocated GPU in the
+  artifact note.
 - **`Priority`** just means you're in line; check estimated start with
   `squeue -u <UNI> --start`
 
 Llama-3.1-8B at FP16 fits on every GPU type Insomnia exposes to the `edu`
-account today (A6000 48 GB, L40/L40S 48 GB, H100 80 GB), so `--gres=gpu:1` is
-the fastest path to a slot when the A6000 nodes are saturated. For the
+account today (A6000 48 GB, L40/L40S 48 GB, H100 80 GB), but benchmark
+evidence should default to typed A6000 requests for comparability. For the
 authoritative live menu of partitions and GPU types:
 
 ```bash

--- a/docs/mitigation_recovery_adjudication.md
+++ b/docs/mitigation_recovery_adjudication.md
@@ -7,8 +7,8 @@ This doc specifies the two mitigation-ladder rungs that come after
 `missing_evidence_final_answer_guard`. The retry/replan recovery rung is now
 wired into the repo-local PE-family runners. The explicit fault/risk
 adjudication rung is now also runnable as a default-off PE-family mitigation
-flag, but it remains **pending rerun evidence** until #66 produces matched
-artifacts and judge rows.
+flag. First GCP A100 four-tier evidence is recorded, but the before/after
+interpretation remains pending a patched matched rerun.
 
 ## Scope
 

--- a/docs/mitigation_rerun_operator_plan.md
+++ b/docs/mitigation_rerun_operator_plan.md
@@ -7,6 +7,10 @@ This is the runner-facing plan for the missing-evidence mitigation ladder.
 It is written for whoever owns the compute session. The taxonomy lane consumes
 the completed artifacts afterward.
 
+Use this doc as the operator entry point for #66. The issue tracks status and
+acceptance; this doc gives the runnable order, config names, validation checks,
+and handoff package.
+
 ## Goal
 
 Produce the evidence needed to populate

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -111,7 +111,7 @@ If you want to verify `import vllm` itself, do that from a compute node rather
 than the login node:
 
 ```bash
-srun --account=edu --partition=short --qos=short --gres=gpu:1 \
+srun --account=edu --partition=short --qos=short --gres=gpu:A6000:1 \
      --mem=64G --time=01:00:00 --pty bash
 cd /insomnia001/depts/edu/users/team13/hpml-assetopsbench-smart-grid-mcp
 source .venv-insomnia/bin/activate
@@ -242,7 +242,8 @@ all three JSON files above. `docs/wandb_schema.md` documents the field names.
 
 | Goal | Override |
 |---|---|
-| Any GPU (not just A6000) | `--gres=gpu:1` |
+| Default Insomnia evidence GPU | `--gres=gpu:A6000:1` |
+| Hardware-flexible exploratory run | `--gres=gpu:1` *(record the allocated GPU; do not mix with typed evidence cohorts)* |
 | Specific GPU type | `--gres=gpu:A6000:1`, `--gres=gpu:h100:1`, `--gres=gpu:l40s:1` |
 | Longer walltime (up to 12h) | `--time=04:00:00` |
 | Different partition | `--partition=burst --qos=burst` |
@@ -337,7 +338,7 @@ diagnoses it.
 
 | Symptom | Next step |
 |---|---|
-| `sbatch` returns `ReqNodeNotAvail` or `Priority` forever | [insomnia_runbook.md §"Queue waits"](insomnia_runbook.md) — try `--gres=gpu:1` to widen the scheduler pool, or an off-peak window |
+| `sbatch` returns `ReqNodeNotAvail` or `Priority` forever | [insomnia_runbook.md §"Queue waits"](insomnia_runbook.md) — prefer an off-peak window for evidence runs; use `--gres=gpu:1` only for explicitly hardware-flexible exploratory work |
 | Slurm log shows only `Waiting for vLLM server to start...` and vLLM log is 0 bytes | [insomnia_runbook.md §"Debugging: foreground vLLM"](insomnia_runbook.md) — on the current 3.11 / vLLM 0.19 stack this usually means a broken model download, a port conflict, or missing CUDA/cuDNN paths; reproduce in the foreground via `srun --pty` to see the real error |
 | `module load cuda/12.3` fails | [insomnia_runbook.md §"CUDA"](insomnia_runbook.md) — module is broken; set `PATH` and `LD_LIBRARY_PATH` directly |
 | WandB run doesn't appear under `assetopsbench-smartgrid` | `wandb login` in `.venv-insomnia`, or export `WANDB_API_KEY`; `ENABLE_WANDB=0` suppresses WandB entirely |

--- a/docs/slurm_cheatsheet.md
+++ b/docs/slurm_cheatsheet.md
@@ -104,17 +104,20 @@ srun \
   --pty bash
 ```
 
-Minimal generic GPU request:
+Minimal default A6000 GPU request:
 
 ```bash
 srun \
   --account=edu \
   --partition=short \
   --qos=short \
-  --gres=gpu:1 \
+  --gres=gpu:A6000:1 \
   --time=00:05:00 \
   --pty bash
 ```
+
+Use generic `--gres=gpu:1` only when hardware does not matter; record the
+allocated GPU before treating the run as evidence.
 
 ## Attach to an already-running job
 
@@ -289,7 +292,7 @@ You are probably on the login node, not the compute node.
 Either:
 
 ```bash
-srun --account=edu --partition=short --qos=short --gres=gpu:1 --time=00:10:00 --pty bash
+srun --account=edu --partition=short --qos=short --gres=gpu:A6000:1 --time=00:10:00 --pty bash
 ```
 
 or attach to the running job:

--- a/scripts/run_exp1_ab_capture.sh
+++ b/scripts/run_exp1_ab_capture.sh
@@ -3,7 +3,7 @@
 #SBATCH --account=edu
 #SBATCH --partition=short
 #SBATCH --qos=short
-#SBATCH --gres=gpu:1
+#SBATCH --gres=gpu:A6000:1
 #SBATCH --mem=64G
 #SBATCH --cpus-per-task=8
 #SBATCH --time=04:00:00

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -3,7 +3,7 @@
 #SBATCH --account=edu
 #SBATCH --partition=short
 #SBATCH --qos=short
-#SBATCH --gres=gpu:1
+#SBATCH --gres=gpu:A6000:1
 #SBATCH --mem=64G
 #SBATCH --cpus-per-task=4
 #SBATCH --time=02:00:00
@@ -96,7 +96,8 @@ VLLM_MODEL_PATH="${VLLM_MODEL_PATH:-models/Llama-3.1-8B-Instruct}"
 VLLM_SERVED_MODEL_NAME="${VLLM_SERVED_MODEL_NAME:-$(basename "$VLLM_MODEL_PATH")}"
 VLLM_DTYPE="${VLLM_DTYPE:-float16}"
 EXTRA_VLLM_ARGS="${EXTRA_VLLM_ARGS:-}"
-export VLLM_DTYPE EXTRA_VLLM_ARGS
+VLLM_GENERATION_CONFIG="${VLLM_GENERATION_CONFIG:-vllm}"
+export VLLM_DTYPE EXTRA_VLLM_ARGS VLLM_GENERATION_CONFIG
 VLLM_ENABLE_AUTO_TOOL_CHOICE="${VLLM_ENABLE_AUTO_TOOL_CHOICE:-1}"
 # Default tool-call parser is model-family-aware. Llama-3.x → llama3_json
 # (the team's pinned `Llama-3.1-8B-Instruct`). Other families
@@ -507,6 +508,7 @@ payload["missing_evidence_repair_max_attempts_per_target"] = int(
 # distinction in Cell C.
 extra_vllm_args = os.environ.get("EXTRA_VLLM_ARGS", "").strip()
 payload["vllm_dtype"] = os.environ.get("VLLM_DTYPE", "float16")
+payload["vllm_generation_config"] = os.environ.get("VLLM_GENERATION_CONFIG", "vllm")
 payload["vllm_extra_args"] = extra_vllm_args
 payload["vllm_extra_args_list"] = extra_vllm_args.split() if extra_vllm_args else []
 payload["runtime_versions"] = runtime_versions()
@@ -1060,6 +1062,7 @@ if [ "$LAUNCH_VLLM" = "1" ]; then
     --port "$VLLM_PORT"
     --max-model-len "$MAX_MODEL_LEN"
     --dtype "$VLLM_DTYPE"
+    --generation-config "$VLLM_GENERATION_CONFIG"
   )
   if [ "$VLLM_ENABLE_AUTO_TOOL_CHOICE" = "1" ]; then
     if [ -z "$VLLM_TOOL_CALL_PARSER" ]; then

--- a/scripts/test_int8_smoke.sh
+++ b/scripts/test_int8_smoke.sh
@@ -3,7 +3,7 @@
 #SBATCH --account=edu
 #SBATCH --partition=short
 #SBATCH --qos=short
-#SBATCH --gres=gpu:1
+#SBATCH --gres=gpu:A6000:1
 #SBATCH --mem=64G
 #SBATCH --cpus-per-task=8
 #SBATCH --time=01:00:00
@@ -109,6 +109,7 @@ setsid python3 -u -m vllm.entrypoints.openai.api_server \
     --port "$PORT" \
     --max-model-len 8192 \
     --quantization compressed-tensors \
+    --generation-config vllm \
     >"$VLLM_LOG" 2>&1 &
 VLLM_PID=$!
 # `setsid` puts the leader and all its children in a new process group whose

--- a/scripts/test_kv_cache_smoke.sh
+++ b/scripts/test_kv_cache_smoke.sh
@@ -3,7 +3,7 @@
 #SBATCH --account=edu
 #SBATCH --partition=short
 #SBATCH --qos=short
-#SBATCH --gres=gpu:1
+#SBATCH --gres=gpu:A6000:1
 #SBATCH --mem=64G
 #SBATCH --cpus-per-task=8
 #SBATCH --time=01:00:00
@@ -15,9 +15,8 @@
 #   1. baseline                                             (no KV optimization)
 #   2. --enable-prefix-caching                              (chosen for Cell C)
 #   3. --enable-prefix-caching --kv-cache-dtype fp8         (originally planned;
-#                                                           known to fail under
-#                                                           FP16 weights in
-#                                                           vLLM 0.19.0 FA3 —
+#                                                           failed in prior
+#                                                           FP16/H100 smoke —
 #                                                           see status doc)
 # One run per variant; all variants use the same model, scenario, and prompt
 # template so latency deltas attribute to KV-cache. The fp8 variant is

--- a/scripts/vllm_serve.sh
+++ b/scripts/vllm_serve.sh
@@ -67,6 +67,7 @@ STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-900}"
 MODEL_PATH="${MODEL_PATH:-models/Llama-3.1-8B-Instruct}"
 PORT="${PORT:-8000}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-32768}"
+VLLM_GENERATION_CONFIG="${VLLM_GENERATION_CONFIG:-vllm}"
 VLLM_SERVED_MODEL_NAME="${VLLM_SERVED_MODEL_NAME:-$(basename "${MODEL_PATH%/}")}"
 
 if [ ! -d "$MODEL_PATH" ]; then
@@ -126,6 +127,7 @@ python3 -m vllm.entrypoints.openai.api_server \
     --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --dtype float16 \
+    --generation-config "$VLLM_GENERATION_CONFIG" \
     >"$VLLM_STARTUP_LOG" 2>&1 &
 
 VLLM_PID=$!


### PR DESCRIPTION
## Summary

- Adds a compute-environment discrepancy note for the mixed Insomnia A6000/H100 first-capture cohort versus the later GCP A100 final-six matrix.
- Cross-links that caveat from the Experiment 2 capture plan and experiment matrix so paper/deck readers do not treat mixed-hardware historical rows as same-cohort evidence.
- Hardens future Insomnia evidence jobs to request A6000 explicitly and passes `--generation-config vllm` through vLLM launch paths.
- Clarifies the #66 mitigation operator entry point while keeping the issue evidence-gated.

Refs #66.

## Verification

- `bash -n scripts/run_experiment.sh scripts/run_exp1_ab_capture.sh scripts/test_int8_smoke.sh scripts/test_kv_cache_smoke.sh scripts/vllm_serve.sh`
- `black --check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_run_experiment_summary.py tests/test_aat_runner.py` (`27 passed, 3 skipped`)
- `git diff --cached --check`
