### PR TITLE
docs(#67): add eval/judge/L3 reproduction section to runbook

### DIFF
--- a/docs/eval_harness_readme.md
+++ b/docs/eval_harness_readme.md
@@ -478,18 +478,25 @@ What it does:
    (newline-delimited JSON, schema v1).
 5. Writes per-call audit logs (prompt + raw response) to `--log-dir`.
 
-The runner deduplicates by `(run_name, scenario_id, trial_index, judge_prompt_version)` —
-re-running is cheap and idempotent; pass `--force` to override.
+The runner deduplicates by `(run_name, scenario_id, trial_index, judge_model, judge_prompt_version)` —
+re-running is cheap and idempotent; pass `--force` to override. `judge_model`
+is part of the key on purpose: re-scoring a run with a different judge model
+appends new rows rather than overwriting the prior judge's verdict.
 
 ### 13.2 Score a single trajectory
 
 ```bash
 python scripts/judge_trajectory.py \
   --trajectory benchmarks/cell_Y_plan_execute/raw/<run-id>/SGT-001_t1.json \
-  --scenario   data/scenarios/iot_01_asset_discovery_query.json \
+  --scenario   data/scenarios/iot_01_list_transformer_sensors.json \
   --run-meta   benchmarks/cell_Y_plan_execute/raw/<run-id>/meta.json \
   --out        results/metrics/scenario_scores.jsonl
 ```
+
+(`iot_01_list_transformer_sensors.json` is the file backing scenario
+`SGT-001`; pick whatever scenario JSON matches the trajectory you're
+scoring. The judge looks the trajectory's `scenario_id` up against the
+file you pass.)
 
 ### 13.3 Required env vars
 
@@ -584,7 +591,9 @@ acquisition date into the report's provenance block. Without `--real`, the
 script emits a stub naming the dataset(s) that still need to be acquired.
 
 The validator depends on `numpy` and `pandas`; install via
-`pip install -r requirements.txt` (or use the team venv that already has them).
+`uv pip install -r requirements.txt` (or use the team venv that already has
+them). Plain `pip install -r requirements.txt` works for non-`uv` Windows
+setups outside the repo's normal flow.
 
 ### 14.2 Version progression
 
@@ -689,9 +698,10 @@ sibling `failure_*_counts.csv` files.
 
 ### 15.3 `results/metrics/evidence_registry.csv` — what each capture proves
 
-92 rows (one per archived run + cohort), each labeled with what claim it
-backs in the paper. This is the authoritative list of paper-eligible
-experiment cells. New captures should append a row here before being cited.
+One row per archived run + cohort (91 data rows on current main, 92 lines
+including the header), each labeled with what claim it backs in the paper.
+This is the authoritative list of paper-eligible experiment cells. New
+captures should append a row here before being cited.
 
 ### 15.4 Result-interpretation rule of thumb
 
@@ -716,7 +726,7 @@ the most recent run-of-record at the top.
 
 | Field | Value |
 |---|---|
-| Repo SHA (branch tip) | (filled in by the commit that lands this section) |
+| Repo SHA (branch tip) | `07cf0cf62d44e356e0265963e85c7663818c37ee` (`akshat/issue67-runbook-eval-section` v1; the post-merge squash SHA on `main` will differ — refresh this row after #200 lands) |
 | Branch base | `origin/main` at `c726220` (W&B final evidence dashboard, #45) |
 | OS / shell | Windows 11, MSYS2 bash + system `python` |
 | Python | 3.x (system) — used only for the schema validator |

--- a/docs/eval_harness_readme.md
+++ b/docs/eval_harness_readme.md
@@ -794,7 +794,7 @@ canonical command and provenance block are reproduced verbatim in:
 - `reports/realism_statistical_v1.md` (provenance block + 5/27 verdict)
 - `reports/realism_statistical_v1.json`
 
-To re-run from a clean checkout (requires `pip install -r requirements.txt`):
+To re-run from a clean checkout (requires `uv pip install -r requirements.txt` — see §14.1 for the convention):
 
 ```bash
 python data/scenarios/validate_realism_statistical.py \

--- a/docs/eval_harness_readme.md
+++ b/docs/eval_harness_readme.md
@@ -7,7 +7,7 @@ canonical: true
 
 # Evaluation Harness Runbook (Local Windows + WatsonX)
 
-*Last updated: 2026-05-06. Owns the eval-harness half of issue #67 (runbook); see `docs/runbook.md` for the Insomnia/Slurm + GCP A100 production paths and `docs/content_brief_scenarios_eval.md` for current scenario/eval/judge facts.*
+*Last updated: 2026-05-10. Owns the eval-harness half of issue #67 (runbook); see `docs/runbook.md` for the Insomnia/Slurm + GCP A100 production paths and `docs/content_brief_scenarios_eval.md` for current scenario/eval/judge facts.*
 
 This README is the practical runbook for getting the **AssetOpsBench evaluation harness** running end-to-end on a local Windows machine, then exercising our **Smart Grid scenarios** from `data/scenarios/`.
 
@@ -21,6 +21,14 @@ This README is the practical runbook for getting the **AssetOpsBench evaluation 
 6. How to test newly-authored Smart Grid scenarios
 7. Smart Grid data pipeline notes relevant to benchmark runs
 8. Common failure modes and fixes
+9. Recommended minimum test matrix
+10. Troubleshooting
+11. Security reminder
+12. Issue #3 — canonical harness smoke run (non-Smart-Grid scenario)
+13. Judge scoring (LLM-as-Judge, 6-dimension rubric)
+14. L3 statistical-fidelity validation (DGA realism)
+15. Result interpretation — JSONL, taxonomy CSV, evidence registry
+16. Current-main reproduction proof note (#67)
 
 ---
 
@@ -255,6 +263,14 @@ cd /d "%SMARTGRID_REPO%"
 python data/scenarios/validate_scenarios.py
 ```
 
+Expected on current main (post PR #199):
+
+```
+Validation passed for 61 scenario files and 5 negative fixtures.
+```
+
+The exact integer is whatever the validator prints — match the validator's output rather than hard-coding a count in your issue comment. Negative fixtures live under `data/scenarios/negative_checks/` and exercise the validator's reject path; they are not part of the runnable corpus.
+
 ## What counts as proof of a successful canonical run?
 
 For issue closure or board status, do not treat “I ran it locally” as enough by itself. A successful harness or scenario run should leave at least one of:
@@ -402,7 +418,7 @@ cd /d "%SMARTGRID_REPO%"
 python data/scenarios/validate_scenarios.py
 ```
 
-Expected: `Validation passed for 31 scenario files and 5 negative fixtures.` (or 36+5 once PR #195 merges; see `data/scenarios/README.md` for the corpus status). The exact number is whatever the current corpus is — match the validator's output rather than hardcoding it in your issue comment.
+Expected on current main (post PR #199): `Validation passed for 61 scenario files and 5 negative fixtures.` See `data/scenarios/README.md` for the corpus breakdown (handcrafted SGT-001..SGT-035, gap-fill SGT-036..SGT-050, capability-targeted SGT-051..SGT-060, AOB carry-over fixtures). Always match the validator's output rather than hardcoding it in your issue comment.
 
 ### Step 2 — Run through the evaluation harness (Windows)
 
@@ -429,3 +445,389 @@ Success indicators in the JSON output:
 - `run_experiment.sh` is a Linux/Slurm script — use the `plan-execute` invocation above on Windows.
 - The committed config for this run is `configs/issue3_aob_harness_smoke.env` (Linux/Insomnia path).
 - Passing only `--server fmsr=...` is intentional: the scenario requires only the FMSR server, and this isolates the smoke test from CouchDB dependencies.
+
+---
+
+## 13) Judge scoring (LLM-as-Judge, 6-dimension rubric)
+
+After a benchmark cell finishes, the trajectory JSON files under
+`benchmarks/<cell>/raw/<run-id>/` are scored by `scripts/judge_trajectory.py`.
+Schema is documented in [judge_schema.md](judge_schema.md); judge model defaults
+to `watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8`.
+
+### 13.1 Score every trajectory in a run directory
+
+```bash
+# From the repo root, with the AssetOpsBench venv active so litellm is
+# importable (the judge is just a litellm client; this works on Insomnia,
+# GCP, or a local Linux/macOS box). On Windows, run from WSL or use the
+# AssetOpsBench `uv run` wrapper.
+python scripts/judge_trajectory.py \
+  --run-dir       benchmarks/cell_Y_plan_execute/raw/<run-id> \
+  --scenario-dir  data/scenarios \
+  --out           results/metrics/scenario_scores.jsonl \
+  --log-dir       results/judge_logs/<run-id>
+```
+
+What it does:
+
+1. Walks `<run-dir>` for `*_t<n>.json` trajectory files.
+2. Joins each trajectory to its scenario by `scenario_id`.
+3. Calls the judge with the [6-dimension rubric prompt](../scripts/judge_trajectory.py).
+4. Appends one JSON object per `(scenario_id, trial_index)` to `--out`
+   (newline-delimited JSON, schema v1).
+5. Writes per-call audit logs (prompt + raw response) to `--log-dir`.
+
+The runner deduplicates by `(run_name, scenario_id, trial_index, judge_prompt_version)` —
+re-running is cheap and idempotent; pass `--force` to override.
+
+### 13.2 Score a single trajectory
+
+```bash
+python scripts/judge_trajectory.py \
+  --trajectory benchmarks/cell_Y_plan_execute/raw/<run-id>/SGT-001_t1.json \
+  --scenario   data/scenarios/iot_01_asset_discovery_query.json \
+  --run-meta   benchmarks/cell_Y_plan_execute/raw/<run-id>/meta.json \
+  --out        results/metrics/scenario_scores.jsonl
+```
+
+### 13.3 Required env vars
+
+```bash
+export WATSONX_APIKEY=...
+export WATSONX_PROJECT_ID=...
+# Optional:
+export WATSONX_URL=https://us-south.ml.cloud.ibm.com
+```
+
+To use a non-default judge model, pass `--judge-model litellm_proxy/<model>` and
+set `LITELLM_API_KEY` + `LITELLM_BASE_URL` instead.
+
+### 13.4 What good output looks like
+
+One line of `results/metrics/scenario_scores.jsonl` (truncated):
+
+```json
+{
+  "schema_version": "v1",
+  "scored_at": "2026-05-06T14:55:03Z",
+  "run_name": "exp2_cell_Y_pe_mcp_baseline_8998340",
+  "scenario_id": "SGT-001",
+  "trial_index": 1,
+  "experiment_cell": "Y",
+  "orchestration_mode": "plan_execute",
+  "model_id": "watsonx/meta-llama/llama-3-3-70b-instruct",
+  "judge_model": "watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
+  "dim_task_completion": true,
+  "dim_data_retrieval_accuracy": true,
+  "dim_generalized_result_verification": true,
+  "dim_agent_sequence_correct": true,
+  "dim_clarity_and_justification": true,
+  "dim_hallucinations": false,
+  "score_6d": 1.0,
+  "pass": true,
+  "pass_threshold": 0.6,
+  "suggestions": "",
+  "trajectory_file": "benchmarks/cell_Y_plan_execute/raw/.../SGT-001_t1.json"
+}
+```
+
+`dim_hallucinations` is inverted: `false` = good (no hallucinations detected).
+The score formula sums the five "good when true" dims plus `(NOT hallucinations)`
+divided by 6; pass threshold is 0.6 (4 of 6).
+
+### 13.5 Where the audit logs land
+
+`--log-dir` writes one file per scored trial:
+
+```
+results/judge_logs/<run-id>/<scenario_id>_run<NN>_judge_log.json
+```
+
+Each contains the rendered system + user prompt sent to the judge and the
+verbatim model response, so anyone can re-derive the score without re-running
+the LLM. These are reproducibility evidence — keep them when archiving a
+canonical capture.
+
+---
+
+## 14) L3 statistical-fidelity validation (DGA realism)
+
+The synthetic DGA data under `data/processed/dga_records.csv` backs every
+PS B and SGT-* scenario that touches `fmsr.get_dga_record` /
+`fmsr.analyze_dga`. The L3 validator quantifies how closely synthetic gas
+distributions match published real-world DGA datasets — KS / EMD / chi-squared
+per gas + per fault class — and writes a versioned report card.
+
+Layer model:
+
+| Layer | What it checks | Driver |
+|---|---|---|
+| L1 schema/structural | required keys, asset-id integrity, single-domain rule | `data/scenarios/validate_scenarios.py` |
+| L2 narrative realism | "would a transformer engineer recognize this as plausible work?" | `docs/archive/scenario_realism_validation.md` + mentor review |
+| **L3 statistical fidelity** | KS / EMD / chi-squared per gas + fault | `data/scenarios/validate_realism_statistical.py` + `docs/dga_realism_statistical_validation.md` |
+
+### 14.1 Run the L3 validator (canonical command)
+
+```bash
+python data/scenarios/validate_realism_statistical.py \
+  --synthetic      data/processed/dga_records.csv \
+  --real           data/external/DGA-dataset-1.csv \
+  --real-source    bantipatel20_dga \
+  --retrieved-date 2026-05-04 \
+  --report         reports/realism_statistical_v1.md \
+  --json           reports/realism_statistical_v1.json
+```
+
+`--retrieved-date YYYY-MM-DD` is required when `--real` is set — it stamps the
+acquisition date into the report's provenance block. Without `--real`, the
+script emits a stub naming the dataset(s) that still need to be acquired.
+
+The validator depends on `numpy` and `pandas`; install via
+`pip install -r requirements.txt` (or use the team venv that already has them).
+
+### 14.2 Version progression
+
+The repo carries the v0 → v1 progression:
+
+| Version | What it shows | Artifact |
+|---|---|---|
+| v0 | pre-tuning baseline (n_synthetic=20, naive label mapping) | `reports/realism_statistical_v0.{md,json}` |
+| v1 | post-fix: descriptive→IEC label map, 5/27 tests pass, directional/pre-tuning | `reports/realism_statistical_v1.{md,json}` |
+| v2/v3 | post-tuning of `data/generate_synthetic.py` (planned in #53) | `reports/realism_statistical_v2.{md,json}` (TBD) |
+
+Treat v1 as the published baseline; the v2 plan is in
+[`docs/dga_realism_statistical_validation.md`](dga_realism_statistical_validation.md) §9 / §12.4.
+
+### 14.3 PS B per-batch convention
+
+Accepted PS B (auto-generated) batches under `data/scenarios/generated/<batch>/`
+should produce a per-batch realism report named:
+
+```
+data/scenarios/generated/<batch>/realism_statistical_<batch_id>.md
+```
+
+This is the L3 hook into the auto-scenario-generation runbook (see
+[`auto_scenario_generation_runbook.md`](auto_scenario_generation_runbook.md))
+and is the L3 row in the §42 / §53 promotion table. When a batch is accepted
+into canon (e.g. PR #195 promoted 5/15 from `first_review_20260502`), the
+realism report is the corresponding L3 evidence artifact.
+
+### 14.4 What the v1 report shows
+
+`reports/realism_statistical_v1.md` carries:
+
+- Provenance block (real-CSV SHA256 + MD5, row count, exact command, script HEAD)
+- Per-gas KS test results (H2, CH4, C2H2, C2H4, C2H6)
+- Per-fault chi-squared comparison (Normal / PD / T1-T3 / D1-D2)
+- Aggregate verdict line (e.g. `Result: 5/27 tests passed`) and the
+  pre-tuning caveat (synthetic n=20 is below the ≈30/group rule of thumb)
+
+This is the figure cited by the paper's §realism paragraph and Row 6 of the
+content brief in [`content_brief_scenarios_eval.md`](content_brief_scenarios_eval.md).
+
+---
+
+## 15) Result interpretation — JSONL, taxonomy CSV, evidence registry
+
+After a canonical capture lands and the judge has run, the three files under
+`results/metrics/` are the team-owned aggregates. A teammate following this
+runbook should read them in this order:
+
+### 15.1 `results/metrics/scenario_scores.jsonl` — the per-trial truth table
+
+One row per `(run_name, scenario_id, trial_index)`. Schema v1 lives in
+[`judge_schema.md`](judge_schema.md). Use this when you need:
+
+- Pass/fail at the trial granularity (`pass`, `score_6d`)
+- Which dimensions failed (`dim_*` booleans)
+- What the judge said it would change (`suggestions`)
+- The trajectory file the judge actually scored (`trajectory_file`)
+
+Quick aggregations:
+
+```bash
+# Total scored trials on current main:
+wc -l results/metrics/scenario_scores.jsonl
+
+# Pass-rate by experiment cell:
+python -c "
+import json, collections
+agg = collections.defaultdict(lambda: [0, 0])
+with open('results/metrics/scenario_scores.jsonl') as f:
+    for line in f:
+        if line.strip():
+            r = json.loads(line)
+            cell = r.get('experiment_cell', '?')
+            agg[cell][0] += int(bool(r.get('pass')))
+            agg[cell][1] += 1
+for cell in sorted(agg):
+    p, t = agg[cell]
+    print(f'{cell}: {p}/{t} = {p/t:.2%}')
+"
+```
+
+### 15.2 `results/metrics/failure_taxonomy_current.csv` — paper-grade failures
+
+Built by `scripts/build_failure_taxonomy.py` from the JSONL above; rows are
+the *failures* (any `dim_*` was false). Columns of interest:
+
+| Column | Meaning |
+|---|---|
+| `paper_eligible` | Row passes the paper inclusion gate (current canon, baseline cells, etc.) |
+| `failed_dims` | Comma-joined list of failed dimensions |
+| `auto_taxonomy_label` | Berkeley-style label assigned automatically |
+| `audit_decision` / `audit_decision_source` | Hand-audit override (see PR #197) |
+| `berkeley_label` | Final Berkeley taxonomy label after audit |
+| `failure_stage` | planning / tool selection / tool execution / verification / final answer |
+
+The current canon (post PR #197) contains roughly **1.97k failure rows** of
+which ~**1.28k** are `paper_eligible=True` — i.e. the "paper-grade failures"
+that back §failure-modes in the writeup. Stage / Berkeley counts live in the
+sibling `failure_*_counts.csv` files.
+
+### 15.3 `results/metrics/evidence_registry.csv` — what each capture proves
+
+92 rows (one per archived run + cohort), each labeled with what claim it
+backs in the paper. This is the authoritative list of paper-eligible
+experiment cells. New captures should append a row here before being cited.
+
+### 15.4 Result-interpretation rule of thumb
+
+- `score_6d == 1.0` and `pass=True` → the agent passed cleanly; no follow-up.
+- `0.6 ≤ score_6d < 1.0` and `pass=True` → soft pass; check `failed_dims` and
+  `suggestions` to see which dimension was on the edge.
+- `pass=False` → row should appear in `failure_taxonomy_current.csv` with a
+  `failed_dims` list. Cross-reference `audit_decision` if a hand audit has
+  flipped or confirmed the auto-label.
+- A failure row missing from `failure_taxonomy_current.csv` means the
+  taxonomy CSV is stale — re-run `python scripts/build_failure_taxonomy.py`.
+
+---
+
+## 16) Current-main reproduction proof note (#67)
+
+This section is a teammate-cold reproduction proof for the eval / scenario / L3
+side of the runbook. Re-run any time the corpus or judge schema changes; keep
+the most recent run-of-record at the top.
+
+### 16.1 Run-of-record: 2026-05-10 on `akshat/issue67-runbook-eval-section`
+
+| Field | Value |
+|---|---|
+| Repo SHA (branch tip) | (filled in by the commit that lands this section) |
+| Branch base | `origin/main` at `c726220` (W&B final evidence dashboard, #45) |
+| OS / shell | Windows 11, MSYS2 bash + system `python` |
+| Python | 3.x (system) — used only for the schema validator |
+| Working dir | `hpml-assetopsbench-smart-grid-mcp` repo root |
+
+#### Command 1 — L1 schema validation
+
+```cmd
+python data/scenarios/validate_scenarios.py
+```
+
+Observed stdout (verbatim):
+
+```
+Validation passed for 61 scenario files and 5 negative fixtures.
+```
+
+Artifact paths covered: every `data/scenarios/*.json` plus the negative
+fixtures under `data/scenarios/negative_checks/`.
+
+#### Command 2 — Judge JSONL aggregate sanity check
+
+```bash
+wc -l results/metrics/scenario_scores.jsonl
+```
+
+Observed stdout (verbatim):
+
+```
+3716 results/metrics/scenario_scores.jsonl
+```
+
+That's **3,716 scored trials** in the canonical aggregate. Schema documented
+in `docs/judge_schema.md`; per-call audit logs under
+`results/judge_logs/<run_name>/`.
+
+#### Command 3 — Failure-taxonomy CSV size + paper-eligibility split
+
+```bash
+wc -l results/metrics/failure_taxonomy_current.csv
+python -c "
+import csv
+rows = list(csv.DictReader(open('results/metrics/failure_taxonomy_current.csv')))
+print('total_failure_rows =', len(rows))
+print('paper_eligible     =', sum(1 for r in rows if r.get('paper_eligible','').lower()=='true'))
+"
+```
+
+Observed stdout (verbatim):
+
+```
+1967 results/metrics/failure_taxonomy_current.csv
+total_failure_rows = 1966
+paper_eligible     = 1276
+```
+
+(The `wc -l` count includes the header row; `1966` is the data-row count.)
+
+#### Command 4 — L3 statistical-fidelity (already-archived v1 report)
+
+The L3 validator was *not* re-run in this proof pass because it depends on
+`numpy` / `pandas` and the paper-cited result is already the v1 report. The
+canonical command and provenance block are reproduced verbatim in:
+
+- `reports/realism_statistical_v1.md` (provenance block + 5/27 verdict)
+- `reports/realism_statistical_v1.json`
+
+To re-run from a clean checkout (requires `pip install -r requirements.txt`):
+
+```bash
+python data/scenarios/validate_realism_statistical.py \
+  --synthetic      data/processed/dga_records.csv \
+  --real           data/external/DGA-dataset-1.csv \
+  --real-source    bantipatel20_dga \
+  --retrieved-date 2026-05-04 \
+  --report         reports/realism_statistical_v1.md \
+  --json           reports/realism_statistical_v1.json
+```
+
+The v1 report's archived `Script HEAD: eea6cb432b32328cce5a967c5641a2be9849aed4`
+fixes the validator version that produced the report on file.
+
+### 16.2 Artifact-path index (one-stop)
+
+| Artifact | Path |
+|---|---|
+| Canonical scenarios | `data/scenarios/*.json` (61 files) |
+| Negative validator fixtures | `data/scenarios/negative_checks/` (5 files) |
+| Per-trial judge JSONL | `results/metrics/scenario_scores.jsonl` |
+| Per-call judge audit logs | `results/judge_logs/<run_name>/*_judge_log.json` |
+| Failure taxonomy (paper-grade) | `results/metrics/failure_taxonomy_current.csv` |
+| Failure stage / Berkeley counts | `results/metrics/failure_taxonomy_current_*_counts.csv` |
+| Evidence registry | `results/metrics/evidence_registry.csv` |
+| L3 v0 baseline report | `reports/realism_statistical_v0.{md,json}` |
+| L3 v1 report (paper-cited) | `reports/realism_statistical_v1.{md,json}` |
+| Trajectory dumps (per cell × run) | `benchmarks/<cell>/raw/<run-id>/<scenario_id>_t<n>.json` |
+| Run summaries | `benchmarks/<cell>/raw/<run-id>/{meta,summary,latencies}.{json,jsonl}` |
+
+### 16.3 What this proof note does NOT cover
+
+- A live judge call (LLM round-trip) — that requires WatsonX credentials and
+  is exercised by §13.1 / §13.2 commands above. The archived JSONL plus
+  `results/judge_logs/` together demonstrate that path.
+- A live `plan-execute` harness call — covered by §2 and §12 commands above
+  and by the `run_harness_smoke.cmd` script.
+- An L3 re-run — depends on `numpy`/`pandas`; v1 report is the published
+  baseline.
+
+A teammate following this section cold should be able to:
+
+1. Confirm the corpus is intact (Command 1).
+2. Confirm the judge aggregate is intact (Commands 2 + 3).
+3. Locate every artifact the paper cites (§16.2 table).
+4. Re-run any of §13 / §14 / §15 commands without verbal context.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -488,6 +488,10 @@ counts, dispositions, pass criteria, safe paper claims, cite-points):
 
 **Eval harness side** (Akshat's half of the runbook, covers scenario
 execution + judge + grading): [eval_harness_readme.md](eval_harness_readme.md).
+The §13–§16 sections there are the current-main reproduction lane for #67:
+§13 judge scoring, §14 L3 statistical-fidelity, §15 result interpretation
+(JSONL + taxonomy CSV + evidence registry), §16 a teammate-cold proof note
+with SHA + commands run + observed stdout + artifact-path index.
 
 **Orchestration wiring** (what Plan-Execute / AaT / Hybrid look like today,
 and what's still upstream): [orchestration_wiring.md](orchestration_wiring.md).

--- a/scripts/build_wandb_dashboard.py
+++ b/scripts/build_wandb_dashboard.py
@@ -23,13 +23,25 @@ FAMILIES = [
     {
         "prefix": ["core15x5_post175", "core_rem16x5_post175"],
         "tags": ["smartgrid-final", "courseworks", "paper-grade", "post-pr175"],
-        "config": {"evidence_tier": "paper_grade", "submission_surface": "courseworks_2026"},
+        "config": {
+            "evidence_tier": "paper_grade",
+            "submission_surface": "courseworks_2026",
+        },
         "label": "core",
     },
     {
         "prefix": ["mitigation15x5_4tier_post175"],
-        "tags": ["smartgrid-final", "courseworks", "paper-grade", "post-pr175", "mitigation-ladder"],
-        "config": {"evidence_tier": "paper_grade", "submission_surface": "courseworks_2026"},
+        "tags": [
+            "smartgrid-final",
+            "courseworks",
+            "paper-grade",
+            "post-pr175",
+            "mitigation-ladder",
+        ],
+        "config": {
+            "evidence_tier": "paper_grade",
+            "submission_surface": "courseworks_2026",
+        },
         "label": "mitigation",
     },
     {
@@ -45,20 +57,48 @@ FAMILIES = [
     {
         "prefix": ["followon15x5_post175", "extra15x5_post175"],
         "tags": ["smartgrid-final", "courseworks", "paper-grade", "post-pr175"],
-        "config": {"evidence_tier": "paper_grade", "submission_surface": "courseworks_2026"},
+        "config": {
+            "evidence_tier": "paper_grade",
+            "submission_surface": "courseworks_2026",
+        },
         "label": "followon-extra",
     },
 ]
 
 EXCLUDE_PREFIXES = [
-    "smoke", "8848", "8850", "8851", "8852", "8853", "8854", "8857",
-    "local-20260413", "local-20260501",
+    "smoke",
+    "8848",
+    "8850",
+    "8851",
+    "8852",
+    "8853",
+    "8854",
+    "8857",
+    "local-20260413",
+    "local-20260501",
     "mitigation_final6_",
-    "final5x6_a100_20260503", "final5x6_extra_a100_20260503",
-    "full21x3_", "all21x3_", "final5x6_post174", "final5x6_followon",
-    "final5x6_extra_variants", "context_", "9125", "9097", "9106", "9108",
-    "9073", "9074", "9071", "8978", "8979", "8993", "8994", "8998",
-    "vq976ljq", "qejvnoug",
+    "final5x6_a100_20260503",
+    "final5x6_extra_a100_20260503",
+    "full21x3_",
+    "all21x3_",
+    "final5x6_post174",
+    "final5x6_followon",
+    "final5x6_extra_variants",
+    "context_",
+    "9125",
+    "9097",
+    "9106",
+    "9108",
+    "9073",
+    "9074",
+    "9071",
+    "8978",
+    "8979",
+    "8993",
+    "8994",
+    "8998",
+    "vq976ljq",
+    "qejvnoug",
 ]
 
 
@@ -108,6 +148,7 @@ print(f"Total newly tagged: {tagged_count}")
 # ---------------------------------------------------------------------------
 print("\nBuilding W&B Report...")
 
+
 def runset(name, tag):
     return wr.Runset(
         entity=ENTITY,
@@ -115,6 +156,7 @@ def runset(name, tag):
         name=name,
         filters=[Tags().isin([tag])],
     )
+
 
 report = wr.Report(
     project=PROJECT,
@@ -132,37 +174,41 @@ blocks = []
 
 # --- Overview ---
 blocks.append(wr.H1(text="Overview"))
-blocks.append(wr.MarkdownBlock(
-    text=(
-        "**SmartGridBench — HPML Spring 2026, Team 13**\n\n"
-        "This dashboard is the final evidence surface submitted to CourseWorks.\n\n"
-        "**Run families included:**\n"
-        "- **Core post-PR175** (`core15x5_post175`, `core_rem16x5_post175`): "
-        "cells A/B/C (transport) and B/Y/YS/Z/ZS (orchestration) on the 31-scenario evidence floor\n"
-        "- **Mitigation ladder** (`mitigation15x5_4tier_post175`): "
-        "4-tier (baseline → guard → repair → adjudication) on YS and ZS\n"
-        "- **Profiling spot-check** (`profile_spotcheck_20260507T0604Z`): "
-        "4 runs with W&B system metrics, nvidia-smi, and torch-trace — observability only\n"
-        "- **Follow-on/extra** (`followon15x5_post175`, `extra15x5_post175`): "
-        "transport follow-ons (YS-TP, ZS-TP) and INT8/BF16 KV variants (D, ZSD)\n\n"
-        "**Excluded:** smoke runs, pre-PR175 diagnostic cohorts, historical `mitigation_final6_*`.\n\n"
-        "**Source inventory:** `results/metrics/profiling_inventory.csv`\n"
-        "**Scenario corpus:** 36 canonical scenarios + 5 negative fixtures "
-        "(result tables use 31-scenario post-PR175 floor)"
+blocks.append(
+    wr.MarkdownBlock(
+        text=(
+            "**SmartGridBench — HPML Spring 2026, Team 13**\n\n"
+            "This dashboard is the final evidence surface submitted to CourseWorks.\n\n"
+            "**Run families included:**\n"
+            "- **Core post-PR175** (`core15x5_post175`, `core_rem16x5_post175`): "
+            "cells A/B/C (transport) and B/Y/YS/Z/ZS (orchestration) on the 31-scenario evidence floor\n"
+            "- **Mitigation ladder** (`mitigation15x5_4tier_post175`): "
+            "4-tier (baseline → guard → repair → adjudication) on YS and ZS\n"
+            "- **Profiling spot-check** (`profile_spotcheck_20260507T0604Z`): "
+            "4 runs with W&B system metrics, nvidia-smi, and torch-trace — observability only\n"
+            "- **Follow-on/extra** (`followon15x5_post175`, `extra15x5_post175`): "
+            "transport follow-ons (YS-TP, ZS-TP) and INT8/BF16 KV variants (D, ZSD)\n\n"
+            "**Excluded:** smoke runs, pre-PR175 diagnostic cohorts, historical `mitigation_final6_*`.\n\n"
+            "**Source inventory:** `results/metrics/profiling_inventory.csv`\n"
+            "**Scenario corpus:** 36 canonical scenarios + 5 negative fixtures "
+            "(result tables use 31-scenario post-PR175 floor)"
+        )
     )
-))
+)
 
 # --- Core benchmark runs ---
 blocks.append(wr.HorizontalRule())
 blocks.append(wr.H1(text="Core Benchmark Runs — post-PR175"))
-blocks.append(wr.MarkdownBlock(
-    text=(
-        "Transport axis (A/B/C) and orchestration axis (B/Y/YS/Z/ZS) "
-        "on the post-PR175 31-scenario evidence floor. "
-        "Both `core15x5_post175` and `core_rem16x5_post175` batches are shown. "
-        "Tag filter: `paper-grade`."
+blocks.append(
+    wr.MarkdownBlock(
+        text=(
+            "Transport axis (A/B/C) and orchestration axis (B/Y/YS/Z/ZS) "
+            "on the post-PR175 31-scenario evidence floor. "
+            "Both `core15x5_post175` and `core_rem16x5_post175` batches are shown. "
+            "Tag filter: `paper-grade`."
+        )
     )
-))
+)
 blocks.append(
     wr.PanelGrid(
         runsets=[runset("Core + follow-on runs", "paper-grade")],
@@ -198,13 +244,15 @@ blocks.append(
 # --- Mitigation ladder ---
 blocks.append(wr.HorizontalRule())
 blocks.append(wr.H1(text="Mitigation Ladder — post-PR175"))
-blocks.append(wr.MarkdownBlock(
-    text=(
-        "4-tier ladder (BASELINE → GUARD → REPAIR → ADJ) on YS (PE+Self-Ask) "
-        "and ZS (Verified PE+Self-Ask) cells. "
-        "Run family: `mitigation15x5_4tier_post175`. Tag: `mitigation-ladder`."
+blocks.append(
+    wr.MarkdownBlock(
+        text=(
+            "4-tier ladder (BASELINE → GUARD → REPAIR → ADJ) on YS (PE+Self-Ask) "
+            "and ZS (Verified PE+Self-Ask) cells. "
+            "Run family: `mitigation15x5_4tier_post175`. Tag: `mitigation-ladder`."
+        )
     )
-))
+)
 blocks.append(
     wr.PanelGrid(
         runsets=[runset("Mitigation ladder", "mitigation-ladder")],
@@ -230,14 +278,16 @@ blocks.append(
 # --- Profiling spot-check ---
 blocks.append(wr.HorizontalRule())
 blocks.append(wr.H1(text="Profiling Spot-Check"))
-blocks.append(wr.MarkdownBlock(
-    text=(
-        "4 runs (v\\_s\\_m, at\\_m, pe\\_s\\_m, at\\_t) with W&B system metrics, "
-        "nvidia-smi, and torch-trace profiling enabled. "
-        "Run family: `profile_spotcheck_20260507T0604Z`. Tag: `profiling-spotcheck`.\n\n"
-        "⚠️ **Caveat:** these rows are observability evidence — not judged task-quality results."
+blocks.append(
+    wr.MarkdownBlock(
+        text=(
+            "4 runs (v\\_s\\_m, at\\_m, pe\\_s\\_m, at\\_t) with W&B system metrics, "
+            "nvidia-smi, and torch-trace profiling enabled. "
+            "Run family: `profile_spotcheck_20260507T0604Z`. Tag: `profiling-spotcheck`.\n\n"
+            "⚠️ **Caveat:** these rows are observability evidence — not judged task-quality results."
+        )
     )
-))
+)
 blocks.append(
     wr.PanelGrid(
         runsets=[runset("Profiling spot-check", "profiling-spotcheck")],
@@ -264,18 +314,20 @@ blocks.append(
 # --- Reproducibility ---
 blocks.append(wr.HorizontalRule())
 blocks.append(wr.H1(text="Reproducibility"))
-blocks.append(wr.MarkdownBlock(
-    text=(
-        "- **GitHub repo:** https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp\n"
-        "- **Run inventory:** `results/metrics/profiling_inventory.csv`\n"
-        "- **Scenario corpus:** `data/scenarios/` "
-        "(36 canonical scenarios + 5 negative fixtures; result tables use 31-scenario floor)\n"
-        "- **Data generation:** `data/generate_synthetic.py` "
-        "(no proprietary CSVs shipped; public-safe synthetic outputs only)\n"
-        "- **Judge model:** Llama-4 Maverick 17B via WatsonX (separate family from task model)\n"
-        "- **Task model:** Llama-3.1-8B-Instruct via vLLM"
+blocks.append(
+    wr.MarkdownBlock(
+        text=(
+            "- **GitHub repo:** https://github.com/HPML6998-S26-Team13/hpml-assetopsbench-smart-grid-mcp\n"
+            "- **Run inventory:** `results/metrics/profiling_inventory.csv`\n"
+            "- **Scenario corpus:** `data/scenarios/` "
+            "(36 canonical scenarios + 5 negative fixtures; result tables use 31-scenario floor)\n"
+            "- **Data generation:** `data/generate_synthetic.py` "
+            "(no proprietary CSVs shipped; public-safe synthetic outputs only)\n"
+            "- **Judge model:** Llama-4 Maverick 17B via WatsonX (separate family from task model)\n"
+            "- **Task model:** Llama-3.1-8B-Instruct via vLLM"
+        )
     )
-))
+)
 
 report.blocks = blocks
 report.save()


### PR DESCRIPTION
## Summary

- Fills the eval-harness half of the runbook (issue #67) so a teammate can reproduce scenario validation, harness invocation, judge scoring, L3 statistical-fidelity, and result interpretation cold from current main.
- Adds §13–§16 to `docs/eval_harness_readme.md` covering judge scoring, L3 validation, result interpretation across the three result CSVs/JSONL files, and a current-main proof note with verbatim stdout.
- Updates `docs/runbook.md` §6 pointer so readers land on the new sections directly.

## Sections added

| # | Topic | What's new |
|---|---|---|
| §13 | Judge scoring (LLM-as-Judge) | Canonical `scripts/judge_trajectory.py` invocations (run-dir + single-trajectory), env vars, scored-row JSONL example, audit-log layout, dedupe / `--force` semantics |
| §14 | L3 statistical-fidelity | Canonical `validate_realism_statistical.py` command, `--retrieved-date` requirement, v0 → v1 → v2/v3 progression, PS B per-batch `realism_statistical_<batch_id>.md` convention |
| §15 | Result interpretation | `scenario_scores.jsonl` per-trial schema with a pass-rate-by-cell snippet, `failure_taxonomy_current.csv` columns + paper-eligibility split, `evidence_registry.csv` role, rule-of-thumb pass/fail reading |
| §16 | Current-main proof note | 2026-05-10 run-of-record (branch base `c726220`), observed verbatim stdout, one-stop artifact-path index, explicit list of what the note does NOT exercise |

Pre-existing references (61 scenarios, judge schema v1, L3 v0/v1) are now consistent across §1, §7 Step A, §12 Step 1, and the new §13–§16 sections.

## Proof note (verbatim)

Branch base: `origin/main` @ `c726220` (W&B final evidence dashboard, #45).

```
$ python data/scenarios/validate_scenarios.py
Validation passed for 61 scenario files and 5 negative fixtures.

$ wc -l results/metrics/scenario_scores.jsonl
3716 results/metrics/scenario_scores.jsonl

$ wc -l results/metrics/failure_taxonomy_current.csv
1967 results/metrics/failure_taxonomy_current.csv     # 1966 data rows
total_failure_rows = 1966
paper_eligible     = 1276
```

L3 v1 already archived at `reports/realism_statistical_v1.{md,json}` (5/27 tests pass, n_synthetic=20 vs n_real=201, directional pre-tuning baseline; provenance block records script HEAD `eea6cb43`).

## Test plan

- [x] `python data/scenarios/validate_scenarios.py` returns the 61+5 success line above
- [x] `wc -l results/metrics/scenario_scores.jsonl` matches the proof-note number
- [x] Failure-taxonomy paper-eligibility split matches the proof-note number
- [x] §13.1 / §13.2 invocations parse as documented in `scripts/judge_trajectory.py`
- [x] §14.1 invocation matches the v1 report's archived `Exact command:` block
- [ ] Teammate sanity-check (Alex / Tanisha / Aaron) — sufficient for #49 final-review pass

## Issue refs

- Refs #67 (eval-harness / scenario / judge / L3 reproduction lane; issue remains open until final sanity-check)
- Sufficient for `#49` final-review portion owned by Akshat

