### PR TITLE
Harden AAT batch scenario guardrails (#133, #66, #91)

### DIFF
--- a/docs/slurm_cheatsheet.md
+++ b/docs/slurm_cheatsheet.md
@@ -1,7 +1,7 @@
 # Slurm Cheatsheet
 
 *Created: 2026-04-12*  
-*Last updated: 2026-04-30*
+*Last updated: 2026-05-04*
 
 Quick command-first reference for common Slurm operations on Insomnia.
 Use this when you just want to submit a job, get an interactive GPU shell,
@@ -32,32 +32,46 @@ Two important realities on Insomnia:
   bursty login-node controller traffic; do not use sub-minute `squeue` /
   `sacct` polling or tight `watch` loops. Scope every query to a job ID or
   your user; never fall back to global `squeue` / `sacct`.
-- **Slurm log paths are resolved relative to the submit directory**
-  (`$SLURM_SUBMIT_DIR`), so submit from the repo root or use `--chdir=...`.
+- **Submit benchmark scripts from the intended repo root/worktree after loading
+  the Insomnia environment.** `scripts/run_experiment.sh` uses
+  `$SLURM_SUBMIT_DIR` as `REPO_ROOT`; on Insomnia, `sbatch --chdir=...` changes
+  the job working directory but does not make `$SLURM_SUBMIT_DIR` point there.
+  Use `cd <repo-root-or-worktree> && source .venv-insomnia/bin/activate &&
+  sbatch ...` for evidence runs.
 
 ## Submit a batch script
 
 Use this when you do not want to sit and wait for the allocation.
 
-From the repo root:
+From the canonical Insomnia checkout:
 
 ```bash
-cd <repo-root-or-worktree>
-sbatch scripts/vllm_serve.sh
+cd /insomnia001/depts/edu/users/team13/hpml-assetopsbench-smart-grid-mcp
+export PATH="$HOME/.local/bin:$PATH"
+source .venv-insomnia/bin/activate
+command -v uv
+sbatch scripts/run_experiment.sh configs/<cell>.env
 ```
 
-Or from anywhere, explicitly:
+From a sibling worktree, use the shared Insomnia venv and submit from inside the
+worktree so `$SLURM_SUBMIT_DIR` is correct:
 
 ```bash
-sbatch \
-  --chdir=<repo-root-or-worktree> \
-  scripts/vllm_serve.sh
+cd /insomnia001/depts/edu/users/team13/worktrees/<slug>
+export PATH="$HOME/.local/bin:$PATH"
+source ../../hpml-assetopsbench-smart-grid-mcp/.venv-insomnia/bin/activate
+command -v uv
+sbatch scripts/run_experiment.sh configs/<cell>.env
 ```
+
+Do not rely on `sbatch --chdir=<repo-root-or-worktree>` for
+`scripts/run_experiment.sh`; use it only for ad hoc scripts that do not derive
+repo paths from `$SLURM_SUBMIT_DIR`.
 
 Capture the job ID:
 
 ```bash
-JOBID=$(sbatch scripts/vllm_serve.sh | awk '{print $4}')
+JOBID=$(sbatch scripts/run_experiment.sh configs/<cell>.env | awk '{print $4}')
 echo "$JOBID"
 ```
 
@@ -67,7 +81,7 @@ With email notifications:
 sbatch \
   --mail-type=BEGIN,END,FAIL \
   --mail-user=<UNI>@columbia.edu \
-  scripts/vllm_serve.sh
+  scripts/run_experiment.sh configs/<cell>.env
 ```
 
 ## Run an ad hoc command when allocation starts

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -33,9 +33,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 import datetime as _dt
+import glob
 import json
 import logging
 import os
+import shlex
 import sys
 import time
 from dataclasses import dataclass, field
@@ -108,6 +110,33 @@ def _json_default(obj: Any) -> Any:
 
 # Importable without the SDK installed, so unit tests can patch before import.
 # Real imports happen lazily inside _main().
+
+
+def _expand_scenario_glob(scenario_glob: str, repo_root: Path) -> list[Path]:
+    """Expand one glob pattern or a shell-style list of scenario paths.
+
+    `run_experiment.sh` has long accepted `SCENARIOS_GLOB` values containing
+    either one glob or a whitespace-separated list of explicit paths. Cell C
+    passes that value through to this batch runner, so mirror the shell-level
+    behavior here instead of treating the whole string as one literal glob.
+    """
+    tokens = shlex.split(scenario_glob)
+    if not tokens:
+        tokens = [scenario_glob]
+
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for token in tokens:
+        pattern = Path(token)
+        if not pattern.is_absolute():
+            pattern = repo_root / pattern
+        for raw_match in sorted(glob.glob(str(pattern))):
+            match = Path(raw_match).resolve()
+            if match in seen:
+                continue
+            paths.append(match)
+            seen.add(match)
+    return paths
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -488,7 +517,7 @@ async def _main_multi(args: argparse.Namespace, repo_root: Path) -> int:
         output_dir = repo_root / output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    scenario_files = sorted(repo_root.glob(args.scenarios_glob))
+    scenario_files = _expand_scenario_glob(args.scenarios_glob, repo_root)
     if not scenario_files:
         _LOG.error("no scenario files matched --scenarios-glob %r", args.scenarios_glob)
         return 2

--- a/scripts/aat_runner.py
+++ b/scripts/aat_runner.py
@@ -120,9 +120,12 @@ def _expand_scenario_glob(scenario_glob: str, repo_root: Path) -> list[Path]:
     passes that value through to this batch runner, so mirror the shell-level
     behavior here instead of treating the whole string as one literal glob.
     """
+    if not scenario_glob.strip():
+        return []
+
     tokens = shlex.split(scenario_glob)
     if not tokens:
-        tokens = [scenario_glob]
+        return []
 
     paths: list[Path] = []
     seen: set[Path] = set()
@@ -131,11 +134,12 @@ def _expand_scenario_glob(scenario_glob: str, repo_root: Path) -> list[Path]:
         if not pattern.is_absolute():
             pattern = repo_root / pattern
         for raw_match in sorted(glob.glob(str(pattern))):
-            match = Path(raw_match).resolve()
-            if match in seen:
+            match = Path(raw_match)
+            key = match.resolve()
+            if key in seen:
                 continue
             paths.append(match)
-            seen.add(match)
+            seen.add(key)
     return paths
 
 

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -15,9 +15,10 @@
 # follow-on runners for Self-Ask PE and Verified PE. Runner templates remain
 # available as explicit escape hatches for parity or variant smoke checks.
 #
-# MUST be submitted from the repo root — `#SBATCH --output=logs/...` resolves
-# relative to $SLURM_SUBMIT_DIR. If you need to submit from elsewhere, add
-# `--chdir=/path/to/repo` to the sbatch invocation.
+# MUST be submitted from the intended repo root or worktree. This script uses
+# $SLURM_SUBMIT_DIR as REPO_ROOT; `sbatch --chdir=/path/to/repo` changes the
+# job's cwd but does not change $SLURM_SUBMIT_DIR on Insomnia, so it is not a
+# safe substitute for `cd /path/to/repo && sbatch ...`.
 #
 # Usage:
 #   sbatch scripts/run_experiment.sh configs/example_baseline.env

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -1166,6 +1166,7 @@ FAIL=0
 TOTAL=0
 RESUME_SKIPPED=0
 RESUME_RERUN=0
+INFRA_FAIL=0
 if [ "$SMARTGRID_RESUME" = "1" ] && [ "$SMARTGRID_FORCE_RERUN" != "1" ]; then
   touch "$LATENCY_FILE"
 else
@@ -1181,7 +1182,12 @@ if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ] && [ 
     exit 1
   fi
   EXPECTED_TOTAL=$(( ${#SCENARIO_FILES[@]} * TRIALS ))
-  run_agent_as_tool_batch "$RUN_DIR" || true
+  BATCH_RC=0
+  run_agent_as_tool_batch "$RUN_DIR" || BATCH_RC=$?
+  if [ "$BATCH_RC" -gt 1 ]; then
+    echo "ERROR: agent-as-tool batch runner failed with exit code $BATCH_RC" >&2
+    INFRA_FAIL=1
+  fi
   # Merge per-trial latency records into the canonical latencies.jsonl.
   if [ -f "$RUN_DIR/_batch_latencies.jsonl" ]; then
     cat "$RUN_DIR/_batch_latencies.jsonl" >>"$LATENCY_FILE"
@@ -1202,6 +1208,7 @@ if [ "$ORCHESTRATION" = "agent_as_tool" ] && [ "$MCP_MODE" = "optimized" ] && [ 
     echo "WARNING: $MISSING trial(s) missing from batch output — counting as failures" >&2
     FAIL=$(( FAIL + MISSING ))
     TOTAL=$(( TOTAL + MISSING ))
+    INFRA_FAIL=1
   fi
 else
 
@@ -1623,3 +1630,7 @@ echo "Failed:    $FAIL"
 echo "Config:    $CONFIG_FILE"
 echo "Summary:   $SUMMARY_FILE"
 echo "Raw dir:   $RUN_DIR"
+if [ "$INFRA_FAIL" -ne 0 ]; then
+  echo "Infrastructure failure detected; exiting nonzero."
+  exit "$INFRA_FAIL"
+fi

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -102,6 +102,25 @@ def test_expand_scenario_glob_accepts_single_bracket_glob(tmp_path: Path):
     assert [path.name for path in scenario_files] == [first.name, second.name]
 
 
+def test_expand_scenario_glob_empty_string_returns_no_paths(tmp_path: Path):
+    from scripts.aat_runner import _expand_scenario_glob
+
+    assert _expand_scenario_glob("", tmp_path) == []
+
+
+def test_expand_scenario_glob_deduplicates_overlapping_patterns(tmp_path: Path):
+    from scripts.aat_runner import _expand_scenario_glob
+
+    first = tmp_path / "multi_01_end_to_end_fault_response.json"
+    second = tmp_path / "multi_02_dga_to_workorder_pipeline.json"
+    first.write_text("{}", encoding="utf-8")
+    second.write_text("{}", encoding="utf-8")
+
+    scenario_files = _expand_scenario_glob(f"{first.name} multi_0[12]_*.json", tmp_path)
+
+    assert [path.name for path in scenario_files] == [first.name, second.name]
+
+
 def test_serialize_run_result_happy_path():
     from scripts.aat_runner import _serialize_run_result
 

--- a/tests/test_aat_runner.py
+++ b/tests/test_aat_runner.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -72,6 +73,33 @@ def _stub_run_result(
         max_turns_reached=max_turns_reached,
         raw_responses=[],
     )
+
+
+def test_expand_scenario_glob_accepts_shell_style_explicit_list(tmp_path: Path):
+    from scripts.aat_runner import _expand_scenario_glob
+
+    first = tmp_path / "multi_01_end_to_end_fault_response.json"
+    second = tmp_path / "multi_02_dga_to_workorder_pipeline.json"
+    first.write_text("{}", encoding="utf-8")
+    second.write_text("{}", encoding="utf-8")
+
+    scenario_files = _expand_scenario_glob(f"{first.name} {second.name}", tmp_path)
+
+    assert [path.name for path in scenario_files] == [first.name, second.name]
+
+
+def test_expand_scenario_glob_accepts_single_bracket_glob(tmp_path: Path):
+    from scripts.aat_runner import _expand_scenario_glob
+
+    first = tmp_path / "multi_01_end_to_end_fault_response.json"
+    second = tmp_path / "multi_02_dga_to_workorder_pipeline.json"
+    third = tmp_path / "multi_03_iot_tsfm_thermal_risk.json"
+    for path in (first, second, third):
+        path.write_text("{}", encoding="utf-8")
+
+    scenario_files = _expand_scenario_glob("multi_0[12]_*.json", tmp_path)
+
+    assert [path.name for path in scenario_files] == [first.name, second.name]
 
 
 def test_serialize_run_result_happy_path():

--- a/tests/test_runner_guardrails.py
+++ b/tests/test_runner_guardrails.py
@@ -28,6 +28,21 @@ def test_per_trial_aat_exports_mcp_server_environment() -> None:
     assert body.index(export_line) < body.index(invocation)
 
 
+def test_aat_batch_infrastructure_failures_are_not_masked() -> None:
+    script = Path("scripts/run_experiment.sh").read_text(encoding="utf-8")
+    body = _function_body(
+        script,
+        'if [ "$ORCHESTRATION" = "agent_as_tool" ]',
+        "else\n\nfor SCENARIO_FILE",
+    )
+
+    assert 'run_agent_as_tool_batch "$RUN_DIR" || true' not in body
+    assert "BATCH_RC=0" in body
+    assert "BATCH_RC=$?" in body
+    assert "INFRA_FAIL=1" in body
+    assert "Infrastructure failure detected; exiting nonzero." in script
+
+
 def test_gcp_batch_driver_hard_fails_incomplete_artifacts() -> None:
     script = Path("scripts/run_gcp_context_batch.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Harden AAT batch handling so explicit scenario lists from batch TSV rows are preserved instead of being misread as an empty expected-trials set.
- Preserve unresolved matched scenario paths while using resolved paths only for deduplication, matching prior `repo_root.glob` semantics for symlinked worktrees.
- Add regression coverage for AAT batch scenario parsing, empty-list handling, duplicate scenario matches, and runner guardrails.
- Document Insomnia batch-submit prerequisites that affected final evidence runs.

## Validation
- `/Users/wax/coding/hpml-assetopsbench-smart-grid-mcp/.venv/bin/python -m pytest -q tests/test_aat_runner.py tests/test_runner_guardrails.py tests/test_run_experiment_summary.py` — 41 passed.

Refs #133, #66, #91.
