### PR TITLE
Harden WatsonX and GCP runner paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-05-04
+
+### Changed
+
+- Hardened hosted WatsonX 70B runner compatibility: AaT runners now omit/drop
+  unsupported `parallel_tool_calls` settings for WatsonX, vanilla PE can opt
+  into the repo-local Smart Grid server-aware runner with self-ask disabled,
+  Smart Grid vanilla PE defaults to that repo-local runner, and single-trial
+  AaT runs export MCP server launch env to child processes. Docs now state that
+  hosted WatsonX 70B rows can run from CPU-only client machines because IBM
+  hosts the model compute.
+- Hardened GCP fallback resume validation for final-six runs: the batch driver
+  now revalidates completed rows before skipping, marks incomplete artifacts as
+  `artifact_failed`, accepts shell-style space-separated scenario lists, and the
+  ZSD16 context config now sources an existing base config.
+
 ## 2026-05-03
 
 ### Changed

--- a/configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384.env
+++ b/configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384.env
@@ -4,7 +4,7 @@
 # stack: Verified PE + Self-Ask, optimized MCP sessions, prefix caching, and the
 # compressed INT8/BF16/fp8-KV serving profile.
 
-source configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_32768.env
+source configs/experiment2/exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized.env
 
 EXPERIMENT_NAME="exp2_cell_ZSD_verified_pe_self_ask_mcp_model_optimized_16384"
 EXPERIMENT_CELL="ZSD16"

--- a/docs/compute_plan.md
+++ b/docs/compute_plan.md
@@ -162,6 +162,10 @@ for evaluation is large; prefer WatsonX API if available, otherwise run on GCP A
 | **Large model (70B, optional)** | WatsonX API (preferred) |
 | **Insomnia queues full** | GCP A100-40GB spot as overflow |
 
+WatsonX API rows can run from CPU-only clients. Use GPU VMs only when the same
+job also self-hosts local vLLM, collects GPU/profiler traces, or needs
+hardware-matched local-serving evidence.
+
 ### Why Insomnia over GCP
 
 - **Cost:** Insomnia is free. GCP burns through credits at $1.81-5.07/hr per GPU.

--- a/docs/reference/watsonx_access.md
+++ b/docs/reference/watsonx_access.md
@@ -127,6 +127,13 @@ response = model.generate_text(
 
 ### Where to use WatsonX
 
+WatsonX-hosted rows do not need a local GPU. The client machine only runs the
+benchmark harness, MCP/direct tool code, artifact writing, and API requests;
+the 70B / judge inference happens on IBM-hosted infrastructure. A laptop,
+Insomnia CPU/login context, or non-GPU GCP VM can run these jobs when it has
+the repo checkout, Python environment, credentials, network, and enough
+wall-clock time.
+
 | Workload | Use WatsonX? | Why |
 |----------|--------------|-----|
 | Llama-3.1-8B-Instruct profiling (Phase 2) | No | Need GPU-level traces from self-hosted vLLM on Insomnia |

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -215,6 +215,24 @@ def _parse_parallel_tool_calls(value: str | None) -> bool | None:
     )
 
 
+def _is_watsonx_model(model_id: str) -> bool:
+    return model_id.strip().lower().startswith("watsonx/")
+
+
+def _configure_litellm_provider_compat(model_id: str) -> None:
+    """Apply provider-specific LiteLLM compatibility knobs."""
+    if not _is_watsonx_model(model_id):
+        return
+    try:
+        import litellm  # type: ignore
+    except ImportError:
+        return
+    # WatsonX rejects OpenAI-only request fields such as parallel_tool_calls
+    # even when their value is false. Ask LiteLLM to drop unsupported params
+    # instead of turning hosted 70B AaT spot checks into artifact failures.
+    litellm.drop_params = True
+
+
 def _serialize_run_result(
     args: argparse.Namespace,
     prompt: str,
@@ -414,22 +432,34 @@ class AaTRunner:
         from agents.extensions.models.litellm_model import LitellmModel
         from scripts.aat_system_prompt import AOB_SYSTEM_PROMPT
 
+        if _is_watsonx_model(self.model_id) and self.parallel_tool_calls is True:
+            raise ValueError(
+                "WatsonX does not support parallel_tool_calls; set "
+                "AAT_PARALLEL_TOOL_CALLS=false or auto for hosted WatsonX runs."
+            )
+        _configure_litellm_provider_compat(self.model_id)
+
         base_url = self.litellm_base_url or os.environ.get("LITELLM_BASE_URL")
         api_key = self.litellm_api_key or os.environ.get("LITELLM_API_KEY")
-        agent = Agent(
-            name="smartgrid_aat",
-            instructions=AOB_SYSTEM_PROMPT,
-            tools=self.tools,
-            mcp_servers=self.mcp_servers,
-            model=LitellmModel(
+        effective_parallel_tool_calls = self.parallel_tool_calls
+        if _is_watsonx_model(self.model_id) and effective_parallel_tool_calls is False:
+            effective_parallel_tool_calls = None
+        agent_kwargs: dict[str, Any] = {
+            "name": "smartgrid_aat",
+            "instructions": AOB_SYSTEM_PROMPT,
+            "tools": self.tools,
+            "mcp_servers": self.mcp_servers,
+            "model": LitellmModel(
                 model=self.model_id,
                 base_url=base_url,
                 api_key=api_key,
             ),
-            model_settings=ModelSettings(
+        }
+        if effective_parallel_tool_calls is not None:
+            agent_kwargs["model_settings"] = ModelSettings(
                 parallel_tool_calls=self.parallel_tool_calls,
-            ),
-        )
+            )
+        agent = Agent(**agent_kwargs)
         return await Runner.run(agent, prompt, max_turns=self.max_turns)
 
 

--- a/scripts/aat_upstream_openai_runner.py
+++ b/scripts/aat_upstream_openai_runner.py
@@ -133,12 +133,27 @@ def _parse_parallel_tool_calls() -> bool | None:
     )
 
 
-def _patch_aob_openai_runner(aob_openai_runner: Any, repo_root: Path) -> list[str]:
+def _is_watsonx_model(model_id: str) -> bool:
+    return model_id.strip().lower().startswith("watsonx/")
+
+
+def _configure_litellm_provider_compat(model_id: str) -> None:
+    if not _is_watsonx_model(model_id):
+        return
+    try:
+        import litellm  # type: ignore
+    except ImportError:
+        return
+    litellm.drop_params = True
+
+
+def _patch_aob_openai_runner(
+    aob_openai_runner: Any,
+    repo_root: Path,
+    model_id: str = "",
+) -> list[str]:
     """Patch AOB runner dependencies while leaving OpenAIAgentRunner.run intact."""
-    from agents import Agent as SDKAgent, ModelSettings
-    from agents.mcp import MCPServerStdio
     from scripts.aat_system_prompt import AOB_SOURCE_SHA
-    from scripts.aat_tools_mcp import _client_timeout_seconds, _server_params
 
     patches: list[str] = []
 
@@ -157,6 +172,10 @@ def _patch_aob_openai_runner(aob_openai_runner: Any, repo_root: Path) -> list[st
             f"expected AOB source SHA {AOB_SOURCE_SHA}. Refusing to run parity "
             "smoke without the local-vLLM parallel_tool_calls setting."
         )
+
+    from agents import Agent as SDKAgent, ModelSettings
+    from agents.mcp import MCPServerStdio
+    from scripts.aat_tools_mcp import _client_timeout_seconds, _server_params
 
     def _build_smartgrid_mcp_servers(
         server_paths: dict[str, Path | str],
@@ -188,12 +207,22 @@ def _patch_aob_openai_runner(aob_openai_runner: Any, repo_root: Path) -> list[st
         return servers
 
     parallel_tool_calls = _parse_parallel_tool_calls()
+    if _is_watsonx_model(model_id) and parallel_tool_calls is True:
+        raise ValueError(
+            "WatsonX does not support parallel_tool_calls; set "
+            "AAT_PARALLEL_TOOL_CALLS=false or auto for hosted WatsonX runs."
+        )
+    _configure_litellm_provider_compat(model_id)
+    effective_parallel_tool_calls = parallel_tool_calls
+    if _is_watsonx_model(model_id) and effective_parallel_tool_calls is False:
+        effective_parallel_tool_calls = None
 
     def _agent_with_model_settings(*args: Any, **kwargs: Any) -> Any:
-        kwargs.setdefault(
-            "model_settings",
-            ModelSettings(parallel_tool_calls=parallel_tool_calls),
-        )
+        if effective_parallel_tool_calls is not None:
+            kwargs.setdefault(
+                "model_settings",
+                ModelSettings(parallel_tool_calls=parallel_tool_calls),
+            )
         return SDKAgent(*args, **kwargs)
 
     aob_openai_runner._build_mcp_servers = _build_smartgrid_mcp_servers
@@ -201,6 +230,8 @@ def _patch_aob_openai_runner(aob_openai_runner: Any, repo_root: Path) -> list[st
 
     aob_openai_runner.Agent = _agent_with_model_settings
     patches.append(f"parallel_tool_calls={parallel_tool_calls}")
+    if _is_watsonx_model(model_id):
+        patches.append("watsonx_drop_unsupported_params")
 
     return patches
 
@@ -286,7 +317,7 @@ async def _main(args: argparse.Namespace) -> int:
 
     from agent.openai_agent import runner as aob_openai_runner
 
-    patches = _patch_aob_openai_runner(aob_openai_runner, repo_root)
+    patches = _patch_aob_openai_runner(aob_openai_runner, repo_root, args.model_id)
     OpenAIAgentRunner = aob_openai_runner.OpenAIAgentRunner
     runner = OpenAIAgentRunner(
         server_paths=server_paths,

--- a/scripts/gcp_resume_state.py
+++ b/scripts/gcp_resume_state.py
@@ -9,6 +9,7 @@ finalization, and manifest events.
 from __future__ import annotations
 
 import argparse
+import glob
 import hashlib
 import importlib.metadata
 import json
@@ -138,6 +139,23 @@ def _scenario_payload(path: Path) -> dict[str, Any]:
 
 def _scenario_basename(path: Path) -> str:
     return path.stem
+
+
+def _expand_scenario_glob(scenario_glob: str) -> list[Path]:
+    """Expand either one glob pattern or a shell-style list of scenario paths."""
+    tokens = shlex.split(scenario_glob)
+    if not tokens:
+        tokens = [scenario_glob]
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for token in tokens:
+        for match in sorted(glob.glob(token)):
+            key = _norm(match)
+            if key in seen:
+                continue
+            paths.append(Path(match))
+            seen.add(key)
+    return paths
 
 
 def _step_failed(step: dict[str, Any]) -> bool:
@@ -313,6 +331,75 @@ def classify_trial(
         "output_path": _posix(output_path),
         "reason": ",".join(sorted(set(incomplete_reasons))) or "missing_json",
         "latency_rows": 0,
+    }
+
+
+def validate_run_artifacts(
+    *,
+    run_dir: Path,
+    scenario_glob: str,
+    trials: int,
+    run_name: str = "",
+    require_latency: bool = True,
+) -> dict[str, Any]:
+    scenario_files = _expand_scenario_glob(scenario_glob)
+    expected = len(scenario_files) * int(trials)
+    complete = 0
+    success = 0
+    failure = 0
+    missing: list[dict[str, Any]] = []
+    latency_file = run_dir / "latencies.jsonl"
+
+    if expected == 0:
+        return {
+            "valid": False,
+            "expected": 0,
+            "complete": 0,
+            "success": 0,
+            "failure": 0,
+            "missing": [],
+            "reason": "no_expected_trials",
+        }
+
+    for scenario_file in scenario_files:
+        basename = _scenario_basename(scenario_file)
+        for trial_index in range(1, int(trials) + 1):
+            output_name = f"{basename}_run{trial_index:02d}.json"
+            if run_name:
+                output_name = f"{run_name}_{output_name}"
+            result = classify_trial(
+                run_dir=run_dir,
+                scenario_file=scenario_file,
+                trial_index=trial_index,
+                output_path=run_dir / output_name,
+                latency_file=latency_file,
+                require_latency=require_latency,
+            )
+            if result["complete"]:
+                complete += 1
+                if result["success"]:
+                    success += 1
+                else:
+                    failure += 1
+                continue
+            missing.append(
+                {
+                    "scenario_file": _posix(scenario_file),
+                    "trial_index": trial_index,
+                    "reason": result["reason"],
+                    "output_path": result["output_path"],
+                }
+            )
+
+    valid = complete == expected
+    return {
+        "valid": valid,
+        "expected": expected,
+        "complete": complete,
+        "success": success,
+        "failure": failure,
+        "missing": missing,
+        "reason": "ok" if valid else "incomplete_trajectory_artifacts",
     }
 
 
@@ -571,6 +658,13 @@ def _build_parser() -> argparse.ArgumentParser:
     event.add_argument("--run-name", required=True)
     event.add_argument("--reason", default="")
     event.add_argument("--batch-id", default="")
+
+    validate = sub.add_parser("validate-run-shell")
+    validate.add_argument("--run-dir", required=True, type=Path)
+    validate.add_argument("--scenario-glob", required=True)
+    validate.add_argument("--trials", required=True, type=int)
+    validate.add_argument("--run-name", default="")
+    validate.add_argument("--require-latency", action="store_true")
     return parser
 
 
@@ -642,6 +736,32 @@ def main() -> None:
             reason=args.reason,
             batch_id=args.batch_id,
         )
+        return
+    if args.command == "validate-run-shell":
+        result = validate_run_artifacts(
+            run_dir=args.run_dir,
+            scenario_glob=args.scenario_glob,
+            trials=args.trials,
+            run_name=args.run_name,
+            require_latency=args.require_latency,
+        )
+        missing_sample = result["missing"][:5]
+        _emit_shell(
+            {
+                "VALIDATION_PASSED": _shell_bool(bool(result["valid"])),
+                "VALIDATION_EXPECTED": result["expected"],
+                "VALIDATION_COMPLETE": result["complete"],
+                "VALIDATION_SUCCESS": result["success"],
+                "VALIDATION_FAILURE": result["failure"],
+                "VALIDATION_MISSING": len(result["missing"]),
+                "VALIDATION_REASON": result["reason"],
+                "VALIDATION_MISSING_SAMPLE": json.dumps(
+                    missing_sample, sort_keys=True, separators=(",", ":")
+                ),
+            }
+        )
+        if not result["valid"]:
+            raise SystemExit(1)
         return
     raise AssertionError(args.command)
 

--- a/scripts/plan_execute_self_ask_runner.py
+++ b/scripts/plan_execute_self_ask_runner.py
@@ -71,7 +71,16 @@ async def _run(args) -> None:
     repair_attempts_by_target = {}
 
     try:
-        self_ask = maybe_self_ask(args.question, llm)
+        self_ask = (
+            SimpleNamespace(
+                needs_self_ask=False,
+                clarifying_questions=[],
+                assumptions=[],
+                augmented_question=args.question,
+            )
+            if args.disable_self_ask
+            else maybe_self_ask(args.question, llm)
+        )
         descriptions = await executor.get_server_descriptions()
         tool_catalog = await build_tool_catalog_for_executor(executor, server_paths)
         planner_descriptions = build_planner_descriptions(descriptions, tool_catalog)
@@ -212,6 +221,7 @@ async def _run(args) -> None:
             "question": args.question,
             "effective_question": self_ask.augmented_question,
             "self_ask": {
+                "enabled": not args.disable_self_ask,
                 "needs_self_ask": self_ask.needs_self_ask,
                 "clarifying_questions": self_ask.clarifying_questions,
                 "assumptions": self_ask.assumptions,
@@ -253,6 +263,11 @@ def main() -> None:
     parser = build_parser(
         "plan-execute-self-ask",
         "Run the PE workflow with a lightweight Self-Ask clarification pass.",
+    )
+    parser.add_argument(
+        "--disable-self-ask",
+        action="store_true",
+        help="Skip the pre-plan Self-Ask clarification pass for this run.",
     )
     args = parser.parse_args()
     setup_logging(args.verbose)

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -138,6 +138,14 @@ TORCH_PROFILE_DIR="${TORCH_PROFILE_DIR:-}"
 HYBRID_RUNNER_TEMPLATE="${HYBRID_RUNNER_TEMPLATE:-}"
 VERIFIED_PE_RUNNER_TEMPLATE="${VERIFIED_PE_RUNNER_TEMPLATE:-}"
 ENABLE_SELF_ASK="${ENABLE_SELF_ASK:-0}"
+PLAN_EXECUTE_REPO_LOCAL="${PLAN_EXECUTE_REPO_LOCAL:-}"
+if [ -z "$PLAN_EXECUTE_REPO_LOCAL" ]; then
+  if [ "$ORCHESTRATION" = "plan_execute" ] && [ "$ENABLE_SMARTGRID_SERVERS" = "1" ]; then
+    PLAN_EXECUTE_REPO_LOCAL=1
+  else
+    PLAN_EXECUTE_REPO_LOCAL=0
+  fi
+fi
 ENABLE_MISSING_EVIDENCE_GUARD="${ENABLE_MISSING_EVIDENCE_GUARD:-0}"
 ENABLE_MISSING_EVIDENCE_REPAIR="${ENABLE_MISSING_EVIDENCE_REPAIR:-0}"
 MISSING_EVIDENCE_REPAIR_MAX_ATTEMPTS="${MISSING_EVIDENCE_REPAIR_MAX_ATTEMPTS:-2}"
@@ -634,7 +642,7 @@ PY
 run_plan_execute_trial() {
   local prompt="$1"
   local out_path="$2"
-  if [ "$ENABLE_SELF_ASK" = "1" ]; then
+  if [ "$ENABLE_SELF_ASK" = "1" ] || [ "${PLAN_EXECUTE_REPO_LOCAL:-0}" = "1" ]; then
     local -a wrapper_cmd=(
       "$AOB_PYTHON"
       "$REPO_ROOT/scripts/plan_execute_self_ask_runner.py"
@@ -643,6 +651,9 @@ run_plan_execute_trial() {
       --aob-path "$AOB_PATH"
       --mcp-mode "$MCP_MODE"
     )
+    if [ "$ENABLE_SELF_ASK" != "1" ]; then
+      wrapper_cmd+=(--disable-self-ask)
+    fi
     if [ "$HARNESS_VERBOSE" = "1" ]; then
       wrapper_cmd+=(--verbose --show-plan --show-trajectory)
     fi
@@ -655,7 +666,6 @@ run_plan_execute_trial() {
   if [ "$HARNESS_VERBOSE" = "1" ]; then
     cmd+=(--verbose --show-plan --show-trajectory)
   fi
-  cmd+=("${SERVER_ARGS[@]}")
   cmd+=("$prompt")
   (cd "$AOB_PATH" && "${cmd[@]}") >"$out_path" 2>>"$HARNESS_LOG"
 }
@@ -917,6 +927,8 @@ run_external_orchestration_trial() {
 run_agent_as_tool_trial() {
   local prompt="$1"
   local out_path="$2"
+
+  export AAT_MCP_SERVER_PYTHON AAT_MCP_SERVER_LAUNCH_MODE AAT_MCP_CLIENT_TIMEOUT_SECONDS
 
   if [ -n "$AAT_RUNNER_TEMPLATE" ]; then
     run_external_orchestration_trial "$prompt" "$out_path" "AAT_RUNNER_TEMPLATE"

--- a/scripts/run_gcp_context_batch.sh
+++ b/scripts/run_gcp_context_batch.sh
@@ -121,6 +121,31 @@ with pathlib.Path(path).open("a", encoding="utf-8") as fh:
 PY
 }
 
+validate_run_artifacts() {
+  local run_dir="$1" scenario_glob="$2" trials="$3" run_name="$4"
+  local validation_rc=0
+  local -a require_latency_args=()
+  if [ "${SMARTGRID_RESUME_REQUIRE_LATENCY:-1}" = "1" ]; then
+    require_latency_args+=(--require-latency)
+  fi
+  local validation_output
+  validation_output="$(
+    "$PYTHON_BIN" scripts/gcp_resume_state.py validate-run-shell \
+      --run-dir "$run_dir" \
+      --scenario-glob "$scenario_glob" \
+      --trials "$trials" \
+      --run-name "$run_name" \
+      "${require_latency_args[@]}"
+  )" || validation_rc=$?
+  eval "$validation_output"
+  echo "Artifact validation for $run_name: ${VALIDATION_COMPLETE:-0}/${VALIDATION_EXPECTED:-0} complete, ${VALIDATION_MISSING:-0} missing"
+  if [ "$validation_rc" -ne 0 ]; then
+    echo "ERROR: incomplete trajectory artifacts for $run_name: ${VALIDATION_REASON:-unknown}" >&2
+    echo "Missing sample: ${VALIDATION_MISSING_SAMPLE:-[]}" >&2
+  fi
+  return "$validation_rc"
+}
+
 preflight_runtime() {
   [ "$DRY_RUN" = "1" ] && return 0
   command -v "$PYTHON_BIN" >/dev/null
@@ -179,9 +204,12 @@ tail -n +2 "$COHORT_TSV" | while IFS=$'\t' read -r label config; do
   started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   if [ "$existing_status" = "complete" ]; then
-    echo "Skipping $label: already complete in $STATE_FILE"
-    append_manifest "$label" "$config" "$run_id" "$run_dir" "" "" "skipped_complete" "$started" "$started"
-    continue
+    if validate_run_artifacts "$run_dir" "$SCENARIOS_GLOB" "$TRIALS" "$run_id"; then
+      echo "Skipping $label: already complete in $STATE_FILE"
+      append_manifest "$label" "$config" "$run_id" "$run_dir" "" "" "skipped_complete" "$started" "$started"
+      continue
+    fi
+    echo "WARNING: $label was marked complete but artifact validation failed; rerunning with SMARTGRID_RESUME=1" >&2
   fi
 
   append_state "$label" "$config" "$run_id" "started" "$started" ""
@@ -201,6 +229,9 @@ tail -n +2 "$COHORT_TSV" | while IFS=$'\t' read -r label config; do
   SMARTGRID_COMPUTE_INSTANCE="${SMARTGRID_COMPUTE_INSTANCE:-$(hostname)}" \
     bash scripts/run_experiment.sh "$config" || run_rc=$?
 
+  artifact_rc=0
+  validate_run_artifacts "$run_dir" "$SCENARIOS_GLOB" "$TRIALS" "$run_id" || artifact_rc=$?
+
   judge_rc=0
   if [ "$RUN_JUDGE" = "1" ]; then
     "$PYTHON_BIN" scripts/judge_trajectory.py \
@@ -212,6 +243,7 @@ tail -n +2 "$COHORT_TSV" | while IFS=$'\t' read -r label config; do
   finished="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   status="complete"
   [ "$run_rc" -ne 0 ] && status="run_failed"
+  [ "$run_rc" -eq 0 ] && [ "$artifact_rc" -ne 0 ] && status="artifact_failed"
   [ "$judge_rc" -ne 0 ] && status="judge_failed"
   append_state "$label" "$config" "$run_id" "$status" "$started" "$finished"
   append_manifest "$label" "$config" "$run_id" "$run_dir" "$run_rc" "$judge_rc" "$status" "$started" "$finished"

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -448,6 +448,91 @@ def test_runner_threads_litellm_env(monkeypatch):
     assert settings.kwargs["parallel_tool_calls"] is False
 
 
+def test_watsonx_runner_omits_openai_only_model_settings(monkeypatch):
+    from scripts.aat_runner import AaTRunner
+
+    captured: dict[str, object] = {}
+
+    class FakeLitellmModel:
+        def __init__(self, model, base_url=None, api_key=None):
+            captured["model"] = model
+
+    class FakeModelSettings:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["agent_kwargs"] = kwargs
+
+    class FakeRunner:
+        @staticmethod
+        async def run(agent, prompt, max_turns):
+            return _stub_run_result()
+
+    fake_litellm = SimpleNamespace(drop_params=False)
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.setitem(
+        sys.modules,
+        "agents",
+        SimpleNamespace(
+            Agent=FakeAgent,
+            ModelSettings=FakeModelSettings,
+            Runner=FakeRunner,
+            __version__="test",
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "agents.extensions", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "agents.extensions.models", SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "agents.extensions.models.litellm_model",
+        SimpleNamespace(LitellmModel=FakeLitellmModel),
+    )
+
+    runner = AaTRunner(
+        model_id="watsonx/meta-llama/llama-3-3-70b-instruct",
+        mcp_mode="direct",
+        parallel_tool_calls=False,
+    )
+    asyncio.run(runner.run("hello"))
+
+    assert captured["model"] == "watsonx/meta-llama/llama-3-3-70b-instruct"
+    assert "model_settings" not in captured["agent_kwargs"]
+    assert fake_litellm.drop_params is True
+
+
+def test_watsonx_runner_rejects_parallel_tool_calls_true(monkeypatch):
+    from scripts.aat_runner import AaTRunner
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agents",
+        SimpleNamespace(
+            Agent=lambda **_kwargs: None,
+            ModelSettings=lambda **_kwargs: None,
+            Runner=SimpleNamespace(run=lambda *_args, **_kwargs: None),
+            __version__="test",
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "agents.extensions", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "agents.extensions.models", SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "agents.extensions.models.litellm_model",
+        SimpleNamespace(LitellmModel=lambda **_kwargs: None),
+    )
+
+    runner = AaTRunner(
+        model_id="watsonx/meta-llama/llama-3-3-70b-instruct",
+        mcp_mode="direct",
+        parallel_tool_calls=True,
+    )
+
+    with pytest.raises(ValueError, match="WatsonX does not support"):
+        asyncio.run(runner.run("hello"))
+
+
 def test_batch_mode_requires_output_dir():
     from scripts.aat_runner import _main
 

--- a/tests/test_aat_upstream_openai_runner.py
+++ b/tests/test_aat_upstream_openai_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -36,7 +37,7 @@ def test_upstream_patch_requires_agent_symbol() -> None:
     assert AOB_SOURCE_SHA in message
 
 
-def test_upstream_patch_replaces_expected_symbols() -> None:
+def test_upstream_patch_replaces_expected_symbols(monkeypatch) -> None:
     from scripts.aat_upstream_openai_runner import _patch_aob_openai_runner
 
     def original_build() -> list[object]:
@@ -50,12 +51,69 @@ def test_upstream_patch_replaces_expected_symbols() -> None:
         Agent=original_agent,
     )
 
+    monkeypatch.setitem(
+        sys.modules,
+        "agents",
+        SimpleNamespace(Agent=original_agent, ModelSettings=lambda **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agents.mcp",
+        SimpleNamespace(MCPServerStdio=lambda **_kwargs: None),
+    )
+
     patches = _patch_aob_openai_runner(module, pathlib.Path.cwd())
 
     assert module._build_mcp_servers is not original_build
     assert module.Agent is not original_agent
     assert "mcp_server_launch" in patches
     assert any(patch.startswith("parallel_tool_calls=") for patch in patches)
+
+
+def test_upstream_patch_omits_watsonx_parallel_setting(monkeypatch) -> None:
+    from scripts.aat_upstream_openai_runner import _patch_aob_openai_runner
+
+    captured: dict[str, object] = {}
+
+    def original_build() -> list[object]:
+        return []
+
+    def sdk_agent(*_args: object, **kwargs: object) -> None:
+        captured["kwargs"] = kwargs
+        return None
+
+    class FakeModelSettings:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    fake_litellm = SimpleNamespace(drop_params=False)
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.setitem(
+        sys.modules,
+        "agents",
+        SimpleNamespace(Agent=sdk_agent, ModelSettings=FakeModelSettings),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agents.mcp",
+        SimpleNamespace(MCPServerStdio=lambda **_kwargs: None),
+    )
+
+    module = SimpleNamespace(
+        _build_mcp_servers=original_build,
+        Agent=sdk_agent,
+    )
+
+    patches = _patch_aob_openai_runner(
+        module,
+        pathlib.Path.cwd(),
+        model_id="watsonx/meta-llama/llama-3-3-70b-instruct",
+    )
+    module.Agent(name="x")
+
+    assert "model_settings" not in captured["kwargs"]
+    assert "watsonx_drop_unsupported_params" in patches
+    assert fake_litellm.drop_params is True
 
 
 def test_upstream_serialize_marks_max_turns_unsuccessful(tmp_path) -> None:

--- a/tests/test_gcp_resume_state.py
+++ b/tests/test_gcp_resume_state.py
@@ -26,18 +26,19 @@ def _trial(path: Path, *, success: bool | None = True, answer: str = "done") -> 
 def _latency(
     path: Path, scenario_file: Path, trial_index: int, output_path: Path
 ) -> None:
-    path.write_text(
-        json.dumps(
-            {
-                "scenario_file": scenario_file.as_posix(),
-                "trial_index": trial_index,
-                "latency_seconds": 1.25,
-                "output_path": output_path.as_posix(),
-            }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "scenario_file": scenario_file.as_posix(),
+                    "trial_index": trial_index,
+                    "latency_seconds": 1.25,
+                    "output_path": output_path.as_posix(),
+                }
+            )
+            + "\n"
         )
-        + "\n",
-        encoding="utf-8",
-    )
 
 
 def _classify(
@@ -235,3 +236,91 @@ def test_finalize_trial_marks_divergent_rerun(tmp_path: Path) -> None:
     rerun = manifest_rows[-1]
     assert rerun["divergent"] is True
     assert rerun["original_output_sha256"] != rerun["final_output_sha256"]
+
+
+def test_validate_run_artifacts_flags_missing_outputs(tmp_path: Path) -> None:
+    scenario_file = _scenario(tmp_path / "multi_01.json")
+
+    result = gcp_resume_state.validate_run_artifacts(
+        run_dir=tmp_path / "run",
+        scenario_glob=scenario_file.as_posix(),
+        trials=1,
+        run_name="batch_Y",
+        require_latency=True,
+    )
+
+    assert result["valid"] is False
+    assert result["expected"] == 1
+    assert result["complete"] == 0
+    assert result["reason"] == "incomplete_trajectory_artifacts"
+    assert result["missing"][0]["reason"] == "missing_json"
+
+
+def test_validate_run_artifacts_counts_terminal_failures_as_complete(
+    tmp_path: Path,
+) -> None:
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    scenario_file = _scenario(scenarios_dir / "multi_01.json")
+    run_dir = tmp_path / "run"
+    run_name = "batch_Y"
+    success_output = _trial(
+        run_dir / f"{run_name}_multi_01_run01.json",
+        success=True,
+    )
+    failure_output = _trial(
+        run_dir / f"{run_name}_multi_01_run02.json",
+        success=False,
+    )
+    _latency(run_dir / "latencies.jsonl", scenario_file, 1, success_output)
+    _latency(run_dir / "latencies.jsonl", scenario_file, 2, failure_output)
+
+    result = gcp_resume_state.validate_run_artifacts(
+        run_dir=run_dir,
+        scenario_glob=scenario_file.as_posix(),
+        trials=2,
+        run_name=run_name,
+        require_latency=True,
+    )
+
+    assert result["valid"] is True
+    assert result["expected"] == 2
+    assert result["complete"] == 2
+    assert result["success"] == 1
+    assert result["failure"] == 1
+    assert result["missing"] == []
+
+
+def test_validate_run_artifacts_accepts_space_separated_scenario_list(
+    tmp_path: Path,
+) -> None:
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    first_scenario = _scenario(scenarios_dir / "multi_01.json", "SGT-001")
+    second_scenario = _scenario(scenarios_dir / "wo_04.json", "SGT-018")
+    run_dir = tmp_path / "run"
+    run_name = "batch_Y"
+
+    first_output = _trial(
+        run_dir / f"{run_name}_multi_01_run01.json",
+        success=True,
+    )
+    second_output = _trial(
+        run_dir / f"{run_name}_wo_04_run01.json",
+        success=True,
+    )
+    _latency(run_dir / "latencies.jsonl", first_scenario, 1, first_output)
+    _latency(run_dir / "latencies.jsonl", second_scenario, 1, second_output)
+
+    result = gcp_resume_state.validate_run_artifacts(
+        run_dir=run_dir,
+        scenario_glob=f"{first_scenario.as_posix()} {second_scenario.as_posix()}",
+        trials=1,
+        run_name=run_name,
+        require_latency=True,
+    )
+
+    assert result["valid"] is True
+    assert result["expected"] == 2
+    assert result["complete"] == 2
+    assert result["missing"] == []

--- a/tests/test_runner_guardrails.py
+++ b/tests/test_runner_guardrails.py
@@ -1,0 +1,65 @@
+"""Text guardrails for shell-runner wiring that is awkward to unit-test live."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _function_body(script: str, start_marker: str, end_marker: str) -> str:
+    start = script.index(start_marker)
+    end = script.index(end_marker, start)
+    return script[start:end]
+
+
+def test_per_trial_aat_exports_mcp_server_environment() -> None:
+    script = Path("scripts/run_experiment.sh").read_text(encoding="utf-8")
+    body = _function_body(
+        script,
+        "run_agent_as_tool_trial()",
+        "run_agent_as_tool_batch()",
+    )
+
+    export_line = (
+        "export AAT_MCP_SERVER_PYTHON AAT_MCP_SERVER_LAUNCH_MODE "
+        "AAT_MCP_CLIENT_TIMEOUT_SECONDS"
+    )
+    invocation = '(cd "$REPO_ROOT" && "${cmd[@]}")'
+    assert export_line in body
+    assert body.index(export_line) < body.index(invocation)
+
+
+def test_gcp_batch_driver_hard_fails_incomplete_artifacts() -> None:
+    script = Path("scripts/run_gcp_context_batch.sh").read_text(encoding="utf-8")
+
+    assert "validate-run-shell" in script
+    assert "incomplete trajectory artifacts" in script
+    assert 'status="artifact_failed"' in script
+    assert 'existing_status" = "complete"' in script
+
+
+def test_plan_execute_repo_local_keeps_smartgrid_server_overrides() -> None:
+    script = Path("scripts/run_experiment.sh").read_text(encoding="utf-8")
+    body = _function_body(
+        script,
+        "run_plan_execute_trial()",
+        "run_json_stdout_trial()",
+    )
+
+    assert 'PLAN_EXECUTE_REPO_LOCAL="${PLAN_EXECUTE_REPO_LOCAL:-}"' in script
+    assert '[ "$ORCHESTRATION" = "plan_execute" ]' in script
+    assert '[ "$ENABLE_SMARTGRID_SERVERS" = "1" ]' in script
+    assert "PLAN_EXECUTE_REPO_LOCAL=1" in script
+    assert '[ "${PLAN_EXECUTE_REPO_LOCAL:-0}" = "1" ]' in body
+    assert "wrapper_cmd+=(--disable-self-ask)" in body
+    assert 'wrapper_cmd+=("${SERVER_ARGS[@]}")' in body
+
+    upstream_cli = body.split("local -a cmd=(uv run plan-execute", 1)[1]
+    assert 'cmd+=("${SERVER_ARGS[@]}")' not in upstream_cli
+
+
+def test_repo_local_pe_runner_can_disable_self_ask() -> None:
+    runner = Path("scripts/plan_execute_self_ask_runner.py").read_text(encoding="utf-8")
+
+    assert '"--disable-self-ask"' in runner
+    assert "if args.disable_self_ask" in runner
+    assert "augmented_question=args.question" in runner


### PR DESCRIPTION
## Summary

- harden hosted WatsonX AaT paths by omitting unsupported `parallel_tool_calls` settings and enabling LiteLLM provider param dropping for WatsonX models
- route SmartGrid vanilla Plan-Execute through the repo-local server-aware runner by default, with self-ask disabled, while preserving explicit non-SmartGrid opt-out paths
- harden GCP fallback resume validation: revalidate completed rows before skipping, mark missing artifacts as `artifact_failed`, support final-six space-separated scenario lists, and fix the ZSD16 context config source

Refs #66, #91.

## Test Plan

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q tests/test_gcp_resume_state.py tests/test_runner_guardrails.py tests/test_aat_runner.py tests/test_aat_upstream_openai_runner.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with 'openai-agents==0.14.5' --with 'mcp[cli]==1.27.0' --with 'litellm==1.81.13' pytest -q tests/`
- `bash -n scripts/run_experiment.sh scripts/run_gcp_context_batch.sh`
- `python3 -m py_compile scripts/gcp_resume_state.py scripts/aat_runner.py scripts/aat_upstream_openai_runner.py scripts/plan_execute_self_ask_runner.py`
- `git diff --check team13/main..HEAD`
