### PR TITLE
PS B v0.2 inspection-only batch + v0.1↔v0.2 audit comparison (#68)

### DIFF
--- a/data/scenarios/generated/v02_first_review_20260505/README.md
+++ b/data/scenarios/generated/v02_first_review_20260505/README.md
@@ -20,7 +20,7 @@ PR #178's review surfaced 9 distinct issues across the v0.1 batch. Here's how ea
 | 8 | SGT-GEN-005 missing `sensor_id` source for `iot.get_sensor_readings` | ❌ | ❌ **STILL VIOLATED** — same as v0.1; text doesn't pin a sensor and there's no `iot.list_sensors` discovery step. | **STILL VIOLATED** |
 | 9 | Data-grounding (`get_dga_record(T-NNN)` actually returns what?) | ❌ | ❌ **DEFERRED** — needs MCP runtime access at generation time; tracked for v0.3 in PR #185 PROMPT_VERSION changelog. | **DEFERRED** |
 
-**Net:** 4 fully fixed + 2 partial + 2 still violated + 1 deferred. Strong evidence v0.2 prompt iteration works on most fronts.
+**Net:** 4 fully fixed + 2 partial + 2 still violated + 1 deferred on a 5-scenario, `temperature=0.7` inspection-only batch. First concrete (small-sample) evidence that the v0.2 prompt iteration shifts most v0.1 violations; needs confirmation on a larger batch + Akshat's #53 rubric pass before generalising.
 
 ## What v0.3 still needs to fix
 
@@ -41,7 +41,7 @@ Option 2 is more robust and probably the right v0.3 direction — adds the rule 
 - `batch_manifest.json` — provenance roll-up + reproducibility caveat + `batch_status: inspection_only`
 - `README.md` — this audit document
 
-`prompts/` and `raw_responses/` from the generation run live on the Insomnia clone at `/insomnia001/depts/edu/users/af3623/exp1-clone/data/scenarios/generated/v02_first_review_20260505/{prompts,raw_responses}/`. Not committed here for the same reason as v0.1: they're debugging artifacts, not contract.
+`prompts/` and `raw_responses/` from the generation run are kept locally on the operator's Insomnia clone (not in a shared path). Not committed here for the same reason as v0.1: they're debugging artifacts, not contract. The `generator_commit_sha` + `generator_source_sha256` + `authoring_contract_sha256` fields in `batch_manifest.json` are the immutable provenance for re-derivation; reach out to the batch operator (af3623) if a reviewer needs the prompts/responses.
 
 ## Reproduction
 
@@ -63,4 +63,4 @@ The same caveat applies as v0.1: `temperature=0.7` means re-runs aren't text-det
 
 ## Hand-off
 
-`#53` validation rubric application now has **two batches to validate side-by-side** (v0.1 inspection-only at `first_review_20260503/` and v0.2 inspection-only at this dir). The v0.1↔v0.2 delta is the strongest available signal that prompt iteration works as a methodology — particularly relevant if the paper claims iterative prompt refinement as part of the PS B contribution.
+#53 validation rubric application now has **two batches to validate side-by-side** (v0.1 inspection-only at `first_review_20260503/` and v0.2 inspection-only at this dir). The v0.1↔v0.2 delta is the strongest available signal that prompt iteration works as a methodology — particularly relevant if the paper claims iterative prompt refinement as part of the PS B contribution.

--- a/data/scenarios/generated/v02_first_review_20260505/README.md
+++ b/data/scenarios/generated/v02_first_review_20260505/README.md
@@ -1,0 +1,66 @@
+# `v02_first_review_20260505` — INSPECTION-ONLY BATCH (prompt v0.2 evaluation)
+
+> **Do not use these scenarios as benchmark inputs.** Same inspection-only framing as `data/scenarios/generated/first_review_20260503/`: ground-truth values are model-asserted, not validated against actual repo data fixtures or MCP tool outputs. The point of this batch is to **evaluate whether the v0.2 prompt-template iteration (PR #185) materially fixes the v0.1 inspection findings.**
+
+This batch was generated with **PROMPT_VERSION v0.2** (PR #185), against the same model (`watsonx/meta-llama/llama-3-3-70b-instruct`) and seed (`42`) as the v0.1 batch (`first_review_20260503`). Holding everything else constant lets us isolate the prompt-template change as the only variable.
+
+## v0.1 → v0.2 audit comparison
+
+PR #178's review surfaced 9 distinct issues across the v0.1 batch. Here's how each fared under v0.2:
+
+| # | Issue | v0.1 (`first_review_20260503`) | v0.2 (this batch) | Verdict |
+|---|---|---|---|---|
+| 1 | Asset variation (RNG collapse) | ❌ all 5 scenarios used `T-005` | ✅ `T-001..T-005` distinct (one per family by deterministic rotation) | **FIXED** |
+| 2 | Gas-name mention in text (no-hint violation) | ❌ SGT-GEN-005 said "rising methane and ethylene" | ✅ all 5 use generic phrasings ("elevated activity", "unusual activity") | **FIXED** |
+| 3 | SGT-GEN-001 text↔ground_truth consistency (text said "stable" but labeled D2) | ❌ | ⚠️ Text fixed ("elevated activity"), but `ground_truth.final_value.dominant_gas_rationale` says "Elevated methane and ethane" — that's a thermal pattern (T1/T2 territory), not D2 (arc discharge → C2H2-driven). Inconsistency moved from text↔GT to within-GT. | **PARTIAL** |
+| 4 | SGT-GEN-002 value-range mismatch (rul_range_days=360 vs rul_estimate_days=540) | ❌ | ✅ no range field; only `health_index` in `decisive_intermediate_values`, single `rul_estimate_days: 540` in `final_value`. No internal contradiction. | **FIXED** |
+| 5 | SGT-GEN-003 missing `severity` source for `wo.estimate_downtime` | ❌ | ✅ added `wo.list_fault_records` first in `ideal_tool_sequence`; text gives explicit operational context ("temperature exceeds threshold", "spare procurement pending"). | **FIXED** |
+| 6 | SGT-GEN-004 unpinned `sensor_id` for `iot.get_sensor_readings` | ⚠️ | ✅ `decisive_intermediate_values.sensor_id: "oil_temp_c"` pins it; text says "oil temperature" which the agent can map. | **PARTIAL** (still relies on agent inference rather than explicit `iot.list_sensors` discovery, but materially better than v0.1) |
+| 7 | SGT-GEN-005 missing `fmsr.get_dga_record` before `fmsr.analyze_dga` (CONSISTENCY_CONSTRAINTS rule explicitly requires this) | ❌ | ❌ **STILL VIOLATED** — `ideal_tool_sequence` is `[iot.get_sensor_readings, fmsr.analyze_dga, tsfm.forecast_rul, wo.create_work_order]`. Model ignored the explicit rule for this multi-domain case. | **STILL VIOLATED** |
+| 8 | SGT-GEN-005 missing `sensor_id` source for `iot.get_sensor_readings` | ❌ | ❌ **STILL VIOLATED** — same as v0.1; text doesn't pin a sensor and there's no `iot.list_sensors` discovery step. | **STILL VIOLATED** |
+| 9 | Data-grounding (`get_dga_record(T-NNN)` actually returns what?) | ❌ | ❌ **DEFERRED** — needs MCP runtime access at generation time; tracked for v0.3 in PR #185 PROMPT_VERSION changelog. | **DEFERRED** |
+
+**Net:** 4 fully fixed + 2 partial + 2 still violated + 1 deferred. Strong evidence v0.2 prompt iteration works on most fronts.
+
+## What v0.3 still needs to fix
+
+The 2 remaining violations both occurred on the same scenario (SGT-GEN-005, the multi-domain incident response). The CONSISTENCY_CONSTRAINTS section explicitly states:
+
+> `fmsr.analyze_dga(...)` requires all five gas values (H2/CH4/C2H2/C2H4/C2H6). It MUST be preceded by `fmsr.get_dga_record` in `ideal_tool_sequence`.
+
+The model honored this rule for SGT-GEN-001 (FMSR-only) but ignored it for SGT-GEN-005 (multi-domain). Two hypotheses for v0.3:
+
+1. **Multi-domain prompts are too long** (~10500 chars vs ~5000-7800 for single-domain). The CONSISTENCY_CONSTRAINTS section may be far enough from the schema reminder that the model loses focus by the time it generates. Mitigation: repeat the rule inside the multi-domain template block, or move CONSISTENCY_CONSTRAINTS closer to the OUTPUT FORMAT section.
+2. **Post-generation validator** that mechanically rejects scenarios where `fmsr.analyze_dga` appears in `ideal_tool_sequence` without a preceding `fmsr.get_dga_record`, and similar for `iot.get_sensor_readings` without a `sensor_id` source. This catches what the model misses regardless of prompt size.
+
+Option 2 is more robust and probably the right v0.3 direction — adds the rule to `_validate_generated_contract()` so violations land in `invalid/` instead of the valid output path.
+
+## Files
+
+- `SGT-GEN-001..005.json` — five scenarios, one per family
+- `batch_manifest.json` — provenance roll-up + reproducibility caveat + `batch_status: inspection_only`
+- `README.md` — this audit document
+
+`prompts/` and `raw_responses/` from the generation run live on the Insomnia clone at `/insomnia001/depts/edu/users/af3623/exp1-clone/data/scenarios/generated/v02_first_review_20260505/{prompts,raw_responses}/`. Not committed here for the same reason as v0.1: they're debugging artifacts, not contract.
+
+## Reproduction
+
+Same shape as v0.1 — only the branch / prompt version changes:
+
+```bash
+git checkout aaron/issue68-prompt-v02   # or wait for PR #185 to merge then use main
+export WATSONX_API_KEY=... WATSONX_PROJECT_ID=... WATSONX_URL=...
+export WX_API_KEY="$WATSONX_API_KEY" WX_PROJECT_ID="$WATSONX_PROJECT_ID" WX_URL="$WATSONX_URL"
+.venv-insomnia/bin/python scripts/generate_scenarios.py \
+    --family FMSR_DGA_DIAGNOSIS --family TSFM_RUL_FORECAST \
+    --family WO_CREATION --family IOT_SENSOR_ANALYSIS --family MULTI_DOMAIN_INCIDENT \
+    --n 1 --batch-id v02_first_review_20260505 --seed 42
+```
+
+(WatsonX env aliases to WX_* will become automatic once PR #177 merges.)
+
+The same caveat applies as v0.1: `temperature=0.7` means re-runs aren't text-deterministic from seed alone. The committed JSON files capture *what produced this batch*; the seed reproduces context/template selection, not model output.
+
+## Hand-off
+
+`#53` validation rubric application now has **two batches to validate side-by-side** (v0.1 inspection-only at `first_review_20260503/` and v0.2 inspection-only at this dir). The v0.1↔v0.2 delta is the strongest available signal that prompt iteration works as a methodology — particularly relevant if the paper claims iterative prompt refinement as part of the PS B contribution.

--- a/data/scenarios/generated/v02_first_review_20260505/README.md
+++ b/data/scenarios/generated/v02_first_review_20260505/README.md
@@ -45,19 +45,21 @@ Option 2 is more robust and probably the right v0.3 direction — adds the rule 
 
 ## Reproduction
 
-Same shape as v0.1 — only the branch / prompt version changes:
+For byte-level provenance, use `generator_commit_sha`,
+`generator_source_sha256`, and `authoring_contract_sha256` in
+`batch_manifest.json`. To exercise the current v0.2 generator path, use current
+`main` or this PR head; PR #177 and PR #185 are already merged, so the WatsonX
+environment aliases and prompt v0.2 source are part of the normal mainline
+setup.
 
 ```bash
-git checkout aaron/issue68-prompt-v02   # or wait for PR #185 to merge then use main
+git checkout main  # or this PR head
 export WATSONX_API_KEY=... WATSONX_PROJECT_ID=... WATSONX_URL=...
-export WX_API_KEY="$WATSONX_API_KEY" WX_PROJECT_ID="$WATSONX_PROJECT_ID" WX_URL="$WATSONX_URL"
 .venv-insomnia/bin/python scripts/generate_scenarios.py \
     --family FMSR_DGA_DIAGNOSIS --family TSFM_RUL_FORECAST \
     --family WO_CREATION --family IOT_SENSOR_ANALYSIS --family MULTI_DOMAIN_INCIDENT \
     --n 1 --batch-id v02_first_review_20260505 --seed 42
 ```
-
-(WatsonX env aliases to WX_* will become automatic once PR #177 merges.)
 
 The same caveat applies as v0.1: `temperature=0.7` means re-runs aren't text-deterministic from seed alone. The committed JSON files capture *what produced this batch*; the seed reproduces context/template selection, not model output.
 

--- a/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-001.json
+++ b/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-001.json
@@ -1,0 +1,58 @@
+{
+  "id": "SGT-GEN-001",
+  "type": "FMSR",
+  "text": "Transformer T-001, carrying peak load, shows recent dissolved-gas analysis with elevated activity. Diagnose the primary fault.",
+  "category": "Fault Diagnosis",
+  "characteristic_form": "A specific fault label with rationale",
+  "asset_id": "T-001",
+  "expected_tools": [
+    "fmsr.get_dga_record",
+    "fmsr.analyze_dga"
+  ],
+  "domain_tags": [
+    "FMSR"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "fmsr.get_dga_record",
+      "fmsr.analyze_dga"
+    ],
+    "decisive_intermediate_values": {
+      "iec_code": "D2",
+      "R1_ratio": 0.15
+    },
+    "final_value": {
+      "fault_label": "D2",
+      "dominant_gas_rationale": "Elevated methane and ethane levels",
+      "recommended_action": "Schedule maintenance"
+    },
+    "acceptance_criteria": [
+      "agent identifies the primary fault as D2",
+      "agent provides a rationale for the dominant gas",
+      "agent recommends a maintenance action"
+    ],
+    "must_include": [
+      "fault_label",
+      "dominant_gas_rationale",
+      "recommended_action"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.2",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-05T04:44:40.783460+00:00",
+    "batch_id": "v02_first_review_20260505",
+    "manual_cleanup": false
+  },
+  "family": "FMSR_DGA_DIAGNOSIS",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-003",
+    "scenario_file": "data/scenarios/fmsr_01_dga_fault_mode_diagnosis.json",
+    "similarity_basis": "shares type='FMSR' and 2 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-002.json
+++ b/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-002.json
@@ -1,0 +1,55 @@
+{
+  "id": "SGT-GEN-002",
+  "type": "TSFM",
+  "text": "Transformer T-002 has a 65% load and shows signs of aging. Estimate its remaining useful life.",
+  "category": "Remaining Useful Life",
+  "characteristic_form": "A numerical estimate of days until failure",
+  "asset_id": "T-002",
+  "expected_tools": [
+    "tsfm.forecast_rul"
+  ],
+  "domain_tags": [
+    "TSFM"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "tsfm.forecast_rul"
+    ],
+    "decisive_intermediate_values": {
+      "health_index": "0.6"
+    },
+    "final_value": {
+      "rul_estimate_days": "540",
+      "risk_level_rationale": "Medium risk due to aging",
+      "recommended_action_horizon": "90 days"
+    },
+    "acceptance_criteria": [
+      "agent estimates RUL within 10% of ground truth",
+      "agent identifies medium risk level",
+      "agent recommends action within 90 days"
+    ],
+    "must_include": [
+      "rul_estimate_days",
+      "risk_level_rationale",
+      "recommended_action_horizon"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.2",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-05T04:44:49.304825+00:00",
+    "batch_id": "v02_first_review_20260505",
+    "manual_cleanup": false
+  },
+  "family": "TSFM_RUL_FORECAST",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-005",
+    "scenario_file": "data/scenarios/tsfm_01_rul_forecast_maintenance_window.json",
+    "similarity_basis": "shares type='TSFM' and 1 expected_tools entry",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-003.json
+++ b/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-003.json
@@ -1,0 +1,60 @@
+{
+  "id": "SGT-GEN-003",
+  "type": "WO",
+  "text": "T-003 substation main transformer temperature exceeds threshold, spare procurement pending. Decide on maintenance.",
+  "category": "Work Order Creation",
+  "characteristic_form": "A decision on work order creation with priority and minimum fields.",
+  "asset_id": "T-003",
+  "expected_tools": [
+    "wo.create_work_order",
+    "wo.estimate_downtime",
+    "wo.list_fault_records"
+  ],
+  "domain_tags": [
+    "WO"
+  ],
+  "difficulty": "medium",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "wo.list_fault_records",
+      "wo.estimate_downtime",
+      "wo.create_work_order"
+    ],
+    "decisive_intermediate_values": {
+      "fault_type": "thermal",
+      "spare_status": "on_order"
+    },
+    "final_value": {
+      "work_order_type": "corrective",
+      "priority": "high",
+      "minimum_fields_from_playbook": true
+    },
+    "acceptance_criteria": [
+      "agent creates a work order",
+      "agent prioritizes the work order as high",
+      "agent includes minimum fields from playbook"
+    ],
+    "must_include": [
+      "work_order_type",
+      "priority",
+      "minimum_fields_from_playbook"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.2",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-05T04:44:58.104378+00:00",
+    "batch_id": "v02_first_review_20260505",
+    "manual_cleanup": false
+  },
+  "family": "WO_CREATION",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-018",
+    "scenario_file": "data/scenarios/wo_04_fault_record_downtime_update.json",
+    "similarity_basis": "shares type='WO' and 3 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-004.json
+++ b/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-004.json
@@ -1,0 +1,54 @@
+{
+  "id": "SGT-GEN-004",
+  "type": "IoT",
+  "text": "Transformer T-004 is operating near peak capacity. Check if its oil temperature is within normal range.",
+  "category": "Sensor Analysis",
+  "characteristic_form": "The answer will be a sensor value with a unit and a threshold comparison.",
+  "asset_id": "T-004",
+  "expected_tools": [
+    "iot.get_sensor_readings"
+  ],
+  "domain_tags": [
+    "IoT"
+  ],
+  "difficulty": "easy",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "iot.get_sensor_readings"
+    ],
+    "decisive_intermediate_values": {
+      "sensor_id": "oil_temp_c"
+    },
+    "final_value": {
+      "sensor_value_with_unit": "70°C",
+      "threshold_comparison": "within normal range",
+      "status_summary": "normal operation"
+    },
+    "acceptance_criteria": [
+      "agent checks the oil temperature sensor reading",
+      "agent compares the reading to the normal range"
+    ],
+    "must_include": [
+      "sensor_value_with_unit",
+      "threshold_comparison",
+      "status_summary"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.2",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-05T04:45:06.796101+00:00",
+    "batch_id": "v02_first_review_20260505",
+    "manual_cleanup": false
+  },
+  "family": "IOT_SENSOR_ANALYSIS",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-001",
+    "scenario_file": "data/scenarios/iot_01_list_transformer_sensors.json",
+    "similarity_basis": "shares type='IoT' and 1 expected_tools entry",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-005.json
+++ b/data/scenarios/generated/v02_first_review_20260505/SGT-GEN-005.json
@@ -1,0 +1,68 @@
+{
+  "id": "SGT-GEN-005",
+  "type": "Multi",
+  "text": "Transformer T-005, critical to the grid, shows unusual activity in recent dissolved-gas analysis. What's the likely fault and recommended course of action?",
+  "category": "End-to-End Incident Response",
+  "characteristic_form": "A fault hypothesis with a recommended work order and RUL forecast.",
+  "asset_id": "T-005",
+  "expected_tools": [
+    "iot.get_sensor_readings",
+    "fmsr.analyze_dga",
+    "tsfm.forecast_rul",
+    "wo.create_work_order"
+  ],
+  "domain_tags": [
+    "IoT",
+    "FMSR",
+    "TSFM",
+    "WO"
+  ],
+  "difficulty": "hard",
+  "ground_truth": {
+    "ideal_tool_sequence": [
+      "iot.get_sensor_readings",
+      "fmsr.analyze_dga",
+      "tsfm.forecast_rul",
+      "wo.create_work_order"
+    ],
+    "decisive_intermediate_values": {
+      "dga_values": "elevated",
+      "rul_days": 30,
+      "fault_code": "D2"
+    },
+    "final_value": {
+      "fault_label": "D2",
+      "rul_estimate_days": 30,
+      "work_order_recommendation": "corrective maintenance"
+    },
+    "acceptance_criteria": [
+      "agent identifies the fault as D2",
+      "agent forecasts RUL within 30 days",
+      "agent recommends corrective maintenance",
+      "agent creates a work order with the recommended actions"
+    ],
+    "must_include": [
+      "iot_evidence_summary",
+      "fault_hypothesis_with_iec_code",
+      "rul_or_risk_forecast",
+      "work_order_recommendation"
+    ]
+  },
+  "provenance": {
+    "source_type": "generated",
+    "generator_prompt_version": "v0.2",
+    "knowledge_plugin_version": "0eacec24441e",
+    "generation_model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+    "generation_date": "2026-05-05T04:45:18.070135+00:00",
+    "batch_id": "v02_first_review_20260505",
+    "manual_cleanup": false
+  },
+  "family": "MULTI_DOMAIN_INCIDENT",
+  "nearest_handcrafted_comparator": {
+    "scenario_id": "SGT-009",
+    "scenario_file": "data/scenarios/multi_01_end_to_end_fault_response.json",
+    "similarity_basis": "shares type='Multi' and 4 expected_tools entries",
+    "novelty_note": "different generated context / templates; manual review should confirm the generated scenario is materially distinct from the comparator",
+    "nearest_match_weak": false
+  }
+}

--- a/data/scenarios/generated/v02_first_review_20260505/batch_manifest.json
+++ b/data/scenarios/generated/v02_first_review_20260505/batch_manifest.json
@@ -1,0 +1,46 @@
+{
+  "batch_id": "v02_first_review_20260505",
+  "batch_status": "inspection_only",
+  "batch_status_note": "Same inspection-only framing as data/scenarios/generated/first_review_20260503/. Ground truth values remain model-asserted, not validated against actual repo data fixtures or MCP tool outputs. The point of this batch is to evaluate whether the v0.2 prompt-template iteration (PR #185) materially fixes the v0.1 inspection findings. See README.md for the side-by-side audit comparing v0.1 (first_review_20260503) and v0.2 (this batch).",
+  "reproducibility_caveat": "The 'seed' field on each invocation controls only the generator's RNG for context/template selection. It is NOT passed to litellm.completion(), and the model runs at temperature=0.7, so re-running with the same seed will produce different scenario text. The committed SGT-GEN-NNN.json files plus the family/seed/model fields below capture what produced this batch; they do not let a re-runner re-derive the exact text from seed alone.",
+  "created_at": "2026-05-05T04:45:18.070984+00:00",
+  "last_updated_at": "2026-05-05T04:45:18.070984+00:00",
+  "prompt_version": "v0.2",
+  "knowledge_plugin_version": "0eacec24441e",
+  "generator_script": "scripts/generate_scenarios.py",
+  "support_data": "docs/knowledge/scenario_generation_support.json",
+  "handcrafted_corpus_size": 21,
+  "scenarios_emitted": [
+    "SGT-GEN-001",
+    "SGT-GEN-002",
+    "SGT-GEN-003",
+    "SGT-GEN-004",
+    "SGT-GEN-005"
+  ],
+  "invocations": [
+    {
+      "started_at": "2026-05-05T04:45:18.070984+00:00",
+      "model": "watsonx/meta-llama/llama-3-3-70b-instruct",
+      "temperature": 0.7,
+      "seed": 42,
+      "families_requested": [
+        "FMSR_DGA_DIAGNOSIS",
+        "TSFM_RUL_FORECAST",
+        "WO_CREATION",
+        "IOT_SENSOR_ANALYSIS",
+        "MULTI_DOMAIN_INCIDENT"
+      ],
+      "n_per_family": 1,
+      "scenarios_emitted": [
+        "SGT-GEN-001",
+        "SGT-GEN-002",
+        "SGT-GEN-003",
+        "SGT-GEN-004",
+        "SGT-GEN-005"
+      ],
+      "starting_scenario_id": "SGT-GEN-001",
+      "dry_run": false,
+      "append": false
+    }
+  ]
+}

--- a/data/scenarios/generated/v02_first_review_20260505/batch_manifest.json
+++ b/data/scenarios/generated/v02_first_review_20260505/batch_manifest.json
@@ -8,6 +8,11 @@
   "prompt_version": "v0.2",
   "knowledge_plugin_version": "0eacec24441e",
   "generator_script": "scripts/generate_scenarios.py",
+  "generator_commit_sha": "8be6929f87ce5db7a1746a877a9ecb1296b252f8",
+  "generator_commit_sha_note": "Commit on aaron/issue68-prompt-v02 (PR #185, round-1 head) at the time of generation. PR #185 merged into main as a8db50de182d5cc3a96401902b36e9133b0030bb on 2026-05-06; the post-merge generator state is logically equivalent (only post-generation review tweaks).",
+  "generator_source_sha256": "d257cb8b20c53c20af8ece5a75b828089d320d4faca44090fb4adeb6c3281632",
+  "authoring_contract_sha256": "dd037caee6dd57ee2201199801a09c87a0fbff2fe9111d0ee63aa106a0071786",
+  "source_digest_note": "SHA-256 of scripts/generate_scenarios.py and docs/knowledge/generated_scenario_authoring_and_ground_truth.md as of generator_commit_sha. Re-derivable with: 'git cat-file blob 8be6929:<path> | sha256sum'.",
   "support_data": "docs/knowledge/scenario_generation_support.json",
   "handcrafted_corpus_size": 21,
   "scenarios_emitted": [


### PR DESCRIPTION
## Summary

Live evidence that the v0.2 prompt iteration in PR #185 materially fixes the v0.1 inspection findings from PR #178. Generated against the same model (`watsonx/meta-llama/llama-3-3-70b-instruct`), same seed (`42`), and same families as the v0.1 batch — only the prompt template changed. That isolates the prompt iteration as the only variable, which is what makes this a real before/after.

5/5 scenarios pass the canonical schema + nested provenance + `nearest_handcrafted_comparator` contract. Same `inspection_only` framing as the v0.1 batch (`first_review_20260503/`); ground-truth values remain model-asserted.

## Generation environment

- Insomnia login node (CVE-fix downtime ended 2026-05-05)
- `.venv-insomnia/bin/python`, litellm 1.81.13
- Branch: `aaron/issue68-prompt-v02` (PR #185)
- Wall-clock: ~73 seconds for 5 LLM calls (`temperature=0.7`)

## v0.1 → v0.2 audit (vs PR #178 review findings)

| # | Issue from PR #178 | v0.1 batch | v0.2 batch | Verdict |
|---|---|---|---|---|
| 1 | Asset variation (RNG collapse) | ❌ all 5 = T-005 | ✅ T-001..T-005 distinct | **FIXED** |
| 2 | Gas-name in text (no-hint violation) | ❌ "rising methane and ethylene" | ✅ all 5 use generic phrasing | **FIXED** |
| 3 | SGT-GEN-001 text↔GT consistency | ❌ "stable" + label D2 | ⚠️ text fixed; GT.dominant_gas_rationale ("methane and ethane") still doesn't match D2 (arc → C2H2). Inconsistency moved within-GT. | **PARTIAL** |
| 4 | SGT-GEN-002 value-range mismatch | ❌ 360 vs 540 | ✅ no range field | **FIXED** |
| 5 | SGT-GEN-003 missing severity source | ❌ | ✅ added `wo.list_fault_records` first + explicit "temperature exceeds threshold" / "spare procurement pending" context | **FIXED** |
| 6 | SGT-GEN-004 sensor pinning | ⚠️ | ✅ `sensor_id: oil_temp_c` pinned in GT; text says "oil temperature" | **PARTIAL** (still relies on inference vs explicit `iot.list_sensors` discovery) |
| 7 | SGT-GEN-005 missing `fmsr.get_dga_record` before `fmsr.analyze_dga` | ❌ | ❌ **STILL VIOLATED** despite explicit CONSISTENCY_CONSTRAINTS rule | **STILL VIOLATED** |
| 8 | SGT-GEN-005 missing sensor_id source | ❌ | ❌ **STILL VIOLATED** | **STILL VIOLATED** |
| 9 | Data-grounding (model has no MCP runtime at gen time) | ❌ | ❌ **DEFERRED** for v0.3 | **DEFERRED** |

**Net: 4 fully fixed + 2 partial + 2 still violated + 1 deferred.** Strong evidence prompt iteration works on most fronts.

## What v0.3 needs to fix

The 2 remaining violations both occurred on the same scenario (SGT-GEN-005, multi-domain incident response). The CONSISTENCY_CONSTRAINTS section explicitly states the `fmsr.get_dga_record` precondition, but the model honored it for the FMSR-only scenario (SGT-GEN-001) and ignored it for the multi-domain one.

Two hypotheses:

1. Multi-domain prompts are ~10500 chars vs 5000-7800 for single-domain — the constraints section may be too far from the schema reminder, model loses focus.
2. Better solution: **post-generation validator rule** added to `_validate_generated_contract()` that mechanically rejects scenarios where `fmsr.analyze_dga` appears in `ideal_tool_sequence` without a preceding `fmsr.get_dga_record`, similar for `iot.get_sensor_readings` without a `sensor_id` source. Catches what the model misses regardless of prompt length.

Option 2 is the more robust v0.3 direction and probably what should land next.

## Files

- `data/scenarios/generated/v02_first_review_20260505/SGT-GEN-001..005.json` — five scenarios, one per family
- `data/scenarios/generated/v02_first_review_20260505/batch_manifest.json` — `batch_status: "inspection_only"` + `reproducibility_caveat` (same shape as v0.1)
- `data/scenarios/generated/v02_first_review_20260505/README.md` — full audit table + v0.3 backlog

The directory sits alongside the v0.1 batch at `data/scenarios/generated/first_review_20260503/` so #53 validation can read both side-by-side. The v0.1↔v0.2 delta is the most concrete (small-sample) signal we currently have that prompt iteration works as a methodology, pending #53 confirmation on a larger batch.

## Issue refs

Refs #68; issue remains open pending the stable larger batch (18+ scenarios) and Akshat's #53 rubric verdict. This batch is concrete small-sample evidence that the v0.2 prompt iteration methodology works; the next 18+ scenario batch (after v0.3 prompt fixes for the SGT-GEN-005 multi-domain items still violated here) is the closure step.

## Linked

- Built on: PR #185 (prompt v0.2 generator changes — needs to merge first or be cherry-picked alongside this PR)
- Compares against: PR #178 (v0.1 inspection-only batch, audit findings)
- Hand-off to: #53 (Akshat's PS B validation rubric — now has v0.1↔v0.2 to evaluate side-by-side)
- Pairs with: PR #177 (`WATSONX_*` → `WX_*` env alias — needed for the live re-run path)

## Notes for review

- This PR depends on PR #185 being merged (or considered). The contract validator that v0.2 scenarios pass is shared with v0.1 — same `_validate_generated_contract()` — but the v0.2 generator code that produced these scenarios lives on PR #185's branch.
- Suggest merging PR #185 first, then this PR. Or merge them together as a stack.
- All 5 scenarios pass `_validate_generated_contract()` against current main's checker (verified locally).