### PR TITLE
Generator prompt v0.2: asset rotation + gas-name no-hint + consistency constraints (#68)

### DIFF
--- a/docs/knowledge/generated_scenario_authoring_and_ground_truth.md
+++ b/docs/knowledge/generated_scenario_authoring_and_ground_truth.md
@@ -36,6 +36,7 @@ scenarios with any of them.
 | **Ratio or threshold hint** | Pre-computes the key analytic step | "The R2 ratio exceeds 3.0, indicating arcing…" |
 | **IEC/IEEE code leak** | Gives away the answer | "The transformer shows D2 fault symptoms…" |
 | **Gas value in prompt** | Removes the data retrieval step | "H2 = 482 ppm, C2H2 = 60 ppm — diagnose…" |
+| **Gas name or formula in prompt** | Hints which fault class is in play | "hydrogen elevated above baseline", "rising methane and ethylene", "C2H2 trending up" |
 | **Decision pre-framed** | Collapses the reasoning task | "Given arcing is confirmed, create a corrective WO…" |
 | **Paraphrase of hand-crafted text** | Circularity risk | Near-copy of any scenario in `data/scenarios/` |
 | **Step-by-step instruction** | Scripted sequence, not open-ended | "First check sensor readings, then run DGA, then issue a WO…" |
@@ -53,7 +54,7 @@ Do not mention the tools or the analytic method.
 | Pattern | Example |
 |---|---|
 | Alarm or relay operation | "Transformer T-007 triggered a Buchholz relay alarm this morning. Determine whether it is safe to re-energize and what immediate action is required." |
-| Scheduled oil sampling result | "Routine DGA sampling on T-003 shows hydrogen elevated above the previous baseline. Identify the probable cause and recommend a monitoring or action plan." |
+| Scheduled oil sampling result | "Routine DGA sampling on T-003 returned readings outside the previous baseline. Identify the probable cause and recommend a monitoring or action plan." (do not name specific gases — see §2 banned table) |
 | Sensor threshold exceedance | "T-011 has been running above rated temperature for the past 48 hours. Investigate the probable cause and recommend corrective action." |
 | Protection trip | "T-019 tripped on differential protection at 02:14 this morning. Identify the most likely fault cause before the team decides on re-energization." |
 | Fleet planning question | "We need to decide whether T-002 can remain in service through the peak-demand season without major maintenance. Assess its condition and make a recommendation." |

--- a/docs/knowledge/generated_scenario_authoring_and_ground_truth.md
+++ b/docs/knowledge/generated_scenario_authoring_and_ground_truth.md
@@ -1,7 +1,7 @@
 # Generated-Scenario Authoring and Ground-Truth Contract
 
 *Created: 2026-04-26*  
-*Last updated: 2026-04-27*  
+*Last updated: 2026-05-05*  
 *Owner: Tanisha Rathod*  
 *Issue: [#90](https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp/issues/90)*
 

--- a/scripts/generate_scenarios.py
+++ b/scripts/generate_scenarios.py
@@ -95,12 +95,14 @@ PROMPT_VERSION = "v0.2"  # bump on any prompt-template change
 #   narrowed the fault class (CH4+C2H4 → thermal pattern) and contradicted
 #   the labeled D2 fault. Addresses PR #178 inspection issue "gas-fault
 #   mismatch in SGT-GEN-005" + "borderline no-hint" finding.
-# - CONSISTENCY_CONSTRAINTS (new section): two explicit checks the model
+# - CONSISTENCY_CONSTRAINTS (new section): three explicit checks the model
 #   must satisfy before emitting JSON:
 #     1. text-evidence ↔ ground_truth.final_value consistency
 #     2. expected_tools callability from prompt context (every tool's
 #        required arguments must be derivable from the text, OR a discovery
 #        tool must precede it in ideal_tool_sequence)
+#     3. asset_id pinning: the rotated asset_id must appear in both the
+#        user-facing text and ground_truth, and not be replaced by the model.
 #   Addresses PR #178 inspection issues SGT-GEN-001 / 003 / 005 / Medium 4.
 # - SCHEMA_REMINDER: tightened ground_truth.final_value example to discourage
 #   the v0.1 SGT-GEN-002 case (decisive_intermediate_values.rul_range_days

--- a/scripts/generate_scenarios.py
+++ b/scripts/generate_scenarios.py
@@ -81,7 +81,39 @@ HANDCRAFTED_DIR = _REPO_ROOT / "data" / "scenarios"
 GENERATED_ROOT = _REPO_ROOT / "data" / "scenarios" / "generated"
 ASSET_CSV = _REPO_ROOT / "data" / "processed" / "asset_metadata.csv"
 
-PROMPT_VERSION = "v0.1"  # bump on any prompt-template change
+PROMPT_VERSION = "v0.2"  # bump on any prompt-template change
+# v0.1 (2026-05-03) → v0.2 (2026-05-05) changelog:
+# - Asset rotation: build_prompt() now takes an explicit asset_id and pins it
+#   in the prompt instead of letting the model pick. Caller passes a
+#   deterministic rotation across T-001..T-020 so a single seed doesn't
+#   collapse every scenario in the batch onto the same transformer (the
+#   v0.1 first batch landed all 5 scenarios on T-005 because temperature=0.7
+#   has a strong bias toward common IDs). Addresses PR #178 inspection issue
+#   "all five use T-005".
+# - NO_HINT_RULES: ban naming gases by chemical formula or common name in the
+#   user-facing text. v0.1 SGT-GEN-005 named "methane and ethylene" which
+#   narrowed the fault class (CH4+C2H4 → thermal pattern) and contradicted
+#   the labeled D2 fault. Addresses PR #178 inspection issue "gas-fault
+#   mismatch in SGT-GEN-005" + "borderline no-hint" finding.
+# - CONSISTENCY_CONSTRAINTS (new section): two explicit checks the model
+#   must satisfy before emitting JSON:
+#     1. text-evidence ↔ ground_truth.final_value consistency
+#     2. expected_tools callability from prompt context (every tool's
+#        required arguments must be derivable from the text, OR a discovery
+#        tool must precede it in ideal_tool_sequence)
+#   Addresses PR #178 inspection issues SGT-GEN-001 / 003 / 005 / Medium 4.
+# - SCHEMA_REMINDER: tightened ground_truth.final_value example to discourage
+#   the v0.1 SGT-GEN-002 case (decisive_intermediate_values.rul_range_days
+#   said 360 but final_value.rul_estimate_days said 540 — out of range).
+#
+# Out of scope for v0.2 (deferred to a real data-grounding pass): inlining
+# actual MCP tool outputs into the prompt at generation time. The model
+# still has no way to know what get_dga_record('T-NNN') actually returns,
+# so ground_truth.decisive_intermediate_values + final_value remain
+# model-asserted. The right structural fix is either prompt-time MCP tool
+# calls or a post-generation grounding pass that overwrites those fields
+# with what the live tools return; tracked under the PS B scale-up backlog
+# in #68. v0.2 is the prompt-side improvements that don't need MCP runtime.
 
 
 def _load_json(path: pathlib.Path) -> dict[str, Any]:
@@ -176,6 +208,13 @@ NO-HINT RULES — banned in the user-facing `text` field:
 - Method names or analytic technique names (e.g. "Duval triangle", "Rogers ratio")
 - IEC fault codes (PD, D1, D2, T1, T2, T3) in the prompt itself — they may appear in `decisive_intermediate_values` only
 - Specific gas concentrations or ratio thresholds
+- Names of dissolved gases by chemical formula OR common name (H2 / hydrogen,
+  CH4 / methane, C2H2 / acetylene, C2H4 / ethylene, C2H6 / ethane, CO,
+  CO2). Naming WHICH gases are rising effectively narrows the fault class
+  to the model and is a closet-form hint. Use a generic phrasing like
+  "recent dissolved-gas analysis shows elevated activity" or "DGA values
+  are within normal range" — neither names the gases nor reveals the
+  fault. (Added v0.2 after SGT-GEN-005 violated this in the v0.1 batch.)
 - Pre-framed decisions ("you should create a work order")
 - Step-by-step instructions
 - Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
@@ -183,9 +222,49 @@ NO-HINT RULES — banned in the user-facing `text` field:
 PREFERRED:
 - Describe an operational event or condition naturally
 - Ask for a decision (diagnosis / RUL / work order / sensor anomaly), not a tool call
-- Ground in one transformer ID and one or two context details (criticality, alarm, recent reading)
+- Ground in the supplied transformer ID and one or two context details (criticality, alarm, recent reading)
 - One task per scenario
 - Under 80 words
+"""
+
+
+CONSISTENCY_CONSTRAINTS = """
+CONSISTENCY CONSTRAINTS — the model MUST satisfy these before emitting JSON.
+Most v0.1 batch failures were here:
+
+1. TEXT EVIDENCE ↔ GROUND TRUTH consistency
+   Whatever evidence appears in `text` (alarm type, sensor reading, gas
+   trend description, load condition) MUST be consistent with the labeled
+   answer in `ground_truth.final_value`. If `ground_truth.final_value`
+   says fault label D2 (low-energy discharge → C2H2-driven), then the
+   `text` cannot describe a thermal pattern. If `ground_truth.final_value`
+   says rul_estimate_days=540, then any range/window the text or
+   `decisive_intermediate_values` mentions MUST contain 540. Do NOT
+   describe stable conditions and then label a fault, or describe rising
+   thermal indicators and then label an arc fault. Pick the answer
+   first; then write text consistent with that answer.
+
+2. EXPECTED_TOOLS CALLABILITY from prompt context
+   For every tool in `expected_tools`, ALL its required arguments must be
+   derivable from the text — OR a prerequisite tool that returns those
+   arguments must precede it in `ideal_tool_sequence`. Rules of thumb:
+     - `iot.get_sensor_readings(transformer_id, sensor_id)` requires a
+       specific sensor_id. Either name the sensor in the text, OR
+       precede this tool with `iot.list_sensors` in ideal_tool_sequence.
+     - `fmsr.analyze_dga(...)` requires all five gas values
+       (H2/CH4/C2H2/C2H4/C2H6). It MUST be preceded by
+       `fmsr.get_dga_record` in ideal_tool_sequence.
+     - `wo.estimate_downtime(transformer_id, severity, ...)` requires a
+       severity. Either describe an unambiguous severity-suggesting
+       event in the text (e.g. "complete loss of function"), OR precede
+       with a fault-classification tool that produces severity.
+     - `wo.create_work_order(...)` requires fault context. It MUST be
+       preceded by something that classifies or identifies the fault
+       (e.g. `fmsr.analyze_dga` or a sensor-threshold check).
+
+3. ASSET ID is supplied to you (see ASSIGNED ASSET below). Use exactly
+   that asset_id. Do not pick a different one, do not vary it across
+   the scenario.
 """
 
 
@@ -289,18 +368,32 @@ def build_prompt(
     operational_contexts: dict[str, Any],
     support: dict[str, Any],
     rng: random.Random,
+    asset_id: str | None = None,
 ) -> str:
     """Assemble the per-scenario LLM prompt from the support data.
 
     Picks one operational context and the family-specific template
     block(s) per `FAMILY_TEMPLATE_ROUTES`. The model is given the family
-    spec, operational context, routed templates, no-hint rules, and the
-    schema reminder.
+    spec, operational context, routed templates, no-hint rules,
+    consistency constraints, and the schema reminder.
+
+    If `asset_id` is None, the model picks (v0.1 behavior — kept for
+    backward-compat with any caller that wants the old shape). The
+    canonical generator path in `main()` always passes an explicit
+    asset_id from a deterministic per-batch rotation; that's the v0.2
+    behavior fix for the "all five scenarios on T-005" failure.
     """
     ctx_name = rng.choice(list(operational_contexts.keys()))
     ctx = operational_contexts[ctx_name]
     template_block = _select_family_templates(family_name, support, rng)
     template_section = f"\n\n{template_block}" if template_block else ""
+    asset_section = (
+        f"\n\nASSIGNED ASSET: {asset_id}\n"
+        f"You MUST use exactly this asset_id (do not pick a different "
+        f"transformer ID, do not vary it across the scenario)."
+        if asset_id
+        else ""
+    )
 
     return f"""You are generating a single Smart Grid maintenance scenario for the SmartGridBench benchmark suite. The scenario will be evaluated against an LLM agent with access to four MCP servers (IoT, FMSR, TSFM, WO).
 
@@ -309,9 +402,11 @@ FAMILY SPEC:
 {json.dumps(family_spec, indent=2)}
 
 OPERATIONAL CONTEXT (`{ctx_name}`):
-{json.dumps(ctx, indent=2)}{template_section}
+{json.dumps(ctx, indent=2)}{template_section}{asset_section}
 
 {NO_HINT_RULES}
+
+{CONSISTENCY_CONSTRAINTS}
 
 {SCHEMA_REMINDER}
 """.strip()
@@ -678,12 +773,33 @@ def main() -> int:
     scenarios_emitted: list[dict[str, Any]] = []
     invocation_starting_id = next_id
 
+    # Asset rotation: deterministically walk through T-001..T-020 across the
+    # batch (ordered by next_id) so a single seed doesn't collapse every
+    # scenario onto the same transformer. The v0.1 first batch landed all 5
+    # scenarios on T-005 because the model has a strong asset bias at
+    # temperature=0.7. PROMPT_VERSION v0.2 fix.
+    asset_pool: list[str] = sorted(valid_asset_ids)
+    if not asset_pool:
+        log.error("no valid asset IDs available; cannot pin asset_id in prompts")
+        return 1
+
     for family in families:
         family_spec = family_matrix[family]
         for i in range(args.n):
             scenario_id = f"SGT-GEN-{next_id:03d}"
             prompt_label = f"{family}_{scenario_id}"
-            prompt = build_prompt(family, family_spec, op_contexts, support, rng)
+            # Walk asset_pool by scenario index (next_id-1) modulo pool size.
+            # Across an N-scenario batch this gives N different assets when
+            # N <= 20; wraps cleanly for larger batches.
+            assigned_asset = asset_pool[(next_id - 1) % len(asset_pool)]
+            prompt = build_prompt(
+                family,
+                family_spec,
+                op_contexts,
+                support,
+                rng,
+                asset_id=assigned_asset,
+            )
             (out_dir / "prompts" / f"{prompt_label}.txt").write_text(
                 prompt, encoding="utf-8"
             )

--- a/scripts/generate_scenarios.py
+++ b/scripts/generate_scenarios.py
@@ -219,7 +219,7 @@ NO-HINT RULES — banned in the user-facing `text` field:
   fault. (Added v0.2 after SGT-GEN-005 violated this in the v0.1 batch.)
 - Pre-framed decisions ("you should create a work order")
 - Step-by-step instructions
-- Paraphrases of any of the 10 hand-crafted scenarios under data/scenarios/
+- Paraphrases of any canonical hand-crafted scenario under data/scenarios/
 
 PREFERRED:
 - Describe an operational event or condition naturally

--- a/tests/test_generate_scenarios_prompt.py
+++ b/tests/test_generate_scenarios_prompt.py
@@ -1,0 +1,280 @@
+"""Unit tests for scripts/generate_scenarios.py prompt assembly (#68 v0.2).
+
+Focused on the v0.1 → v0.2 prompt-template changes that landed for the PR
+#178 inspection-only batch's findings:
+
+  - asset_id pinning (`build_prompt(..., asset_id="T-NNN")` injects an
+    ASSIGNED ASSET section the model must use exactly)
+  - NO_HINT_RULES expansion (gas-name ban added)
+  - CONSISTENCY_CONSTRAINTS injection (text↔ground_truth + tool callability)
+  - PROMPT_VERSION bumped to v0.2
+
+Pure prompt-string inspection — no LLM call, no MCP runtime. The prompt
+template is the contract; these tests assert it stays a contract.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@pytest.fixture
+def support():
+    """Real support data so route + template selection match production."""
+    from scripts import generate_scenarios
+
+    return generate_scenarios._load_json(generate_scenarios.SUPPORT_PATH)
+
+
+@pytest.fixture
+def family_spec(support):
+    return support["scenario_family_matrix"]["families"]["FMSR_DGA_DIAGNOSIS"]
+
+
+@pytest.fixture
+def op_contexts(support):
+    return support["operational_context_profiles"]["profiles"]
+
+
+def _rng(seed=42):
+    import random
+
+    return random.Random(seed)
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_VERSION
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_version_is_v0_2():
+    """The version pinned in provenance must reflect the v0.2 prompt set."""
+    from scripts import generate_scenarios
+
+    assert generate_scenarios.PROMPT_VERSION == "v0.2"
+
+
+# ---------------------------------------------------------------------------
+# Asset pinning (v0.2 fix for "all five used T-005" in the v0.1 batch)
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_pins_asset_id(family_spec, op_contexts, support):
+    """An explicit asset_id must appear in the rendered prompt verbatim."""
+    from scripts.generate_scenarios import build_prompt
+
+    prompt = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-013",
+    )
+    assert "ASSIGNED ASSET: T-013" in prompt
+    assert "MUST use exactly this asset_id" in prompt
+
+
+def test_build_prompt_omits_asset_section_when_unset(family_spec, op_contexts, support):
+    """Backward-compat: if no asset_id is passed, the ASSIGNED-ASSET injection
+    block is omitted entirely. (The CONSISTENCY_CONSTRAINTS body still mentions
+    'ASSIGNED ASSET below' as a forward-reference, so we look for the actual
+    injected pattern `ASSIGNED ASSET: T-NNN` rather than the substring alone.)"""
+    import re
+
+    from scripts.generate_scenarios import build_prompt
+
+    prompt = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id=None,
+    )
+    # The injected section always has the literal `ASSIGNED ASSET: T-NNN` line.
+    # Without an asset, that line must NOT appear.
+    assert not re.search(r"ASSIGNED ASSET:\s*T-\d{3}", prompt)
+    # And the imperative line that only appears in the injection.
+    assert "MUST use exactly this asset_id" not in prompt
+
+
+def test_build_prompt_asset_id_is_pinned_per_call(family_spec, op_contexts, support):
+    """Different asset_ids produce different ASSIGNED ASSET sections."""
+    from scripts.generate_scenarios import build_prompt
+
+    p1 = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-001",
+    )
+    p2 = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-002",
+    )
+    assert "ASSIGNED ASSET: T-001" in p1
+    assert "ASSIGNED ASSET: T-002" in p2
+    assert "ASSIGNED ASSET: T-001" not in p2
+
+
+# ---------------------------------------------------------------------------
+# NO_HINT_RULES expansion: gas-name ban
+# ---------------------------------------------------------------------------
+
+
+def test_no_hint_rules_ban_gas_names_by_formula_and_common_name(
+    family_spec, op_contexts, support
+):
+    """The prompt must explicitly ban naming gases (per PR #178 SGT-GEN-005)."""
+    from scripts.generate_scenarios import build_prompt
+
+    prompt = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-001",
+    )
+    # The ban appears in NO_HINT_RULES.
+    assert "Names of dissolved gases" in prompt
+    # Both representations are explicitly named so the model can't argue
+    # the formula vs common-name path is allowed.
+    for token in (
+        "H2",
+        "hydrogen",
+        "CH4",
+        "methane",
+        "C2H2",
+        "acetylene",
+        "C2H4",
+        "ethylene",
+    ):
+        assert token in prompt, f"expected gas token {token!r} in NO_HINT_RULES ban"
+
+
+# ---------------------------------------------------------------------------
+# CONSISTENCY_CONSTRAINTS injection
+# ---------------------------------------------------------------------------
+
+
+def test_consistency_constraints_injected(family_spec, op_contexts, support):
+    """The 3-rule CONSISTENCY CONSTRAINTS section must appear in every prompt."""
+    from scripts.generate_scenarios import build_prompt
+
+    prompt = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-001",
+    )
+    assert "CONSISTENCY CONSTRAINTS" in prompt
+    # Rule 1: text ↔ ground_truth
+    assert "TEXT EVIDENCE" in prompt
+    assert "ground_truth.final_value" in prompt
+    # Rule 2: tool callability + concrete tool examples
+    assert "EXPECTED_TOOLS CALLABILITY" in prompt
+    assert "iot.get_sensor_readings" in prompt
+    assert "fmsr.analyze_dga" in prompt
+    assert "wo.estimate_downtime" in prompt
+    assert "wo.create_work_order" in prompt
+    # Rule 3: asset id usage
+    assert "ASSET ID is supplied to you" in prompt
+
+
+def test_consistency_block_appears_before_schema_reminder(
+    family_spec, op_contexts, support
+):
+    """Order matters: model should read constraints before the schema."""
+    from scripts.generate_scenarios import build_prompt
+
+    prompt = build_prompt(
+        "FMSR_DGA_DIAGNOSIS",
+        family_spec,
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-001",
+    )
+    consistency_idx = prompt.index("CONSISTENCY CONSTRAINTS")
+    schema_idx = prompt.index("OUTPUT FORMAT")
+    assert consistency_idx < schema_idx
+
+
+# ---------------------------------------------------------------------------
+# Asset rotation order (the algorithm main() uses)
+# ---------------------------------------------------------------------------
+
+
+def test_asset_rotation_walks_pool_modulo_size():
+    """`asset_pool[(next_id - 1) % len(asset_pool)]` produces N distinct
+    assets for N <= 20 then wraps. This is the rotation algorithm in main().
+    """
+    asset_pool = sorted(f"T-{i:03d}" for i in range(1, 21))
+    assert len(asset_pool) == 20
+
+    # First 5 scenarios get 5 different assets.
+    picks = [asset_pool[(next_id - 1) % len(asset_pool)] for next_id in range(1, 6)]
+    assert picks == ["T-001", "T-002", "T-003", "T-004", "T-005"]
+    assert len(set(picks)) == 5  # no v0.1 collapse onto T-005
+
+    # Wrap at 21.
+    pick_21 = asset_pool[(21 - 1) % len(asset_pool)]
+    assert pick_21 == "T-001"
+
+
+# ---------------------------------------------------------------------------
+# v0.2 prompt is non-trivially larger than v0.1 (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_v0_2_prompt_includes_all_required_sections(family_spec, op_contexts, support):
+    """A spot-check that the v0.2 prompt has every section we promised in
+    PROMPT_VERSION's changelog comment."""
+    from scripts.generate_scenarios import build_prompt
+
+    prompt = build_prompt(
+        "MULTI_DOMAIN_INCIDENT",
+        support["scenario_family_matrix"]["families"]["MULTI_DOMAIN_INCIDENT"],
+        op_contexts,
+        support,
+        _rng(),
+        asset_id="T-007",
+    )
+    required_section_markers = [
+        "FAMILY: MULTI_DOMAIN_INCIDENT",
+        "FAMILY SPEC:",
+        "OPERATIONAL CONTEXT",
+        # Multi-domain pulls all three template families.
+        "EVENT/ALARM TEMPLATE",
+        "DGA TREND TEMPLATE",
+        "WORK-ORDER PLAYBOOK ENTRY",
+        # v0.2 additions.
+        "ASSIGNED ASSET: T-007",
+        "NO-HINT RULES",
+        "Names of dissolved gases",
+        "CONSISTENCY CONSTRAINTS",
+        "TEXT EVIDENCE",
+        "EXPECTED_TOOLS CALLABILITY",
+        # Schema reminder closes the prompt.
+        "OUTPUT FORMAT",
+    ]
+    for marker in required_section_markers:
+        assert marker in prompt, f"missing prompt section marker: {marker!r}"


### PR DESCRIPTION
## Summary

PS B generator prompt iteration from `v0.1` → `v0.2`. Addresses 4 of 5 prompt-iteration items from the inspection-only batch's README in PR #178; the 5th (data-grounding) remains deferred since it requires generation-time MCP runtime access.

This is **prompt-side only** — no MCP runtime calls, no batch regeneration. The next batch generated with this branch will use v0.2 prompts and stamp `provenance.generator_prompt_version: v0.2`.

## Changes

### 1. Asset rotation (fixes "all five used T-005")

`scripts/generate_scenarios.py:main()` now walks `valid_asset_ids` deterministically by scenario index:

```python
asset_pool = sorted(valid_asset_ids)        # T-001..T-020
assigned_asset = asset_pool[(next_id - 1) % len(asset_pool)]
```

For N ≤ 20 scenarios this gives N distinct assets. Caller passes the rotated `asset_id` explicitly to `build_prompt()`; the prompt now contains an `ASSIGNED ASSET: T-NNN` section + an imperative line ("you MUST use exactly this asset_id"). The v0.1 RNG was independently picking per family at temperature=0.7, which collapsed every scenario to T-005.

Live dry-run of all 5 families with `--seed 42` produces:

```
SGT-GEN-001 → T-001
SGT-GEN-002 → T-002
SGT-GEN-003 → T-003
SGT-GEN-004 → T-004
SGT-GEN-005 → T-005
```

Five distinct assets, deterministic, reproducible.

### 2. Gas-name no-hint ban (fixes SGT-GEN-005 borderline finding)

`NO_HINT_RULES` now explicitly bans naming dissolved gases by either chemical formula (H2, CH4, C2H2, C2H4, C2H6, CO, CO2) OR common name (hydrogen, methane, acetylene, ethylene, ethane). Naming WHICH gases are rising is a closet-form fault-class hint — v0.1's SGT-GEN-005 said "rising methane and ethylene" (CH4+C2H4 → thermal pattern T1-T3) and contradicted its own `ground_truth.fault_code: D2`.

Suggests a generic phrasing like "recent dissolved-gas analysis shows elevated activity" or "DGA values are within normal range."

### 3. CONSISTENCY_CONSTRAINTS section (fixes SGT-GEN-001 / 002 / 003 / 005)

New 3-rule block inserted between `NO_HINT_RULES` and `SCHEMA_REMINDER`:

1. **Text evidence ↔ ground_truth.final_value consistency.** Pick the answer first, then write text consistent with that answer. If labeled fault is D2 (arc discharge), the text can't describe a thermal pattern; if `rul_estimate_days=540`, any range mentioned must contain 540.

2. **`expected_tools` callability from prompt context.** Every tool's required arguments must be derivable from the text, OR a discovery tool must precede it in `ideal_tool_sequence`. Concrete examples for `iot.get_sensor_readings` (needs `sensor_id`), `fmsr.analyze_dga` (needs all 5 gases), `wo.estimate_downtime` (needs `severity`), `wo.create_work_order` (needs fault context).

3. **Asset id is supplied to you** (see ASSIGNED ASSET); use exactly that value, do not vary across the scenario.

## What's NOT in v0.2 (deferred)

**Item 2 from the PR #178 README — data-grounding `ground_truth.decisive_intermediate_values` + `final_value` against actual MCP tool outputs.** The model has no way to know what `get_dga_record('T-NNN')` actually returns at generation time, so those fields remain model-asserted in v0.2 batches.

The right structural fix is one of:
- **Prompt-time MCP tool calls** — generator runs the tools first, inlines actual outputs into the prompt
- **Post-generation grounding pass** — generator emits scenarios as today, then a second pass calls the tools and overwrites `decisive_intermediate_values` + `final_value`

Both are bigger lifts than v0.2 prompt-side work. Tracked in the `PROMPT_VERSION` changelog comment for the next iteration.

## Tests

`tests/test_generate_scenarios_prompt.py` (NEW, 9 tests):

- `PROMPT_VERSION` pinned to `v0.2`
- `build_prompt` asset_id pinning (presence + uniqueness + omission backward-compat)
- `NO_HINT_RULES` gas-name ban (both formula and common name representations)
- `CONSISTENCY_CONSTRAINTS` injection + ordering before `SCHEMA_REMINDER`
- Asset rotation algorithm correctness (5 distinct for N=5, wraps at 21)
- Multi-domain end-to-end section markers (regression guard for all v0.2 sections)

```
python -m pytest tests/test_generate_scenarios_prompt.py -q  -> 9 passed
python -m pytest tests/ -q                                   -> 226 passed
  (1 deselected = pre-existing uv-binary flake on test_aat_tools_direct,
   unrelated to this PR)
python -m black --check (2 files)                            -> clean
```

## When to fire the next live batch

- After #53 validation rubric is applied to the v0.1 inspection-only batch (PR #178), so we know whether v0.2's prompt fixes target the right things
- And/or after this PR merges so v0.2 is on `main`
- Then: `--batch-id second_review_$(date +%Y%m%d)` with `--seed 42` for reproducibility

The next batch should pass #53 rubric for items 1+3+4+5 from the PR #178 README. Item 2 (data-grounded ground truth) will still be model-asserted until a separate grounding-pass PR lands.

## Closes / Linked

- Refs #68; issue remains intentionally open pending the stable generated batch (Akshat #53 validation accepted, plausible final 50+ scenario target). This PR is one of several iterations toward that closure point.
- Builds on: PR #147 (generator scaffold), PR #178 (inspection-only first batch + audit findings).
- Pairs with: PR #177 (`WATSONX_*` → `WX_*` env alias) — needed for the live re-run path to work end-to-end on Insomnia/GCP.
