### PR TITLE
PS B second reviewable batch (#2 / #68)

### DIFF
--- a/data/scenarios/generated/first_review_20260503/README.md
+++ b/data/scenarios/generated/first_review_20260503/README.md
@@ -1,0 +1,42 @@
+# `first_review_20260503` — INSPECTION-ONLY BATCH
+
+> **Do not use these scenarios as benchmark inputs.** Their `ground_truth` values are model-asserted, not validated against the actual repo data fixtures or MCP tool outputs. A correct tool-using agent would be scored wrong on at least three of the five scenarios.
+
+This batch is the first end-to-end output of `scripts/generate_scenarios.py` (PS B prototype, `#2`). It exists to prove that the generator pipeline runs end-to-end, that the validator + nested-provenance contract works, and to surface the first concrete prompt-iteration signal for `#68` scale-up. The scenarios themselves are not paper-corpus material.
+
+## Why inspection-only and not benchmark-ready
+
+Verified by Alex's PR #178 review against the actual MCP tool outputs and `data/processed/*.csv` fixtures:
+
+| Scenario | Severity | Issue |
+|---|---|---|
+| `SGT-GEN-001` | High | Text says "stable gas levels" but `ground_truth.final_value.primary_fault: D2` (low-energy discharge). `get_dga_record("T-005")` actually returns `fault_label="Normal"` with stable gases — does NOT support D2/R-ratio. |
+| `SGT-GEN-002` | High | `ground_truth.final_value.rul_estimate_days: 540` and `decisive_intermediate_values.health_index: 0.6`, but `forecast_rul("T-005")` actually returns `current_rul_days=3364` / `projected_rul_days=3334`. |
+| `SGT-GEN-003` | High | `expected_tools` includes `wo.estimate_downtime` which requires a `severity` argument; the prompt provides no severity source. The tool sequence isn't callable from prompt context alone. |
+| `SGT-GEN-004` | Medium | `iot.get_sensor_readings` requires an exact `sensor_id` and returns historical fixture rows. Scenario doesn't pin sensor/channel/timestamp → the answer is non-reproducible. Either pin the sensor, or add an `iot.list_sensors` discovery step. |
+| `SGT-GEN-005` | High | Multi-domain. Prompt names `methane` + `ethylene` (CH4 + C2H4 → thermal pattern T1-T3) but `ground_truth.fault_code: D2` (arc-discharge, characterized by C2H2). Gases don't match the labeled fault. Also `expected_tools` includes `iot.get_sensor_readings` (needs sensor_id source) and `fmsr.analyze_dga` (needs all 5 gases) but omits `fmsr.get_dga_record`. |
+| All five | Medium | Every scenario uses asset `T-005`. Family matrix `variation_axes` says "vary across T-001 to T-020"; the RNG (seed=42) independently picked T-005 for each family because the prompt template doesn't enforce cross-scenario asset variation. |
+
+## Reproducibility caveat (#178 review M2)
+
+The `seed=42` recorded in `batch_manifest.json:invocations[0].seed` controls **only the generator's RNG for context / template selection**. It is **not** passed to `litellm.completion()`, and the model runs at `temperature=0.7`, so re-running with the same seed will give different scenario text. The committed `SGT-GEN-001..005.json` files plus the prompts in the manifest fully capture *what produced this batch*; they do not let a re-runner re-derive the exact text from seed alone. Raw prompts and responses live on the Insomnia clone at `/insomnia001/depts/edu/users/af3623/exp1-clone/data/scenarios/generated/first_review_20260503/{prompts,raw_responses}/` but are not committed here (debugging artifacts, not contract).
+
+## How this is segregated from the benchmark corpus
+
+- The team's CI gate (`python data/scenarios/validate_scenarios.py`) only globs `data/scenarios/*.json` (top-level, non-recursive). This subdirectory is not picked up.
+- The `nearest_handcrafted_comparator` block on each scenario points at the canonical comparator so promotion to the corpus would be a per-scenario decision, not a bulk move.
+- The generator's contract validator passes (5/5) — the issues above are **semantic** (data-grounding + tool-call preconditions), not structural.
+
+## What `#68` scale-up needs to add to fix this
+
+These become the prompt-iteration backlog for `#68`. Bump `PROMPT_VERSION` from `v0.1` to `v0.2` when these land:
+
+1. Inject explicit constraint: "the gases / sensor evidence in the text MUST be consistent with the fault label in `ground_truth.final_value`."
+2. Either inline the actual MCP-tool outputs into the prompt at generation time so ground truth is data-grounded, or do a post-generation grounding pass that runs the `ideal_tool_sequence` against the live MCP servers and overwrites `decisive_intermediate_values` + `final_value` with what the tools actually return.
+3. For each `expected_tools` entry, the prompt must supply a source for every required argument — or the generator must include the appropriate discovery tool (e.g. `iot.list_sensors` before `iot.get_sensor_readings`).
+4. Add a per-family asset-variation override that rotates through `T-001..T-020` deterministically per `--seed` instead of relying on independent RNG draws.
+5. Decide whether naming gases by chemical formula or common name counts as a no-hint violation (Akshat's call under `#53`).
+
+## Hand-off
+
+`#53` validation rubric application owns the official quality call. The findings above are offered as a starting signal for that review, not as a substitute.

--- a/data/scenarios/generated/first_review_20260503/README.md
+++ b/data/scenarios/generated/first_review_20260503/README.md
@@ -19,7 +19,7 @@ Verified by Alex's PR #178 review against the actual MCP tool outputs and `data/
 
 ## Reproducibility caveat (#178 review M2)
 
-The `seed=42` recorded in `batch_manifest.json:invocations[0].seed` controls **only the generator's RNG for context / template selection**. It is **not** passed to `litellm.completion()`, and the model runs at `temperature=0.7`, so re-running with the same seed will give different scenario text. The committed `SGT-GEN-001..005.json` files plus the prompts in the manifest fully capture *what produced this batch*; they do not let a re-runner re-derive the exact text from seed alone. Raw prompts and responses live on the Insomnia clone at `/insomnia001/depts/edu/users/af3623/exp1-clone/data/scenarios/generated/first_review_20260503/{prompts,raw_responses}/` but are not committed here (debugging artifacts, not contract).
+The `seed=42` recorded in `batch_manifest.json:invocations[0].seed` controls **only the generator's RNG for context / template selection**. It is **not** passed to `litellm.completion()`, and the model runs at `temperature=0.7`, so re-running with the same seed will give different scenario text. The committed `SGT-GEN-001..005.json` files plus manifest provenance capture the reviewed artifact; they do not let a re-runner re-derive the exact text from seed alone. Raw prompts and responses were kept as uncommitted debug artifacts, not as part of the public scenario contract.
 
 ## How this is segregated from the benchmark corpus
 

--- a/data/scenarios/generated/first_review_20260503/SGT-GEN-001.json
+++ b/data/scenarios/generated/first_review_20260503/SGT-GEN-001.json
@@ -1,0 +1,56 @@
+{
+  "id": "SGT-GEN-001",
+  "type": "FMSR",
+  "text": "Transformer T-005 is operating at 98% capacity with no spare available. Recent DGA readings show stable gas levels. Determine the primary fault and recommend the next inspection step.",
+  "category": "Fault Diagnosis",
+  "characteristic_form": "A diagnosis with a recommended action",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga"
+  ],
+  "domain_tags": [
+    "FMSR"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "decisive_intermediate_values": {
+      "R1": "0.067",
+      "R2": "0.021",
+      "R3": "1.26"
+    },
+    "final_value": {
+      "primary_fault": "D2",
+      "recommended_action": "Schedule a detailed inspection"
+    },
+    "acceptance_criteria": [
+      "agent identifies the primary fault as D2",
+      "agent recommends a detailed inspection"
+    ],
+    "must_include": [
+      "primary fault",
+      "recommended action"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-04T03:54:16.921184+00:00",
+    "batch_id": "first_review_20260503",
+    "manual_cleanup": false
+  },
+  "family": "FMSR_DGA_DIAGNOSIS",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-003",
+    "scenario_file": "data/scenarios/fmsr_01_dga_fault_mode_diagnosis.json",
+    "similarity_basis": "shares type='FMSR' and 2 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260503/SGT-GEN-002.json
+++ b/data/scenarios/generated/first_review_20260503/SGT-GEN-002.json
@@ -1,0 +1,53 @@
+{
+  "id": "SGT-GEN-002",
+  "type": "TSFM",
+  "text": "Forecast remaining life for transformer T-005, which has shown stable degradation trends and is currently at 65% load.",
+  "category": "Remaining Useful Life",
+  "characteristic_form": "The answer will be a numerical estimate of days until end-of-life.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "tsfm.forecast_rul"
+  ],
+  "domain_tags": [
+    "TSFM"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "tsfm.forecast_rul"
+    ],
+    "decisive_intermediate_values": {
+      "health_index": "0.6",
+      "rul_range_days": "360"
+    },
+    "final_value": {
+      "rul_estimate_days": "540"
+    },
+    "acceptance_criteria": [
+      "agent provides a numerical RUL estimate",
+      "agent bases estimate on current health index"
+    ],
+    "must_include": [
+      "rul_estimate_days",
+      "risk_level_rationale",
+      "recommended_action_horizon"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-04T03:54:26.682955+00:00",
+    "batch_id": "first_review_20260503",
+    "manual_cleanup": false
+  },
+  "family": "TSFM_RUL_FORECAST",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-005",
+    "scenario_file": "data/scenarios/tsfm_01_rul_forecast_maintenance_window.json",
+    "similarity_basis": "shares type='TSFM' and 1 expected_tools entry",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260503/SGT-GEN-003.json
+++ b/data/scenarios/generated/first_review_20260503/SGT-GEN-003.json
@@ -1,0 +1,56 @@
+{
+  "id": "SGT-GEN-003",
+  "type": "WO",
+  "text": "T-005 main transformer temperature exceeds threshold, what's the next step?",
+  "category": "Work Order Creation",
+  "characteristic_form": "A decision to create a work order with specified fields.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "wo.create_work_order",
+    "wo.estimate_downtime"
+  ],
+  "domain_tags": [
+    "WO"
+  ],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "wo.create_work_order",
+      "wo.estimate_downtime"
+    ],
+    "decisive_intermediate_values": {
+      "fault_code": "T3",
+      "condition_tier": "C4"
+    },
+    "final_value": {
+      "work_order_type": "corrective",
+      "priority": "high"
+    },
+    "acceptance_criteria": [
+      "agent creates a work order",
+      "agent estimates downtime"
+    ],
+    "must_include": [
+      "work_order_type",
+      "priority",
+      "minimum_fields_from_playbook"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-04T03:54:36.377901+00:00",
+    "batch_id": "first_review_20260503",
+    "manual_cleanup": false
+  },
+  "family": "WO_CREATION",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-007",
+    "scenario_file": "data/scenarios/wo_01_create_inspection_order.json",
+    "similarity_basis": "shares type='WO' and 2 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260503/SGT-GEN-004.json
+++ b/data/scenarios/generated/first_review_20260503/SGT-GEN-004.json
@@ -1,0 +1,52 @@
+{
+  "id": "SGT-GEN-004",
+  "type": "IoT",
+  "text": "Transformer T-005 is operating near peak load. Check the winding temperature and determine if it's within safe limits.",
+  "category": "Sensor Analysis",
+  "characteristic_form": "A comparison of the current sensor reading to a threshold value.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "iot.get_sensor_readings"
+  ],
+  "domain_tags": [
+    "IoT"
+  ],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "iot.get_sensor_readings"
+    ],
+    "decisive_intermediate_values": {
+      "winding_temp_top_c": "80"
+    },
+    "final_value": {
+      "status_summary": "within safe limits"
+    },
+    "acceptance_criteria": [
+      "agent retrieves the current winding temperature",
+      "agent compares the temperature to a safe threshold"
+    ],
+    "must_include": [
+      "sensor_value_with_unit",
+      "threshold_comparison",
+      "status_summary"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-04T03:54:47.760089+00:00",
+    "batch_id": "first_review_20260503",
+    "manual_cleanup": false
+  },
+  "family": "IOT_SENSOR_ANALYSIS",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-001",
+    "scenario_file": "data/scenarios/iot_01_list_transformer_sensors.json",
+    "similarity_basis": "shares type='IoT' and 1 expected_tools entry",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260503/SGT-GEN-005.json
+++ b/data/scenarios/generated/first_review_20260503/SGT-GEN-005.json
@@ -1,0 +1,66 @@
+{
+  "id": "SGT-GEN-005",
+  "type": "Multi",
+  "text": "Transformer T-005 is operating at 98% capacity with no spare available. Recent DGA samples show rising methane and ethylene levels. Determine the fault mode and recommend maintenance.",
+  "category": "End-to-End Incident Response",
+  "characteristic_form": "A fault diagnosis with a recommended maintenance decision.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "iot.get_sensor_readings",
+    "fmsr.analyze_dga",
+    "tsfm.forecast_rul",
+    "wo.create_work_order"
+  ],
+  "domain_tags": [
+    "IoT",
+    "FMSR",
+    "TSFM",
+    "WO"
+  ],
+  "difficulty": "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "iot.get_sensor_readings",
+      "fmsr.analyze_dga",
+      "tsfm.forecast_rul",
+      "wo.create_work_order"
+    ],
+    "decisive_intermediate_values": {
+      "fault_code": "D2",
+      "rul_days": 14
+    },
+    "final_value": {
+      "fault_label": "D2",
+      "maintenance_decision": "corrective maintenance"
+    },
+    "acceptance_criteria": [
+      "agent identifies the fault mode as D2",
+      "agent forecasts the remaining useful life",
+      "agent recommends corrective maintenance",
+      "agent creates a work order"
+    ],
+    "must_include": [
+      "iot_evidence_summary",
+      "fault_hypothesis_with_iec_code",
+      "rul_or_risk_forecast",
+      "work_order_recommendation"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.1",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-04T03:54:59.292457+00:00",
+    "batch_id": "first_review_20260503",
+    "manual_cleanup": false
+  },
+  "family": "MULTI_DOMAIN_INCIDENT",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-009",
+    "scenario_file": "data/scenarios/multi_01_end_to_end_fault_response.json",
+    "similarity_basis": "shares type='Multi' and 4 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/first_review_20260503/batch_manifest.json
+++ b/data/scenarios/generated/first_review_20260503/batch_manifest.json
@@ -1,5 +1,8 @@
 {
   "batch_id": "first_review_20260503",
+  "batch_status": "inspection_only",
+  "batch_status_note": "Ground truth values are model-asserted, not validated against actual repo data fixtures or MCP tool outputs. Do NOT use these scenarios as benchmark inputs. See README.md in this directory for the full audit (5 issues across 5 scenarios per Alex's #178 review).",
+  "reproducibility_caveat": "The 'seed' field on each invocation controls only the generator's RNG for context/template selection. It is NOT passed to litellm.completion(), and the model runs at temperature=0.7, so re-running with the same seed will produce different scenario text. The committed SGT-GEN-NNN.json files plus the family/seed/model fields below capture what produced this batch; they do not let a re-runner re-derive the exact text from seed alone.",
   "created_at": "2026-05-04T03:55:01.227687+00:00",
   "last_updated_at": "2026-05-04T03:55:01.227687+00:00",
   "prompt_version": "v0.1",

--- a/data/scenarios/generated/first_review_20260503/batch_manifest.json
+++ b/data/scenarios/generated/first_review_20260503/batch_manifest.json
@@ -1,0 +1,43 @@
+{
+  "batch_id": "first_review_20260503",
+  "created_at": "2026-05-04T03:55:01.227687+00:00",
+  "last_updated_at": "2026-05-04T03:55:01.227687+00:00",
+  "prompt_version": "v0.1",
+  "knowledge_plugin_version": "0eacec24441e",
+  "generator_script": "scripts/generate_scenarios.py",
+  "support_data": "docs/knowledge/scenario_generation_support.json",
+  "handcrafted_corpus_size": 21,
+  "scenarios_emitted": [
+    "SGT-GEN-001",
+    "SGT-GEN-002",
+    "SGT-GEN-003",
+    "SGT-GEN-004",
+    "SGT-GEN-005"
+  ],
+  "invocations": [
+    {
+      "started_at": "2026-05-04T03:55:01.227687+00:00",
+      "model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "temperature": 0.7,
+      "seed": 42,
+      "families_requested": [
+        "FMSR_DGA_DIAGNOSIS",
+        "TSFM_RUL_FORECAST",
+        "WO_CREATION",
+        "IOT_SENSOR_ANALYSIS",
+        "MULTI_DOMAIN_INCIDENT"
+      ],
+      "n_per_family": 1,
+      "scenarios_emitted": [
+        "SGT-GEN-001",
+        "SGT-GEN-002",
+        "SGT-GEN-003",
+        "SGT-GEN-004",
+        "SGT-GEN-005"
+      ],
+      "starting_scenario_id": "SGT-GEN-001",
+      "dry_run": false,
+      "append": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

First inspection-only batch from the PS B generator scaffold (PR #147). Five scenarios — one per family from the matrix in `docs/knowledge/scenario_generation_support.json` — produced via WatsonX Llama-3.3-70B and committed under `data/scenarios/generated/first_review_20260503/`.

**This batch is intentionally NOT benchmark corpus.** Ground-truth values are model-asserted, not validated against actual repo data fixtures or MCP tool outputs. The directory's `README.md` says so prominently; the batch manifest carries `"batch_status": "inspection_only"`. A correct tool-using agent would be scored wrong on at least three of the five scenarios, so segregating them from the canonical corpus is essential.

The batch's job here is to:
1. Prove the generator pipeline (PR #147) runs end-to-end against WatsonX
2. Validate the schema + nested-provenance contract (5/5 pass)
3. Produce the first concrete prompt-iteration signal for `#68` scale-up

That meets `#2`'s "Done when" — the team can inspect a first generated batch and rerun the prototype from repo-tracked instructions.

## Why inspection-only and not benchmark-ready

Per Alex's PR review, verified against the actual MCP tool outputs:

| Scenario | Severity | Issue |
|---|---|---|
| `SGT-GEN-001` | High | Text says "stable gas levels" but `ground_truth.final_value.primary_fault: D2`. `get_dga_record("T-005")` actually returns `fault_label="Normal"` — does NOT support D2. |
| `SGT-GEN-002` | High | Ground truth says `rul_estimate_days: 540` / `health_index: 0.6`, but `forecast_rul("T-005")` actually returns `current_rul_days=3364` / `projected_rul_days=3334`. |
| `SGT-GEN-003` | High | `expected_tools` includes `wo.estimate_downtime` (requires `severity` arg); the prompt provides no severity source. Tool sequence isn't callable from prompt context. |
| `SGT-GEN-004` | Medium | `iot.get_sensor_readings` requires exact `sensor_id`; scenario doesn't pin sensor/channel/timestamp → answer non-reproducible. |
| `SGT-GEN-005` | High | Multi-domain. Prompt names `methane`+`ethylene` (CH4+C2H4 → thermal T1-T3) but `ground_truth.fault_code: D2` (arc-discharge → C2H2). Gases don't match labeled fault. Also missing `fmsr.get_dga_record` from `expected_tools`. |
| All five | Medium | Every scenario uses asset `T-005`. RNG (seed=42) independently picked T-005 each time; prompt template doesn't enforce cross-scenario asset variation. |

The full breakdown lives in `data/scenarios/generated/first_review_20260503/README.md` along with the prompt-template fixes that should land under `#68` (bump `PROMPT_VERSION` v0.1 → v0.2).

## Changes vs the prior PR head

`66ba20c` had the 5 scenarios + a "looks-like-benchmark-corpus" framing. `0a892cd` adds the explicit inspection-only status:

- **`data/scenarios/generated/first_review_20260503/README.md`** (NEW) — full audit table + reproducibility caveat + `#68` prompt-iteration backlog
- **`data/scenarios/generated/first_review_20260503/batch_manifest.json`** — adds `batch_status="inspection_only"` + `batch_status_note` + `reproducibility_caveat` field, addressing Alex's M2 finding about the seed not propagating to `litellm.completion`

The 5 SGT-GEN-NNN.json files are unchanged — they're real generator output and shouldn't be hand-edited inside the inspection-only artifact.

## Closes

- `#2` — first generated batch can be inspected and rerun from repo-tracked instructions

## Hand-off

`#53` validation rubric application owns the official quality call. The audit above is the starting signal, not a substitute.

`#68` scale-up gets the concrete prompt-template fix list from the batch's `README.md`. The single most important fix is data-grounding the ground truth — either inline the actual MCP-tool outputs into the prompt at generation time, or run a post-generation grounding pass that calls the tools and overwrites `decisive_intermediate_values` + `final_value`.

## Reproduction

```bash
export WATSONX_API_KEY=... WATSONX_PROJECT_ID=... WATSONX_URL=...
# (PR #177 makes the WATSONX_* → WX_* alias automatic; until that merges,
#  also: export WX_API_KEY="$WATSONX_API_KEY" WX_PROJECT_ID=... WX_URL=...)
.venv-insomnia/bin/python scripts/generate_scenarios.py \
    --family FMSR_DGA_DIAGNOSIS --family TSFM_RUL_FORECAST \
    --family WO_CREATION --family IOT_SENSOR_ANALYSIS --family MULTI_DOMAIN_INCIDENT \
    --n 1 --batch-id first_review_20260503 --seed 42
```

**Caveat (now explicit in the manifest):** `seed` controls only the generator's RNG for context/template selection, not `litellm.completion`. With `temperature=0.7` the model output isn't deterministic from seed alone. The committed `SGT-GEN-NNN.json` files plus the manifest's `family`/`seed`/`model` capture *what produced this batch*; they don't let a re-runner re-derive the exact text from seed alone.

## Linked

- Builds on: PR #147 (generator scaffold), `#83` / `#90` / PR #128 (support data + authoring contract)
- Hand-off to: `#53` (Akshat's PS B validation rubric)
- Scale-up follow-on: `#68` (prompt-iteration backlog in the batch's README.md)
- Sibling: PR #177 (WATSONX→WX env alias — makes the live re-run path one-shot)