### PR TITLE
Add hosted 70B CPU rerun support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Added a post-PR179 WatsonX Llama-3.3-70B final-six x3 cohort and made the
+  GCP batch launcher skip local model/vLLM preflight when explicitly running
+  hosted-model-only CPU lanes.
 - Hardened hosted WatsonX 70B runner compatibility: AaT runners now omit/drop
   unsupported `parallel_tool_calls` settings for WatsonX, vanilla PE can opt
   into the repo-local Smart Grid server-aware runner with self-ask disabled,

--- a/configs/watsonx_70b_final6_3x/A70B_aat_direct.env
+++ b/configs/watsonx_70b_final6_3x/A70B_aat_direct.env
@@ -1,0 +1,16 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/A_aat_direct.env
+
+EXPERIMENT_NAME="final6x3_70b_aat_direct_watsonx"
+EXPERIMENT_CELL="A70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/B70B_aat_mcp_baseline.env
+++ b/configs/watsonx_70b_final6_3x/B70B_aat_mcp_baseline.env
@@ -1,0 +1,19 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/B_aat_mcp_baseline.env
+
+EXPERIMENT_NAME="final6x3_70b_aat_mcp_baseline_watsonx"
+EXPERIMENT_CELL="B70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+AAT_MCP_SERVER_LAUNCH_MODE="uv"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=180
+AAT_PARALLEL_TOOL_CALLS=false
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/C70B_aat_mcp_optimized.env
+++ b/configs/watsonx_70b_final6_3x/C70B_aat_mcp_optimized.env
@@ -1,0 +1,20 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/C_aat_mcp_optimized.env
+
+EXPERIMENT_NAME="final6x3_70b_aat_mcp_optimized_watsonx"
+EXPERIMENT_CELL="C70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+EXTRA_VLLM_ARGS=""
+AAT_MCP_SERVER_LAUNCH_MODE="uv"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=180
+AAT_PARALLEL_TOOL_CALLS=false
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/Y70B_pe_mcp_baseline.env
+++ b/configs/watsonx_70b_final6_3x/Y70B_pe_mcp_baseline.env
@@ -1,0 +1,19 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/Y_pe_mcp_baseline.env
+
+EXPERIMENT_NAME="final6x3_70b_exp2_cell_Y_pe_mcp_baseline_watsonx"
+EXPERIMENT_CELL="Y70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+PLAN_EXECUTE_REPO_LOCAL=1
+AAT_MCP_SERVER_LAUNCH_MODE="uv"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=180
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/YS70B_pe_self_ask_mcp_baseline.env
+++ b/configs/watsonx_70b_final6_3x/YS70B_pe_self_ask_mcp_baseline.env
@@ -1,0 +1,19 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/YS_pe_self_ask_mcp_baseline.env
+
+EXPERIMENT_NAME="final6x3_70b_exp2_cell_YS_pe_self_ask_mcp_baseline_watsonx"
+EXPERIMENT_CELL="YS70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+PLAN_EXECUTE_REPO_LOCAL=1
+AAT_MCP_SERVER_LAUNCH_MODE="uv"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=180
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/Z70B_verified_pe_mcp_baseline.env
+++ b/configs/watsonx_70b_final6_3x/Z70B_verified_pe_mcp_baseline.env
@@ -1,0 +1,19 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/Z_verified_pe_mcp_baseline.env
+
+EXPERIMENT_NAME="final6x3_70b_exp2_cell_Z_verified_pe_mcp_baseline_watsonx"
+EXPERIMENT_CELL="Z70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+PLAN_EXECUTE_REPO_LOCAL=1
+AAT_MCP_SERVER_LAUNCH_MODE="uv"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=180
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/ZS70B_verified_pe_self_ask_mcp_baseline.env
+++ b/configs/watsonx_70b_final6_3x/ZS70B_verified_pe_self_ask_mcp_baseline.env
@@ -1,0 +1,19 @@
+# WatsonX Llama-3.3-70B final-six scaling cohort.
+source configs/final_matrix_5x6/ZS_verified_pe_self_ask_mcp_baseline.env
+
+EXPERIMENT_NAME="final6x3_70b_exp2_cell_ZS_verified_pe_self_ask_mcp_baseline_watsonx"
+EXPERIMENT_CELL="ZS70B"
+EXPERIMENT_FAMILY="watsonx_70b_scaling"
+MODEL_ID="watsonx/meta-llama/llama-3-3-70b-instruct"
+MODEL_PROVIDER="watsonx"
+SERVING_STACK="watsonx_api"
+QUANTIZATION_MODE="provider_managed_fp8"
+TRIALS=3
+LAUNCH_VLLM=0
+TORCH_PROFILE=0
+ENABLE_WANDB=0
+WANDB_MODE="offline"
+PLAN_EXECUTE_REPO_LOCAL=1
+AAT_MCP_SERVER_LAUNCH_MODE="uv"
+AAT_MCP_CLIENT_TIMEOUT_SECONDS=180
+JUDGE_MODEL="watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8"

--- a/configs/watsonx_70b_final6_3x/cohort.tsv
+++ b/configs/watsonx_70b_final6_3x/cohort.tsv
@@ -1,0 +1,8 @@
+label	config
+A70B	configs/watsonx_70b_final6_3x/A70B_aat_direct.env
+B70B	configs/watsonx_70b_final6_3x/B70B_aat_mcp_baseline.env
+C70B	configs/watsonx_70b_final6_3x/C70B_aat_mcp_optimized.env
+Y70B	configs/watsonx_70b_final6_3x/Y70B_pe_mcp_baseline.env
+YS70B	configs/watsonx_70b_final6_3x/YS70B_pe_self_ask_mcp_baseline.env
+Z70B	configs/watsonx_70b_final6_3x/Z70B_verified_pe_mcp_baseline.env
+ZS70B	configs/watsonx_70b_final6_3x/ZS70B_verified_pe_self_ask_mcp_baseline.env

--- a/scripts/orchestration_utils.py
+++ b/scripts/orchestration_utils.py
@@ -11,7 +11,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any
 
 LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
@@ -450,6 +450,11 @@ def bootstrap_aob(aob_path: Path) -> None:
         path_text = str(path)
         if path_text not in sys.path:
             sys.path.insert(0, path_text)
+    if "agent" not in sys.modules:
+        agent_package = ModuleType("agent")
+        agent_package.__path__ = [str(agent_src_path)]  # type: ignore[attr-defined]
+        agent_package.__package__ = "agent"
+        sys.modules["agent"] = agent_package
 
 
 def preflight_aob_runtime_dependencies() -> None:
@@ -650,12 +655,20 @@ def effective_server_paths(entries: list[str], repo_root: Path) -> dict[str, Pat
 def build_executor(llm, server_paths: dict[str, Path], *, mcp_mode: str = "baseline"):
     """Build the PE-family step executor for the requested MCP mode."""
     if mcp_mode == "baseline":
-        from plan_execute.executor import Executor
+        from agent.plan_execute.executor import Executor
 
         return Executor(llm, server_paths)
     if mcp_mode == "optimized":
         return ReusedMCPExecutor(llm, server_paths, resolve_repo_root())
     raise ValueError(f"Unsupported MCP mode for PE-family runner: {mcp_mode!r}")
+
+
+def load_plan_execute_planner():
+    """Load AOB's PE planner with compatibility for common dependency labels."""
+    from agent.plan_execute import planner as planner_module
+
+    planner_module._DEP_NUM_RE = re.compile(r"#(?:S|Task)(\d+)")
+    return planner_module.Planner
 
 
 async def close_executor(executor: Any) -> None:
@@ -841,8 +854,8 @@ class ReusedMCPExecutor:
         question: str,
         tool_schema: str = "",
     ):
-        from plan_execute.executor import _extract_content, _resolve_args_with_llm
-        from plan_execute.models import StepResult
+        from agent.plan_execute.executor import _extract_content, _resolve_args_with_llm
+        from agent.plan_execute.models import StepResult
 
         if step.server not in self._server_paths:
             return StepResult(
@@ -904,7 +917,7 @@ def build_planning_question(question: str) -> str:
 async def build_tool_catalog(
     server_paths: dict[str, Path],
 ) -> dict[str, dict[str, dict[str, str]]]:
-    from plan_execute.executor import _list_tools
+    from agent.plan_execute.executor import _list_tools
 
     catalog: dict[str, dict[str, dict[str, str]]] = {}
     for name, path in server_paths.items():
@@ -1536,7 +1549,7 @@ def generate_suffix_plan(planner, replan_question: str, descriptions: dict[str, 
 
 
 def renumber_plan(plan, offset: int):
-    from plan_execute.models import Plan, PlanStep
+    from agent.plan_execute.models import Plan, PlanStep
 
     renumbered_steps = []
     for step in plan.steps:

--- a/scripts/plan_execute_self_ask_runner.py
+++ b/scripts/plan_execute_self_ask_runner.py
@@ -27,6 +27,7 @@ from orchestration_utils import (
     finalize_missing_evidence_repair_state,
     load_fault_risk_adjudication_config,
     load_missing_evidence_repair_config,
+    load_plan_execute_planner,
     mark_missing_evidence_attempt_result,
     mark_missing_evidence_unrepaired,
     maybe_self_ask,
@@ -58,11 +59,10 @@ async def _run(args) -> None:
     bootstrap_aob(aob_path)
     preflight_aob_runtime_dependencies()
 
-    from plan_execute.planner import Planner
-
     llm = build_llm(args.model_id)
     server_paths = effective_server_paths(args.servers, repo_root)
 
+    Planner = load_plan_execute_planner()
     planner = Planner(llm)
     executor = build_executor(llm, server_paths, mcp_mode=args.mcp_mode)
     repair_config = load_missing_evidence_repair_config()

--- a/scripts/run_gcp_context_batch.sh
+++ b/scripts/run_gcp_context_batch.sh
@@ -21,6 +21,9 @@ Usage: scripts/run_gcp_context_batch.sh [--batch-id ID|--resume-batch ID] [--row
 
 Runs the canonical seven-row GCP context closeout cohort with stable run IDs,
 SMARTGRID_RESUME=1, per-row manifest/state files, and idempotent judge scoring.
+
+Set SMARTGRID_SKIP_LOCAL_MODEL_PREFLIGHT=1 only for hosted-model cohorts
+where every row has LAUNCH_VLLM=0.
 EOF
 }
 
@@ -149,6 +152,15 @@ validate_run_artifacts() {
 preflight_runtime() {
   [ "$DRY_RUN" = "1" ] && return 0
   command -v "$PYTHON_BIN" >/dev/null
+  "$PYTHON_BIN" - <<'PY'
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit("Python >=3.11 required")
+PY
+  if [ "${SMARTGRID_SKIP_LOCAL_MODEL_PREFLIGHT:-0}" = "1" ]; then
+    return 0
+  fi
   command -v g++ >/dev/null
   command -v cc1plus >/dev/null
   if command -v nvidia-smi >/dev/null 2>&1; then
@@ -156,10 +168,6 @@ preflight_runtime() {
   fi
   "$PYTHON_BIN" - <<'PY'
 import importlib.util
-import sys
-
-if sys.version_info < (3, 11):
-    raise SystemExit("Python >=3.11 required")
 for module in ("torch", "vllm"):
     if importlib.util.find_spec(module) is None:
         raise SystemExit(f"{module} is not importable")

--- a/scripts/verified_pe_runner.py
+++ b/scripts/verified_pe_runner.py
@@ -31,6 +31,7 @@ from orchestration_utils import (
     generate_suffix_plan,
     load_fault_risk_adjudication_config,
     load_missing_evidence_repair_config,
+    load_plan_execute_planner,
     mark_missing_evidence_attempt_result,
     mark_missing_evidence_unrepaired,
     maybe_self_ask,
@@ -88,10 +89,9 @@ async def _run(args) -> None:
     bootstrap_aob(aob_path)
     preflight_aob_runtime_dependencies()
 
-    from plan_execute.planner import Planner
-
     llm = build_llm(args.model_id)
     server_paths = effective_server_paths(args.servers, repo_root)
+    Planner = load_plan_execute_planner()
     planner = Planner(llm)
     executor = build_executor(llm, server_paths, mcp_mode=args.mcp_mode)
     repair_config = load_missing_evidence_repair_config()

--- a/tests/test_orchestration_utils.py
+++ b/tests/test_orchestration_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,7 +14,9 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from orchestration_utils import (  # noqa: E402
     available_sensor_ids,
+    bootstrap_aob,
     build_fault_risk_adjudication_state,
+    build_executor,
     build_parser,
     build_planner_descriptions,
     build_planning_question,
@@ -36,6 +39,7 @@ from orchestration_utils import (  # noqa: E402
     generate_suffix_plan,
     load_fault_risk_adjudication_config,
     load_missing_evidence_repair_config,
+    load_plan_execute_planner,
     maybe_self_ask,
     normalize_plan_steps,
     normalize_response_text,
@@ -150,6 +154,97 @@ class OrchestrationUtilsTests(unittest.TestCase):
         )
         self.assertTrue(executor.called)
         self.assertIn("list_assets", result["iot"])
+
+    def test_build_executor_skips_aob_agent_package_side_effects(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aob_path = Path(tmp)
+            agent_path = aob_path / "src" / "agent"
+            plan_execute_path = agent_path / "plan_execute"
+            plan_execute_path.mkdir(parents=True)
+            (agent_path / "__init__.py").write_text(
+                'raise RuntimeError("agent package init should not run")\n',
+                encoding="utf-8",
+            )
+            (agent_path / "runner.py").write_text(
+                "DEFAULT_SERVER_PATHS = {'iot': 'iot.py'}\n",
+                encoding="utf-8",
+            )
+            (plan_execute_path / "__init__.py").write_text("", encoding="utf-8")
+            (plan_execute_path / "executor.py").write_text(
+                "from ..runner import DEFAULT_SERVER_PATHS\n\n"
+                "class Executor:\n"
+                "    def __init__(self, llm, server_paths):\n"
+                "        self.llm = llm\n"
+                "        self.server_paths = server_paths\n"
+                "        self.default_server_paths = DEFAULT_SERVER_PATHS\n",
+                encoding="utf-8",
+            )
+
+            old_agent_modules = {
+                name: module
+                for name, module in sys.modules.items()
+                if name == "agent" or name.startswith("agent.")
+            }
+            old_sys_path = list(sys.path)
+            for name in old_agent_modules:
+                sys.modules.pop(name, None)
+            try:
+                bootstrap_aob(aob_path)
+                executor = build_executor(
+                    object(),
+                    {"iot": Path("iot.py")},
+                    mcp_mode="baseline",
+                )
+            finally:
+                for name in list(sys.modules):
+                    if name == "agent" or name.startswith("agent."):
+                        sys.modules.pop(name, None)
+                sys.modules.update(old_agent_modules)
+                sys.path[:] = old_sys_path
+
+        self.assertEqual(executor.server_paths, {"iot": Path("iot.py")})
+        self.assertEqual(executor.default_server_paths, {"iot": "iot.py"})
+
+    def test_load_plan_execute_planner_accepts_task_dependencies(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aob_path = Path(tmp)
+            agent_path = aob_path / "src" / "agent"
+            plan_execute_path = agent_path / "plan_execute"
+            plan_execute_path.mkdir(parents=True)
+            (agent_path / "__init__.py").write_text(
+                'raise RuntimeError("agent package init should not run")\n',
+                encoding="utf-8",
+            )
+            (plan_execute_path / "__init__.py").write_text("", encoding="utf-8")
+            (plan_execute_path / "planner.py").write_text(
+                "import re\n"
+                "_DEP_NUM_RE = re.compile(r'#S(\\d+)')\n\n"
+                "class Planner:\n"
+                "    pass\n",
+                encoding="utf-8",
+            )
+
+            old_agent_modules = {
+                name: module
+                for name, module in sys.modules.items()
+                if name == "agent" or name.startswith("agent.")
+            }
+            old_sys_path = list(sys.path)
+            for name in old_agent_modules:
+                sys.modules.pop(name, None)
+            try:
+                bootstrap_aob(aob_path)
+                Planner = load_plan_execute_planner()
+                from agent.plan_execute import planner as planner_module
+            finally:
+                for name in list(sys.modules):
+                    if name == "agent" or name.startswith("agent."):
+                        sys.modules.pop(name, None)
+                sys.modules.update(old_agent_modules)
+                sys.path[:] = old_sys_path
+
+        self.assertEqual(Planner.__name__, "Planner")
+        self.assertEqual(planner_module._DEP_NUM_RE.findall("#Task1 #S2"), ["1", "2"])
 
     def test_close_executor_awaits_optional_aclose(self):
         class Executor:

--- a/tests/test_runner_guardrails.py
+++ b/tests/test_runner_guardrails.py
@@ -35,6 +35,7 @@ def test_gcp_batch_driver_hard_fails_incomplete_artifacts() -> None:
     assert "incomplete trajectory artifacts" in script
     assert 'status="artifact_failed"' in script
     assert 'existing_status" = "complete"' in script
+    assert "SMARTGRID_SKIP_LOCAL_MODEL_PREFLIGHT" in script
 
 
 def test_plan_execute_repo_local_keeps_smartgrid_server_overrides() -> None:


### PR DESCRIPTION
## Summary
- Add the final-six hosted WatsonX 70B CPU rerun cohort configs for A/B/C/Y/YS/Z/ZS.
- Harden the GCP batch runner for CPU-only hosted-model lanes and explicit no-judge batches.
- Fix repo-local Plan-Execute imports on clean CPU clients and accept hosted-70B `#TaskN` dependency labels as a compatibility alias.

## Context
Refs #35, #64, #66. This keeps the post-PR #179 path clean for hosted 70B reruns from CPU-only GCP clients. Prior dirty-client rows remain useful diagnostics, but claim-grade 70B rows should be rerun from this floor after merge.

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q tests/test_runner_guardrails.py tests/test_gcp_resume_state.py tests/test_orchestration_utils.py`
