### PR TITLE
Auto-alias WATSONX_* env vars to WX_* for litellm WatsonX provider

### DIFF
--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -223,6 +223,14 @@ def _configure_litellm_provider_compat(model_id: str) -> None:
     """Apply provider-specific LiteLLM compatibility knobs."""
     if not _is_watsonx_model(model_id):
         return
+    # Bridge documented WATSONX_* env vars to the WX_* names litellm's newer
+    # WatsonX provider expects (litellm 1.81.x rejects with
+    # "Watsonx project_id and space_id not set" otherwise). Shared helper
+    # at scripts/watsonx_env.py covers every Python call site that drives
+    # a watsonx/* model. (#177)
+    from scripts.watsonx_env import propagate_watsonx_env
+
+    propagate_watsonx_env()
     try:
         import litellm  # type: ignore
     except ImportError:

--- a/scripts/generate_scenarios.py
+++ b/scripts/generate_scenarios.py
@@ -334,6 +334,14 @@ def call_llm(
             "or run with --dry-run."
         ) from exc
 
+    if model.startswith("watsonx/"):
+        # Bridge documented WATSONX_* env vars to the WX_* names litellm's
+        # newer WatsonX provider expects. Shared helper covers every Python
+        # call site (generator + aat_runner + judge_trajectory).
+        from scripts.watsonx_env import propagate_watsonx_env
+
+        propagate_watsonx_env()
+
     log.info(
         "calling %s (temperature=%.2f, max_tokens=%d, prompt_chars=%d)",
         model,

--- a/scripts/judge_trajectory.py
+++ b/scripts/judge_trajectory.py
@@ -61,6 +61,13 @@ _REPO_ROOT = Path(
     os.environ.get("REPO_ROOT", Path(__file__).resolve().parent.parent)
 ).resolve()
 
+# Ensure repo root is on sys.path so `from scripts.X import Y` resolves when
+# this file is invoked as `python scripts/judge_trajectory.py` (which puts
+# scripts/, not the repo root, on sys.path by default). Mirrors the same
+# guard in scripts/aat_runner.py.
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 
 def _rel(p: Path) -> str:
     """Return a repo-root-relative POSIX path, falling back to absolute."""
@@ -170,6 +177,15 @@ def _call_judge(
             "litellm is required. Run from the AssetOpsBench venv: "
             "source AssetOpsBench/.venv/bin/activate"
         )
+
+    # Bridge documented WATSONX_* env vars to the WX_* names litellm's
+    # newer WatsonX provider expects. The default judge model (and most
+    # team judge configurations) is a watsonx/* model. Shared helper
+    # covers the same case in the generator + AaT runner. (#177)
+    if judge_model.strip().lower().startswith("watsonx/"):
+        from scripts.watsonx_env import propagate_watsonx_env
+
+        propagate_watsonx_env()
 
     messages = [
         {"role": "system", "content": _SYSTEM_PROMPT},

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -293,6 +293,22 @@ fi
 if [ -n "${WATSONX_APIKEY:-}" ] && [ -z "${WATSONX_API_KEY:-}" ]; then
   export WATSONX_API_KEY="$WATSONX_APIKEY"
 fi
+# Bridge documented WATSONX_* env vars to the WX_* names litellm's newer
+# WatsonX provider expects (litellm 1.81.x rejects with
+# "Watsonx project_id and space_id not set" otherwise). Subprocess Python
+# entry points (generator, AaT runner, judge_trajectory.py) call the same
+# alias via scripts/watsonx_env.py; doing it here too keeps inherited
+# env consistent for any sub-shell or PE/Verified PE runner that bypasses
+# the Python helper. (#177)
+if [ -n "${WATSONX_API_KEY:-}" ] && [ -z "${WX_API_KEY:-}" ]; then
+  export WX_API_KEY="$WATSONX_API_KEY"
+fi
+if [ -n "${WATSONX_PROJECT_ID:-}" ] && [ -z "${WX_PROJECT_ID:-}" ]; then
+  export WX_PROJECT_ID="$WATSONX_PROJECT_ID"
+fi
+if [ -n "${WATSONX_URL:-}" ] && [ -z "${WX_URL:-}" ]; then
+  export WX_URL="$WATSONX_URL"
+fi
 
 if [ ! -f "$AOB_PATH/pyproject.toml" ]; then
   echo "ERROR: AssetOpsBench not found at $AOB_PATH" >&2

--- a/scripts/watsonx_env.py
+++ b/scripts/watsonx_env.py
@@ -1,0 +1,49 @@
+"""Cross-call-site WatsonX env-var alias helper.
+
+The team's `.env` and `docs/reference/watsonx_access.md` document
+`WATSONX_API_KEY` / `WATSONX_PROJECT_ID` / `WATSONX_URL`, but newer
+litellm WatsonX provider versions (≥ 1.81.x as observed in the team
+`.venv-insomnia`) read `WX_API_KEY` / `WX_PROJECT_ID` / `WX_URL` and
+fail with `"Watsonx project_id and space_id not set"` if only the
+`WATSONX_*` names are set.
+
+This helper copies `WATSONX_<NAME>` into `WX_<NAME>` when `WX_<NAME>`
+is unset. Caller-provided `WX_*` values win (no clobber). It mirrors
+the long-standing `WATSONX_API_KEY` ↔ `WATSONX_APIKEY` bridge in
+`scripts/run_experiment.sh:290`.
+
+Used by every Python entry point in this repo that drives a
+`watsonx/...` LiteLLM model:
+
+  - scripts/generate_scenarios.py (PS B generator → litellm.completion)
+  - scripts/aat_runner.py         (AaT runner → Agents SDK LitellmModel)
+  - scripts/judge_trajectory.py   (judge → litellm.completion)
+
+The bash wrapper `scripts/run_experiment.sh` does the same alias inline
+so subprocess paths (replay loop, batch mode, etc.) inherit the WX_*
+names without going through Python.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Source / destination env-var pairs. Order is irrelevant; absent sources
+# are skipped, present-destination overrides win.
+_WATSONX_ENV_ALIASES: tuple[tuple[str, str], ...] = (
+    ("WATSONX_API_KEY", "WX_API_KEY"),
+    ("WATSONX_PROJECT_ID", "WX_PROJECT_ID"),
+    ("WATSONX_URL", "WX_URL"),
+)
+
+
+def propagate_watsonx_env() -> None:
+    """Mirror `WATSONX_<NAME>` → `WX_<NAME>` for litellm WatsonX provider.
+
+    No-clobber: a pre-set `WX_*` value wins. Missing source values are
+    silently skipped (i.e. the function is safe to call even when no
+    WatsonX env vars are present).
+    """
+    for src, dst in _WATSONX_ENV_ALIASES:
+        if dst not in os.environ and os.environ.get(src):
+            os.environ[dst] = os.environ[src]

--- a/tests/test_watsonx_env.py
+++ b/tests/test_watsonx_env.py
@@ -1,0 +1,163 @@
+"""Unit tests for scripts/watsonx_env.py.
+
+The helper bridges documented WATSONX_* env vars to the WX_* names that
+litellm's newer WatsonX provider expects. (#177 / PR #130 review fall-out)
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Names this helper touches. Tests scrub them in setup/teardown so a stray
+# value from the pytest invoker's shell can't leak between cases.
+_NAMES = (
+    "WATSONX_API_KEY",
+    "WATSONX_PROJECT_ID",
+    "WATSONX_URL",
+    "WX_API_KEY",
+    "WX_PROJECT_ID",
+    "WX_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    """Wipe every WATSONX/WX env var so each test starts clean."""
+    for name in _NAMES:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def _propagate():
+    """Fresh import + call so each test sees a fresh module."""
+    from scripts import watsonx_env
+
+    importlib.reload(watsonx_env)
+    watsonx_env.propagate_watsonx_env()
+
+
+def test_watsonx_to_wx_copy(monkeypatch):
+    """All three documented WATSONX_* names land in their WX_* aliases."""
+    monkeypatch.setenv("WATSONX_API_KEY", "key-abc")
+    monkeypatch.setenv("WATSONX_PROJECT_ID", "proj-123")
+    monkeypatch.setenv("WATSONX_URL", "https://us-south.ml.cloud.ibm.com")
+
+    _propagate()
+
+    assert os.environ["WX_API_KEY"] == "key-abc"
+    assert os.environ["WX_PROJECT_ID"] == "proj-123"
+    assert os.environ["WX_URL"] == "https://us-south.ml.cloud.ibm.com"
+
+
+def test_existing_wx_value_is_not_clobbered(monkeypatch):
+    """Caller-set WX_* wins over the WATSONX_* source. (No-clobber contract.)"""
+    monkeypatch.setenv("WATSONX_API_KEY", "from-watsonx")
+    monkeypatch.setenv("WX_API_KEY", "preset-by-caller")
+    monkeypatch.setenv("WATSONX_PROJECT_ID", "proj-from-watsonx")
+    # WX_PROJECT_ID intentionally unset — should still get copied.
+
+    _propagate()
+
+    assert os.environ["WX_API_KEY"] == "preset-by-caller"  # not clobbered
+    assert os.environ["WX_PROJECT_ID"] == "proj-from-watsonx"  # filled in
+
+
+def test_no_op_when_nothing_set():
+    """Helper is safe to call when no WatsonX env vars are present."""
+    # Sanity: fixture left these absent.
+    for name in _NAMES:
+        assert name not in os.environ
+
+    _propagate()
+
+    for name in _NAMES:
+        assert name not in os.environ
+
+
+def test_partial_source_partial_destination(monkeypatch):
+    """Only present source vars get copied; absent ones don't create empty WX_*."""
+    monkeypatch.setenv("WATSONX_API_KEY", "key-only")
+    # WATSONX_PROJECT_ID and WATSONX_URL deliberately absent.
+
+    _propagate()
+
+    assert os.environ["WX_API_KEY"] == "key-only"
+    assert "WX_PROJECT_ID" not in os.environ
+    assert "WX_URL" not in os.environ
+
+
+def test_empty_string_source_is_treated_as_absent(monkeypatch):
+    """A WATSONX_* set to '' should not produce an empty WX_* (avoids passing
+    an empty string into litellm where None / unset would be the right shape)."""
+    monkeypatch.setenv("WATSONX_API_KEY", "")
+    monkeypatch.setenv("WATSONX_PROJECT_ID", "proj-real")
+
+    _propagate()
+
+    assert "WX_API_KEY" not in os.environ
+    assert os.environ["WX_PROJECT_ID"] == "proj-real"
+
+
+# ---------------------------------------------------------------------------
+# Generator integration: call_llm() with a non-WatsonX model must NOT mutate
+# WX_* env vars. Per Alex's review: the alias should only fire on watsonx/*.
+# ---------------------------------------------------------------------------
+
+
+def test_generator_call_llm_skips_alias_for_non_watsonx_models(monkeypatch):
+    """call_llm() with model='openai/...' must not touch WX_* env vars.
+
+    Stubs litellm so the test doesn't need network or the real package.
+    """
+    monkeypatch.setenv("WATSONX_API_KEY", "should-stay-in-WATSONX_only")
+
+    # Pre-condition: WX_API_KEY absent.
+    assert "WX_API_KEY" not in os.environ
+
+    # Stub litellm to avoid the real network call.
+    fake_litellm = type(sys)("litellm")
+    fake_litellm.completion = lambda **kwargs: {
+        "choices": [{"message": {"content": "stub"}}]
+    }
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    from scripts import generate_scenarios
+
+    importlib.reload(generate_scenarios)
+
+    out = generate_scenarios.call_llm("hello", model="openai/gpt-4o-mini")
+    assert out == "stub"
+    # Critical: no leakage into WX_* for non-watsonx models.
+    assert "WX_API_KEY" not in os.environ
+
+
+def test_generator_call_llm_propagates_alias_for_watsonx_models(monkeypatch):
+    """call_llm() with model='watsonx/...' triggers the WATSONX_* → WX_* copy."""
+    monkeypatch.setenv("WATSONX_API_KEY", "key-real")
+    monkeypatch.setenv("WATSONX_PROJECT_ID", "proj-real")
+    monkeypatch.setenv("WATSONX_URL", "https://us-south.ml.cloud.ibm.com")
+
+    fake_litellm = type(sys)("litellm")
+    fake_litellm.completion = lambda **kwargs: {
+        "choices": [{"message": {"content": "stub"}}]
+    }
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    from scripts import generate_scenarios
+
+    importlib.reload(generate_scenarios)
+
+    out = generate_scenarios.call_llm("hello", model="watsonx/meta-llama/llama-3-3")
+    assert out == "stub"
+    assert os.environ["WX_API_KEY"] == "key-real"
+    assert os.environ["WX_PROJECT_ID"] == "proj-real"
+    assert os.environ["WX_URL"] == "https://us-south.ml.cloud.ibm.com"


### PR DESCRIPTION
## Summary

Newer LiteLLM WatsonX provider versions (>= 1.81.x) read `WX_API_KEY` / `WX_PROJECT_ID` / `WX_URL`, while the team's documented setup and existing `.env` files use `WATSONX_API_KEY`, `WATSONX_PROJECT_ID`, and `WATSONX_URL`. Without aliases, hosted WatsonX paths can fail with a missing project/space error even when the documented environment is present.

This PR adds a shared no-clobber alias helper and wires it through all current WatsonX LiteLLM entry points so either naming convention works.

## Fix

- Add `scripts/watsonx_env.py` with `propagate_watsonx_env()`.
- Call the helper from `scripts/generate_scenarios.py` for `watsonx/*` generation calls.
- Call the helper from `scripts/aat_runner.py` before hosted-WatsonX `LitellmModel` construction.
- Call the helper from `scripts/judge_trajectory.py` before WatsonX judge calls, with the repo-root import guard needed for script invocation.
- Add a shell-side `WX_*` bridge in `scripts/run_experiment.sh` so subprocess runner paths inherit the aliases.
- Preserve caller-provided `WX_*` values; `WATSONX_*` only fills missing `WX_*` variables.

## Verified

- `python -m pytest tests/test_watsonx_env.py tests/test_aat_runner.py tests/test_run_experiment_summary.py -q`
- `bash -n scripts/run_experiment.sh`
- `black --check` via CI

## Issue

No tracked issue; surfaced during hosted WatsonX smoke testing.
