### PR TITLE
docs(#42, #67): 1-page scenario+eval+judge content brief, refresh stale doc facts

### DIFF
--- a/data/scenarios/README.md
+++ b/data/scenarios/README.md
@@ -1,6 +1,6 @@
 # data/scenarios/
 
-*Last updated: 2026-04-21*
+*Last updated: 2026-05-06*
 
 Smart Grid transformer maintenance scenarios, following the AssetOpsBench scenario format. Each scenario is a multi-turn agentic task where an LLM agent must use the IoT / FMSR / TSFM / WO MCP tools to diagnose, forecast, or remediate a transformer fault.
 
@@ -26,8 +26,9 @@ See the upstream AssetOpsBench structure in `src/scenarios/local/vibration_utter
 
 ## Targets
 
-- **W2 (Apr 7-13):** 15+ validated scenarios (Akshat)
-- **W4 (Apr 21-27):** 30+ scenarios (Akshat + team) — stretch goal per mid-point report
+- **W2 (Apr 7-13):** 15+ validated scenarios (Akshat) — **met.** HPML #15 closed.
+- **W4 (Apr 21-27):** 30+ scenarios (Akshat + team) — stretch goal per mid-point report. **Met.** HPML #33 closed at 31 hand-authored scenarios.
+- **PS B promotion lane:** 5 generated scenarios queued for canonical promotion in PR #195 (`SGT-031..SGT-035`); validator goes 31+5 -> 36+5 on merge. See `data/scenarios/generated/README.md` for the disposition table.
 
 ## Conventions
 
@@ -50,6 +51,10 @@ This catches schema violations and negative-fixture regressions before you get t
 the heavier harness path. For the full harness workflow, see
 [../../docs/eval_harness_readme.md](../../docs/eval_harness_readme.md).
 
-## Status (Apr 7, 2026)
+## Status (2026-05-06)
 
-Scaffolding only. First batch of 5-10 scenarios owed by Akshat from Sun Apr 5 (delivery "tonight" per Apr 6 20:31 message); target 15+ by Apr 13.
+- **Canonical:** 31 hand-authored scenarios + 5 negative fixtures. Validator (`python data/scenarios/validate_scenarios.py`) reports `Validation passed for 31 scenario files and 5 negative fixtures.` Domain mix: FMSR 7, IoT 6, Multi 8, TSFM 4, WO 6.
+- **Generated (PS B):** 15 candidates across 3 batches under `data/scenarios/generated/`. PR #191 (merged) landed the disposition table at `data/scenarios/generated/disposition_2026-05-06.csv` — 5 `accept_with_edits`, 10 `reject_duplicate`, 0 `reject_unusable`, 0 `reject_structural`. Both methodology bars (≥70% accept-or-edits; <20% reject_dup) fail at 33% / 67%; the batch is not benchmark-ready as a whole.
+- **Promotion in flight:** PR #195 promotes the 5 `accept_with_edits` rows into canonical with bounded edits applied + provenance retained. Once merged, validator reports 36+5 and the corpus has both hand-authored and (clearly-flagged) generated-source records.
+- **Eval coverage (current evidence):** 2,420 paper-grade judge rows across the 31 canonical scenarios per `results/metrics/evidence_registry.csv`. Refresh against the 36-floor will follow the next paper-grade evidence pull.
+- **For the paper:** see `docs/content_brief_scenarios_eval.md` for the 1-page fact pack of safe-to-cite numbers.

--- a/docs/content_brief_scenarios_eval.md
+++ b/docs/content_brief_scenarios_eval.md
@@ -1,0 +1,72 @@
+# Content brief — Scenarios + Eval + Judge
+
+*Last updated: 2026-05-06. Owner: Akshat (issue #42). Audience: Alex, for the paper's scenarios + eval sections.*
+
+This is a 1-page fact pack. Numbers are reproducible from the artifacts cited in each bullet. Cross-checked against `evidence_registry.csv` (PR #188) and `scenario_scores.jsonl` on `team13/main@87a9b77` (post-PR191 disposition merge).
+
+## Scenarios
+
+- **Canonical corpus:** 31 hand-authored Smart Grid scenarios at `data/scenarios/*.json`. Validated by `python data/scenarios/validate_scenarios.py` (`Validation passed for 31 scenario files and 5 negative fixtures`). Closes HPML #15 (15+ floor) and HPML #33 (30+ stretch).
+- **Pending promotion:** PR #195 promotes 5 `accept_with_edits` generated rows into canonical (`SGT-031..SGT-035`). Validator passes 36+5 once #195 lands. Brief assumes pre-merge state of 31; bump to 36 on merge.
+- **Negative fixtures:** 5 at `data/scenarios/negative_checks/*.json` covering single-/multi-domain mismatches, missing-domain coverage, and unknown-tool rejection.
+- **Domain mix (current 31):** FMSR 7 (incl. 1 AOB-style), IoT 6, Multi 8, TSFM 4, WO 6.
+- **Asset universe:** T-001..T-020 (`data/processed/asset_metadata.csv`). All scenario `asset_id`s validate against this list.
+- **Tool universe:** 19 canonical MCP tools across IoT/FMSR/TSFM/WO domains, defined in `data/scenarios/validate_scenarios.py:CANONICAL_TOOLS`. Validator rejects unknown tools and cross-domain tool use in single-domain scenarios.
+
+## Generated scenarios (PS B)
+
+- **Three batches:** `data/scenarios/generated/{first_review_20260502, first_review_20260503, v02_first_review_20260505}/`. 5 SGT-GEN-* records each. Total **15 generated candidates** validated under the methodology in `docs/ps_b_evaluation_methodology.md`.
+- **Disposition outcome (PR #191, merged):** machine-readable table at `data/scenarios/generated/disposition_2026-05-06.csv`. **5 `accept_with_edits` / 10 `reject_duplicate` / 0 `reject_unusable` / 0 `reject_structural`.** Both methodology bars (≥70% accept-or-edits; <20% reject_duplicate) fail at 33% / 67%; no batch publishes as benchmark-ready, but the 5 `accept_with_edits` rows are bounded-edit candidates.
+- **Promotion path:** PR #195 ports the 5 with provenance retained (source path, disposition CSV reference, applied-edits list, and reviewer-selected comparator) under canonical names `fmsr_07`, `iot_07`, `iot_08`, `wo_07`, `iot_09`.
+- **#55 stretch (50+):** still short at 36 even after PR #195 — needs ≥14 hand-crafted companions or an explicit defer per the `post-class-defer` label.
+
+## Eval harness
+
+- **Orchestration paths:** `plan_execute`, `verified_pe`, `agent_as_tool`. Cell mapping per `evidence_registry.csv`:
+  - **Direct/MCP path** (Cells A/B/C/D + 70B variants) — Agent-as-Tool with direct or MCP calls.
+  - **PE family** (Y/YS/Z/ZS + Y/YS/Z/ZS-70B + ZSD + Y/YS/ZS-TP, follow-on/extra) — plan-execute + verified-PE + Self-Ask ablations.
+- **Models judged:** `openai/Llama-3.1-8B-Instruct` (1,835 paper-grade rows), `watsonx/meta-llama/llama-3-3-70b-instruct` (435), `openai/Llama-3.1-8B-Instruct-int8` (150).
+- **Pipeline entry:** `scripts/run_experiment.sh <config.env>` (Slurm-aware on Insomnia, Slurm-skipped on GCP). Configs in `configs/`. Resumable via `SMARTGRID_RUN_ID` + `SMARTGRID_RESUME` (PR #170).
+- **Artifacts per run:** `benchmarks/cell_<X>/raw/<run-id>/` with `meta.json`, `latencies.jsonl`, `harness.log`, `vllm.log` (if `LAUNCH_VLLM=1`), and one `<scenario>_t<n>.json` per scenario × trial. WandB run URL stamped in `meta.json` when `ENABLE_WANDB=1`.
+- **Compute provenance:** `gpu_type` in `summary.json` records Insomnia A6000 vs GCP A100 vs other (PR #145). Canonical 8B rows on Insomnia A6000 (Apr 26-28) + GCP A100 (`gcp_a100_final_20260503`).
+
+## Judge
+
+- **Default judge model:** `watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8` (overridable with `--judge-model`). Pipeline: `scripts/judge_trajectory.py` -> `results/metrics/scenario_scores.jsonl` (one JSON per line; schema `v1`).
+- **Six rubric dimensions** (booleans; True = good except `dim_hallucinations` where False = good): `task_completion`, `data_retrieval_accuracy`, `agent_sequence_correct`, `clarity_and_justification`, `generalized_result_verification`, `hallucinations`. Schema in `docs/judge_schema.md`.
+- **Aggregate:** `score_6d = (sum of 5 True booleans + NOT hallucinations) / 6`, range [0, 1]. Pass threshold 0.6 (≥4/6).
+- **Audit logs:** `results/judge_logs/<run_name>/<scenario_id>_runNN_judge_log.json` — full prompt + response per call when `--log-dir` is set.
+- **Manual sanity audit:** `results/metrics/manual_judge_audit.csv` — 12 stratified mitigation trajectories with 12/12 judge/manual pass-label agreement (judge-calibration check, not paper-grade mitigation evidence).
+
+## Evidence numbers (cite in §Eval and §Failure analysis)
+
+- **Total judge rows:** 3,716 in `results/metrics/scenario_scores.jsonl`.
+- **Paper-grade subset:** 2,420 rows (37 paper-eligible run_names per `evidence_registry.csv`; `include_in_paper=true`).
+- **Paper-grade failures:** 1,276 (`pass=false` ↔ `score_6d < 0.6` align perfectly). Programmatically classified in PR #193's `results/metrics/failure_taxonomy_current.csv`. Auto-label distribution: `low_task_completion=944`, `low_data_retrieval_accuracy=182`, `low_agent_sequence_correct=78`, `low_generalized_result_verification=72`. (`low_hallucinations` and `low_clarity_and_justification` don't appear as the dominant label because they only co-occur with earlier-priority dim failures; they're visible in `failed_dims`.)
+- **Failed-dim co-occurrence:** failure rows fail 2-6 dims at once (4-dim mode is largest at 469 rows). `failed_dims` column in `failure_taxonomy_current.csv` carries the full pattern per row.
+- **Hand audit (#194):** 46-row stratified sample (one per non-empty (cell, auto-label) stratum, deterministic seed) flagged for manual review. Owner TBD.
+- **Excluded rows:** 1,296 (3,716 − 2,420). Reasons in `evidence_registry.csv:reason` — most common: post-PR180 cohort superseded by post-PR175 clean floor (28 run_names); legacy final-six A100 matrix (11); pre-PR173/final-six mitigation diagnostic (8). All preserved (`status=superseded` / `diagnostic` / `invalid_tooling`) rather than expunged.
+
+## Safe paper claims
+
+- "31 hand-authored validated scenarios across 5 task domains" — sourced from validator output. (Bump to 36 after PR #195.)
+- "All 31 scenarios passed schema validation, asset-id resolution, and tool-canonicality checks before inclusion."
+- "2,420 LLM-judge rows form the paper-grade evaluation cohort, drawn from a larger 3,716-row evaluation pool with 1,296 rows explicitly tracked as superseded or diagnostic."
+- "Of 1,276 paper-grade failures, 74% present `task_completion` as the highest-priority failed rubric dimension, with 4-5 dim co-occurring failures most common." (Source: `failure_taxonomy_current.csv` after PR #193 lands.)
+- "An auto-generated batch of 15 scenarios produced 5 bounded-edit promotions and 10 near-duplicate rejections under the methodology in `docs/ps_b_evaluation_methodology.md`." (PR #191 disposition; PR #195 promotion.)
+
+## Anti-claims (do not state in paper)
+
+- ❌ "≥70% acceptance" on the generated batch — the methodology bar fails at 33%.
+- ❌ "Manual hand audit confirms the auto-taxonomy on every paper-grade failure" — only the 46-row stratified sample + paper-cited rows are slated for manual review (#194).
+- ❌ "All 19 MCP tools have been exercised across paper-grade rows" — no row-level coverage map yet; needs trajectory-walk to confirm.
+- ❌ "50+ scenarios" — corpus is 31 (36 after #195). #55 stretch deferred.
+
+## Pointers (for fact-checking this brief)
+
+- Validator + canonical scenarios: `data/scenarios/validate_scenarios.py`, `data/scenarios/*.json`, `data/scenarios/README.md`
+- PS B / generated: `data/scenarios/generated/README.md`, `data/scenarios/generated/disposition_2026-05-06.csv`, `docs/ps_b_evaluation_methodology.md`
+- Evidence registry: `docs/evidence_registry.md`, `results/metrics/evidence_registry.csv`
+- Judge schema: `docs/judge_schema.md`, `scripts/judge_trajectory.py`, `results/metrics/scenario_scores.jsonl`
+- Failure inventory: `results/metrics/failure_taxonomy_current.csv` + `scripts/build_failure_taxonomy.py` (PR #193)
+- Runbook: `docs/runbook.md` (infra), `docs/eval_harness_readme.md` (eval harness side, owns #67)

--- a/docs/content_brief_scenarios_eval.md
+++ b/docs/content_brief_scenarios_eval.md
@@ -2,7 +2,7 @@
 
 *Last updated: 2026-05-06. Owner: Akshat (issue #42). Audience: Alex, for the paper's scenarios + eval sections.*
 
-This is a 1-page fact pack. Numbers are reproducible from the artifacts cited in each bullet. Cross-checked against `evidence_registry.csv` (PR #188) and `scenario_scores.jsonl` on `team13/main@87a9b77` (post-PR191 disposition merge).
+This is a 1-page fact pack. Numbers are reproducible from the artifacts cited in each bullet, all sourced from `team13/main@aa0aeee` (post-PR193 merge — `results/metrics/failure_taxonomy_current.csv` was added by PR #193 and the registry/judge artifacts come from PR #188). Sources by section: scenario counts from `data/scenarios/*.json` + `data/scenarios/generated/disposition_2026-05-06.csv` (PR #191); evidence counts from `results/metrics/evidence_registry.csv` (PR #188) + `results/metrics/scenario_scores.jsonl` (continuously updated, all paper-eligible rows on the PR #175 floor); failure-taxonomy counts from `results/metrics/failure_taxonomy_current.csv` (PR #193).
 
 ## Scenarios
 
@@ -28,7 +28,7 @@ This is a 1-page fact pack. Numbers are reproducible from the artifacts cited in
 - **Models judged:** `openai/Llama-3.1-8B-Instruct` (1,835 paper-grade rows), `watsonx/meta-llama/llama-3-3-70b-instruct` (435), `openai/Llama-3.1-8B-Instruct-int8` (150).
 - **Pipeline entry:** `scripts/run_experiment.sh <config.env>` (Slurm-aware on Insomnia, Slurm-skipped on GCP). Configs in `configs/`. Resumable via `SMARTGRID_RUN_ID` + `SMARTGRID_RESUME` (PR #170).
 - **Artifacts per run:** `benchmarks/cell_<X>/raw/<run-id>/` with `meta.json`, `latencies.jsonl`, `harness.log`, `vllm.log` (if `LAUNCH_VLLM=1`), and one `<scenario>_t<n>.json` per scenario × trial. WandB run URL stamped in `meta.json` when `ENABLE_WANDB=1`.
-- **Compute provenance:** `gpu_type` in `summary.json` records Insomnia A6000 vs GCP A100 vs other (PR #145). Canonical 8B rows on Insomnia A6000 (Apr 26-28) + GCP A100 (`gcp_a100_final_20260503`).
+- **Compute provenance (paper-grade):** all paper-grade 8B rows are post-PR175 GCP A100 cohorts. The 6 paper-grade `cohort_id`s in `evidence_registry.csv` are `core15_broad`, `core16_extension`, `mitigation15_4tier`, `followon_extra15`, `watsonx70b_main15`, `watsonx70b_topup15` — every paper-grade run_name carries the `core15x5_post175_a100_*` / `core16_extension_post175_a100_*` / similar prefix. `gpu_type` in `summary.json` records the actual GPU (PR #145). **Historical / superseded** (do not cite as canonical): the Apr 26-28 Insomnia A6000 captures and `gcp_a100_final_20260503` are tracked in the registry as `status=superseded` under cohort `final6_legacy_a100_matrix` (11 rows) — preserved for provenance, not paper-eligible.
 
 ## Judge
 

--- a/docs/eval_harness_readme.md
+++ b/docs/eval_harness_readme.md
@@ -1,6 +1,6 @@
 # Evaluation Harness Runbook (Local Windows + WatsonX)
 
-*Last updated: 2026-04-07*
+*Last updated: 2026-05-06. Owns the eval-harness half of issue #67 (runbook); see `docs/runbook.md` for the Insomnia/Slurm + GCP A100 production paths and `docs/content_brief_scenarios_eval.md` for current scenario/eval/judge facts.*
 
 This README is the practical runbook for getting the **AssetOpsBench evaluation harness** running end-to-end on a local Windows machine, then exercising our **Smart Grid scenarios** from `data/scenarios/`.
 
@@ -395,7 +395,7 @@ cd /d "%SMARTGRID_REPO%"
 python data/scenarios/validate_scenarios.py
 ```
 
-Expected: `Validation passed for 11 scenario files and 5 negative fixtures.`
+Expected: `Validation passed for 31 scenario files and 5 negative fixtures.` (or 36+5 once PR #195 merges; see `data/scenarios/README.md` for the corpus status). The exact number is whatever the current corpus is — match the validator's output rather than hardcoding it in your issue comment.
 
 ### Step 2 — Run through the evaluation harness (Windows)
 

--- a/docs/judge_schema.md
+++ b/docs/judge_schema.md
@@ -54,7 +54,7 @@ Range: [0.0, 1.0]. Default pass threshold: 0.6 (4 out of 6 dimensions good).
 | `scenario_id` | string | `id` field from scenario JSON (e.g. `AOB-FMSR-001`) |
 | `scenario_file` | string | Repo-relative path to scenario JSON |
 | `trial_index` | integer | 1-indexed trial number within the run |
-| `experiment_cell` | string | `A`, `B`, `C`, `Y`, `Z` |
+| `experiment_cell` | string | The experiment cell. Initial 5-cell vocabulary was `A`, `B`, `C`, `Y`, `Z`; post-PR175 evidence adds `D`, `YS`, `ZS`, `ZSD`, `Y/YS/Z/ZS-TP`, and the `*70B` hosted-WatsonX variants. See `results/metrics/evidence_registry.csv` for the authoritative list of paper-eligible cells. |
 | `orchestration_mode` | string | `plan_execute`, `agent_as_tool`, `hybrid` |
 | `mcp_mode` | string | `baseline`, `optimized`, `direct` |
 | `model_id` | string | Model that produced the trajectory |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -475,6 +475,10 @@ paths, what each run actually proves): [validation_log.md](validation_log.md).
 
 ### Eval / scenarios / judge (Akshat / Tanisha lanes)
 
+**Paper-bound 1-page fact pack** for scenarios + eval + judge (current
+counts, dispositions, pass criteria, safe paper claims, cite-points):
+[content_brief_scenarios_eval.md](content_brief_scenarios_eval.md).
+
 **Eval harness side** (Akshat's half of the runbook, covers scenario
 execution + judge + grading): [eval_harness_readme.md](eval_harness_readme.md).
 
@@ -489,9 +493,13 @@ ablations): [experiment2_capture_plan.md](experiment2_capture_plan.md).
 
 **PS B (auto-scenario generation) runbook**:
 [auto_scenario_generation_runbook.md](auto_scenario_generation_runbook.md).
-First inspection-only batch lands at
-`data/scenarios/generated/first_review_20260503/`; `#53` validation
-rubric application owns the official quality call.
+Three batches now live under `data/scenarios/generated/`
+(`first_review_20260502`, `first_review_20260503`,
+`v02_first_review_20260505`). The `#53` per-scenario disposition table at
+`data/scenarios/generated/disposition_2026-05-06.csv` (PR #191, merged)
+records the official quality call: 5/15 `accept_with_edits`,
+10/15 `reject_duplicate`. PR #195 promotes the 5 with bounded edits
+applied; on merge the canonical corpus moves 31 -> 36.
 
 ### Historical
 


### PR DESCRIPTION
## Summary

**Closes #42** (1-page content brief). **Refs #67** (eval-harness runbook section): the existing `docs/eval_harness_readme.md` already covers the eval-harness side; this PR fixes its stale fact and points it at the new content brief, so a teammate following it from cold doesn't need to ask Akshat. Also feeds **#49** (final runbook review) by giving the runbook a single canonical fact-pack to cite.

## Files

- **`docs/content_brief_scenarios_eval.md` (new)** — 1-page fact pack. Sections: Scenarios, Generated scenarios (PS B), Eval harness, Judge, Evidence numbers, Safe paper claims, Anti-claims, Pointers. Numbers cross-checked against `scenario_scores.jsonl` + `evidence_registry.csv` + `disposition_2026-05-06.csv` on `team13/main@87a9b77`.
- **`data/scenarios/README.md`** — last-updated bumped 2026-04-21 -> 2026-05-06; the very stale "Status (Apr 7, 2026)" section is replaced with the current 31-scenario state, disposition outcome, and PR #195 promotion path. Targets section notes HPML #15 + #33 closed.
- **`docs/eval_harness_readme.md`** — fixed the documented validator assertion (`11 scenario files` -> `31 scenario files`), bumped last-updated to 2026-05-06, added a header pointer to the new brief and to `docs/runbook.md`.
- **`docs/runbook.md`** — §6 PS B pointer was naming only the first inspection-only batch; updated to reference all 3 batches + the PR #191 disposition CSV (5/10 outcome) + the PR #195 promotion. Added a `content_brief_scenarios_eval.md` pointer under §6 eval-side.
- **`docs/judge_schema.md`** — `experiment_cell` example was the initial 5-cell vocabulary; expanded to mention the post-PR175 cells (D, YS, ZS, ZSD, *_TP, *70B) and pointed at `evidence_registry.csv` as authoritative.

## Headline facts the brief locks in

- 31 canonical scenarios (FMSR 7, IoT 6, Multi 8, TSFM 4, WO 6) + 5 negatives. Bumps to 36 once PR #195 lands.
- 15 generated candidates across 3 batches; PR #191 disposition: 5 `accept_with_edits` / 10 `reject_duplicate` / 0 unusable / 0 structural. Methodology bars fail at 33% / 67%.
- 3,716 total judge rows -> 2,420 paper-eligible (37 run_names, `include_in_paper=true`) -> 1,276 paper-grade failures. Auto-taxonomy distribution (`low_task_completion=944, low_data_retrieval_accuracy=182, low_agent_sequence_correct=78, low_generalized_result_verification=72`) sourced from PR #193's `failure_taxonomy_current.csv`.
- 19 canonical MCP tools; pass threshold 0.6 (>=4/6 dim booleans); judge model `watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8`.

## Test plan

- [x] `python data/scenarios/validate_scenarios.py` -> 31+5 (unchanged).
- [x] `git diff --check` clean.
- [x] All cited counts reproduce from the artifacts the brief names. Independently re-derived from `scenario_scores.jsonl` + `evidence_registry.csv`: 3,716 total judge rows, 2,420 paper-eligible, 1,276 paper-grade failures.
- [ ] Reviewer spot-check: open `docs/content_brief_scenarios_eval.md`, walk every "Source: X" pointer, confirm the cited file/CSV exists at the path named.
- [ ] Reviewer spot-check: confirm the safe-claims and anti-claims sections accurately reflect what's defensible from current evidence (and isn't).

## Out of scope

- Refresh of `failure_taxonomy_current.csv` against the 36-floor. Current PR #193 is keyed to 31; the next paper-grade evidence pull regenerates the artifact and a follow-up PR will bump the brief's failure-mode counts.
- Manual audit of the 46-row stratified sample (#194). The brief calls this out as remaining work.
- Closing #49 (final runbook review). #49 wants a teammate sanity-check; this PR makes the docs fact-correct so that review can be productive.