### PR TITLE
Add GCP cleanup audit helper (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ canonical: true
 
 # Changelog
 
-## 2026-05-09
+## 2026-05-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ canonical: true
 
 # Changelog
 
+## 2026-05-09
+
+### Added
+
+- Added `scripts/gcp_cleanup_audit.py`, a read-only GCP fallback closeout
+  helper that audits instances, disks, snapshots, routers/NATs, static IPs,
+  active quota preferences, and selected quota snapshots before Issue #91 is
+  closed.
+
 ## 2026-05-07
 
 ### Added

--- a/docs/gcp_fallback.md
+++ b/docs/gcp_fallback.md
@@ -329,6 +329,20 @@ gcloud compute instances list --project="$PROJECT"
 gcloud compute disks list --project="$PROJECT"   # persistent disks can outlive instances
 ```
 
+For a fuller read-only closeout audit, use the helper from the local trusted
+checkout:
+
+```bash
+python scripts/gcp_cleanup_audit.py \
+    --project "$PROJECT" \
+    --regions us-central1,us-east1,us-east4,us-west1,us-west3,us-west4 \
+    --out ".codex/tmp/gcp_cleanup_audit_${PROJECT}.json"
+```
+
+It lists instances, disks, snapshots, routers, router NATs, static IPs, active
+quota preferences, and selected GPU/address/disk quota snapshots. It does not
+stop or delete anything; use its output before declaring the fallback lane clean.
+
 Boot disks are normally deleted with the instance when
 `--instance-termination-action=DELETE` is set, but double-check. An idle
 200GB pd-ssd costs ~$34/month if you forget it.
@@ -373,8 +387,6 @@ artifact return over IAP. Remaining production-hardening items:
 
 - A launcher/helper that tries zones first, then regions, and writes the chosen
   project/zone/instance/run directory into a handoff file.
-- A cleanup/audit helper that lists instances, disks, snapshots, routers/NATs,
-  static IPs, and active quota preferences before the fallback lane is closed.
 
 ## 11. Budget tracking
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,7 @@ what you want to do but not which command to run, start here.
 | [judge_trajectory.py](judge_trajectory.py) | LLM-as-Judge scoring helper for trajectory artifacts |
 | [gcp_resume_state.py](gcp_resume_state.py) | Resume-state helper used by `run_experiment.sh` for trial classification, manifest events, and latency-row upserts |
 | [gcp_pull_context_artifacts.sh](gcp_pull_context_artifacts.sh) | Pull GCP context-batch artifacts over IAP and merge judge score rows without duplicates |
+| [gcp_cleanup_audit.py](gcp_cleanup_audit.py) | Read-only GCP fallback closeout audit for instances, disks, snapshots, NATs, static IPs, and quota state |
 | [tmux_watch_run.sh](tmux_watch_run.sh) | Convenience watcher for long-running jobs or logs |
 
 ## Related indexes

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ canonical: true
 
 # scripts/
 
-*Last updated: 2026-05-03*
+*Last updated: 2026-05-10*
 
 Executable entrypoints and helper utilities for the repo. If you know roughly
 what you want to do but not which command to run, start here.

--- a/scripts/gcp_cleanup_audit.py
+++ b/scripts/gcp_cleanup_audit.py
@@ -38,6 +38,8 @@ QUOTA_MARKERS = (
     "ADDRESSES",
 )
 
+DEFAULT_GCLOUD_TIMEOUT_SECONDS = 120
+
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 
 
@@ -76,8 +78,24 @@ def _gcloud_command(
     return command
 
 
-def _run_json(command: list[str], runner: Runner) -> dict[str, Any]:
-    result = runner(command, check=False, capture_output=True, text=True)
+def _run_json(
+    command: list[str], runner: Runner, *, timeout_seconds: int
+) -> dict[str, Any]:
+    try:
+        result = runner(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "ok": False,
+            "command": command,
+            "items": [],
+            "error": f"gcloud timed out after {timeout_seconds}s: {exc}",
+        }
     if result.returncode != 0:
         return {
             "ok": False,
@@ -120,6 +138,7 @@ def collect_audit(
     regions: Sequence[str] = DEFAULT_REGIONS,
     runner: Runner = subprocess.run,
     dry_run: bool = False,
+    timeout_seconds: int = DEFAULT_GCLOUD_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     audit: dict[str, Any] = {
         "schema_version": 1,
@@ -138,7 +157,7 @@ def collect_audit(
         audit["resources"][name] = (
             {"ok": True, "command": command, "items": [], "error": ""}
             if dry_run
-            else _run_json(command, runner)
+            else _run_json(command, runner, timeout_seconds=timeout_seconds)
         )
 
     routers = audit["resources"]["routers"]
@@ -166,14 +185,24 @@ def collect_audit(
             result = (
                 {"ok": True, "command": command, "items": [], "error": ""}
                 if dry_run
-                else _run_json(command, runner)
+                else _run_json(command, runner, timeout_seconds=timeout_seconds)
             )
             nat_entries.append({"router": router_name, "region": region, **result})
-    audit["resources"]["router_nats"] = {
-        "ok": all(entry["ok"] for entry in nat_entries),
-        "items": nat_entries,
-        "error": "",
-    }
+        audit["resources"]["router_nats"] = {
+            "ok": all(entry["ok"] for entry in nat_entries),
+            "command": [entry["command"] for entry in nat_entries],
+            "items": nat_entries,
+            "error": "; ".join(
+                entry["error"] for entry in nat_entries if entry.get("error")
+            ),
+        }
+    else:
+        audit["resources"]["router_nats"] = {
+            "ok": False,
+            "command": [],
+            "items": [],
+            "error": f"routers list failed; router NAT audit skipped: {routers.get('error')}",
+        }
 
     preference_command = _gcloud_command(
         ("beta", "quotas", "preferences", "list"),
@@ -183,7 +212,7 @@ def collect_audit(
     audit["quota_preferences"] = (
         {"ok": True, "command": preference_command, "items": [], "error": ""}
         if dry_run
-        else _run_json(preference_command, runner)
+        else _run_json(preference_command, runner, timeout_seconds=timeout_seconds)
     )
 
     global_command = _gcloud_command(
@@ -194,7 +223,7 @@ def collect_audit(
     global_result = (
         {"ok": True, "command": global_command, "items": {}, "error": ""}
         if dry_run
-        else _run_json(global_command, runner)
+        else _run_json(global_command, runner, timeout_seconds=timeout_seconds)
     )
     audit["quota_snapshot"]["global"] = {
         **global_result,
@@ -210,7 +239,7 @@ def collect_audit(
         result = (
             {"ok": True, "command": command, "items": {}, "error": ""}
             if dry_run
-            else _run_json(command, runner)
+            else _run_json(command, runner, timeout_seconds=timeout_seconds)
         )
         audit["quota_snapshot"]["regions"][region] = {
             **result,

--- a/scripts/gcp_cleanup_audit.py
+++ b/scripts/gcp_cleanup_audit.py
@@ -67,11 +67,9 @@ def _gcloud_command(
     *,
     project: str,
     account: str | None,
-    project_flag: bool = True,
 ) -> list[str]:
     command = ["gcloud", *args]
-    if project_flag:
-        command.append(f"--project={project}")
+    command.append(f"--project={project}")
     if account:
         command.append(f"--account={account}")
     command.extend(["--format=json", "--quiet"])
@@ -190,7 +188,8 @@ def collect_audit(
             nat_entries.append({"router": router_name, "region": region, **result})
         audit["resources"]["router_nats"] = {
             "ok": all(entry["ok"] for entry in nat_entries),
-            "command": [entry["command"] for entry in nat_entries],
+            "command": routers["command"],
+            "commands": [entry["command"] for entry in nat_entries],
             "items": nat_entries,
             "error": "; ".join(
                 entry["error"] for entry in nat_entries if entry.get("error")
@@ -199,7 +198,8 @@ def collect_audit(
     else:
         audit["resources"]["router_nats"] = {
             "ok": False,
-            "command": [],
+            "command": routers["command"],
+            "commands": [],
             "items": [],
             "error": f"routers list failed; router NAT audit skipped: {routers.get('error')}",
         }
@@ -339,7 +339,10 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the read-only gcloud commands that would be run.",
+        help=(
+            "Record the read-only gcloud commands without executing them; "
+            "--out still writes the dry-run audit JSON."
+        ),
     )
     return parser.parse_args(argv)
 

--- a/scripts/gcp_cleanup_audit.py
+++ b/scripts/gcp_cleanup_audit.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Read-only GCP fallback cleanup audit for Issue #91 closeout."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REGIONS = (
+    "us-central1",
+    "us-east1",
+    "us-east4",
+    "us-west1",
+    "us-west3",
+    "us-west4",
+)
+
+RESOURCE_COMMANDS = {
+    "instances": ("compute", "instances", "list"),
+    "disks": ("compute", "disks", "list"),
+    "snapshots": ("compute", "snapshots", "list"),
+    "routers": ("compute", "routers", "list"),
+    "addresses": ("compute", "addresses", "list"),
+}
+
+QUOTA_MARKERS = (
+    "A100",
+    "GPU",
+    "CPUS",
+    "DISKS",
+    "SSD",
+    "ADDRESSES",
+)
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _split_csv(values: Sequence[str] | None) -> list[str]:
+    if not values:
+        return list(DEFAULT_REGIONS)
+    out: list[str] = []
+    for value in values:
+        out.extend(part.strip() for part in value.split(",") if part.strip())
+    return out or list(DEFAULT_REGIONS)
+
+
+def _resource_leaf(value: str | None) -> str:
+    if not value:
+        return ""
+    return value.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _gcloud_command(
+    args: Sequence[str],
+    *,
+    project: str,
+    account: str | None,
+    project_flag: bool = True,
+) -> list[str]:
+    command = ["gcloud", *args]
+    if project_flag:
+        command.append(f"--project={project}")
+    if account:
+        command.append(f"--account={account}")
+    command.extend(["--format=json", "--quiet"])
+    return command
+
+
+def _run_json(command: list[str], runner: Runner) -> dict[str, Any]:
+    result = runner(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "command": command,
+            "items": [],
+            "error": (result.stderr or result.stdout or "").strip(),
+        }
+    stdout = (result.stdout or "").strip()
+    try:
+        payload = json.loads(stdout) if stdout else []
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "command": command,
+            "items": [],
+            "error": f"invalid JSON from gcloud: {exc}",
+        }
+    return {"ok": True, "command": command, "items": payload, "error": ""}
+
+
+def _interesting_quotas(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        quotas = payload.get("quotas") or []
+    elif isinstance(payload, list):
+        quotas = payload
+    else:
+        quotas = []
+    out = []
+    for quota in quotas:
+        metric = str(quota.get("metric") or quota.get("quotaId") or "")
+        if any(marker in metric.upper() for marker in QUOTA_MARKERS):
+            out.append(quota)
+    return out
+
+
+def collect_audit(
+    *,
+    project: str,
+    account: str | None = None,
+    regions: Sequence[str] = DEFAULT_REGIONS,
+    runner: Runner = subprocess.run,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    audit: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": _utc_now(),
+        "project": project,
+        "account": account,
+        "regions": list(regions),
+        "dry_run": dry_run,
+        "resources": {},
+        "quota_preferences": {},
+        "quota_snapshot": {"global": {}, "regions": {}},
+    }
+
+    for name, base in RESOURCE_COMMANDS.items():
+        command = _gcloud_command(base, project=project, account=account)
+        audit["resources"][name] = (
+            {"ok": True, "command": command, "items": [], "error": ""}
+            if dry_run
+            else _run_json(command, runner)
+        )
+
+    routers = audit["resources"]["routers"]
+    nat_entries: list[dict[str, Any]] = []
+    if routers["ok"]:
+        for router in routers["items"]:
+            router_name = router.get("name")
+            region = _resource_leaf(router.get("region"))
+            if not router_name or not region:
+                continue
+            command = _gcloud_command(
+                (
+                    "compute",
+                    "routers",
+                    "nats",
+                    "list",
+                    "--router",
+                    router_name,
+                    "--region",
+                    region,
+                ),
+                project=project,
+                account=account,
+            )
+            result = (
+                {"ok": True, "command": command, "items": [], "error": ""}
+                if dry_run
+                else _run_json(command, runner)
+            )
+            nat_entries.append({"router": router_name, "region": region, **result})
+    audit["resources"]["router_nats"] = {
+        "ok": all(entry["ok"] for entry in nat_entries),
+        "items": nat_entries,
+        "error": "",
+    }
+
+    preference_command = _gcloud_command(
+        ("beta", "quotas", "preferences", "list"),
+        project=project,
+        account=account,
+    )
+    audit["quota_preferences"] = (
+        {"ok": True, "command": preference_command, "items": [], "error": ""}
+        if dry_run
+        else _run_json(preference_command, runner)
+    )
+
+    global_command = _gcloud_command(
+        ("compute", "project-info", "describe"),
+        project=project,
+        account=account,
+    )
+    global_result = (
+        {"ok": True, "command": global_command, "items": {}, "error": ""}
+        if dry_run
+        else _run_json(global_command, runner)
+    )
+    audit["quota_snapshot"]["global"] = {
+        **global_result,
+        "items": _interesting_quotas(global_result["items"]),
+    }
+
+    for region in regions:
+        command = _gcloud_command(
+            ("compute", "regions", "describe", region),
+            project=project,
+            account=account,
+        )
+        result = (
+            {"ok": True, "command": command, "items": {}, "error": ""}
+            if dry_run
+            else _run_json(command, runner)
+        )
+        audit["quota_snapshot"]["regions"][region] = {
+            **result,
+            "items": _interesting_quotas(result["items"]),
+        }
+
+    return audit
+
+
+def _quota_line(quota: dict[str, Any]) -> str:
+    metric = quota.get("metric") or quota.get("quotaId") or "unknown"
+    usage = quota.get("usage")
+    limit = quota.get("limit")
+    if usage is not None or limit is not None:
+        return f"{metric}: usage={usage} limit={limit}"
+    return str(metric)
+
+
+def render_text(audit: dict[str, Any]) -> str:
+    lines = [
+        f"GCP cleanup audit project={audit['project']} account={audit.get('account') or '(active gcloud account)'}",
+        f"generated_at={audit['generated_at']} dry_run={audit['dry_run']}",
+    ]
+
+    for name in ("instances", "disks", "snapshots", "routers", "addresses"):
+        result = audit["resources"][name]
+        items = result.get("items") or []
+        status = "ok" if result.get("ok") else "ERROR"
+        lines.append(f"{name}: {len(items)} [{status}]")
+        if not result.get("ok"):
+            lines.append(f"  error: {result.get('error')}")
+            continue
+        for item in items:
+            region_or_zone = _resource_leaf(item.get("zone") or item.get("region"))
+            suffix = f" ({region_or_zone})" if region_or_zone else ""
+            lines.append(f"  - {item.get('name', '<unnamed>')}{suffix}")
+
+    nat_result = audit["resources"]["router_nats"]
+    nat_count = sum(
+        len(entry.get("items") or []) for entry in nat_result.get("items") or []
+    )
+    lines.append(
+        f"router_nats: {nat_count} [{'ok' if nat_result.get('ok') else 'ERROR'}]"
+    )
+    for entry in nat_result.get("items") or []:
+        for nat in entry.get("items") or []:
+            lines.append(
+                f"  - {nat.get('name', '<unnamed>')} ({entry['region']}/{entry['router']})"
+            )
+        if not entry.get("ok"):
+            lines.append(
+                f"  error {entry['region']}/{entry['router']}: {entry.get('error')}"
+            )
+
+    preferences = audit["quota_preferences"]
+    lines.append(
+        f"quota_preferences: {len(preferences.get('items') or [])} [{'ok' if preferences.get('ok') else 'ERROR'}]"
+    )
+    if not preferences.get("ok"):
+        lines.append(f"  error: {preferences.get('error')}")
+
+    global_quotas = audit["quota_snapshot"]["global"]
+    lines.append(f"global_quota_snapshot: {len(global_quotas.get('items') or [])}")
+    for quota in global_quotas.get("items") or []:
+        lines.append(f"  - {_quota_line(quota)}")
+
+    for region, result in audit["quota_snapshot"]["regions"].items():
+        lines.append(
+            f"regional_quota_snapshot {region}: {len(result.get('items') or [])}"
+        )
+        if not result.get("ok"):
+            lines.append(f"  error: {result.get('error')}")
+            continue
+        for quota in result.get("items") or []:
+            lines.append(f"  - {_quota_line(quota)}")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read-only cleanup/cost audit for SmartGridBench GCP fallback projects."
+    )
+    parser.add_argument("--project", required=True, help="GCP project id to audit.")
+    parser.add_argument("--account", help="Optional gcloud account to use.")
+    parser.add_argument(
+        "--regions",
+        action="append",
+        help="Comma-separated quota regions to snapshot. Defaults to known fallback regions.",
+    )
+    parser.add_argument(
+        "--out", type=Path, help="Optional path for the JSON audit artifact."
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Print JSON instead of text."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the read-only gcloud commands that would be run.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    audit = collect_audit(
+        project=args.project,
+        account=args.account,
+        regions=_split_csv(args.regions),
+        dry_run=args.dry_run,
+    )
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if args.json:
+        print(json.dumps(audit, indent=2, sort_keys=True))
+    else:
+        print(render_text(audit), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gcp_cleanup_audit.py
+++ b/tests/test_gcp_cleanup_audit.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts import gcp_cleanup_audit
+
+
+class FakeGcloud:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    def __call__(self, command, **kwargs):
+        self.commands.append(list(command))
+        joined = " ".join(command)
+        if "compute instances list" in joined:
+            payload = [
+                {
+                    "name": "smartgrid-a100-demo",
+                    "zone": "https://www.googleapis.com/compute/v1/projects/p/zones/us-east1-b",
+                }
+            ]
+        elif "compute disks list" in joined:
+            payload = [{"name": "smartgrid-a100-demo", "zone": "zones/us-east1-b"}]
+        elif "compute snapshots list" in joined:
+            payload = [{"name": "smartgrid-a100-snapshot"}]
+        elif "compute routers list" in joined:
+            payload = [
+                {
+                    "name": "smartgrid-nat-router",
+                    "region": "https://www.googleapis.com/compute/v1/projects/p/regions/us-central1",
+                }
+            ]
+        elif "compute routers nats list" in joined:
+            payload = [{"name": "smartgrid-nat"}]
+        elif "compute addresses list" in joined:
+            payload = [{"name": "smartgrid-static-ip", "region": "regions/us-central1"}]
+        elif "beta quotas preferences list" in joined:
+            payload = [{"name": "projects/p/locations/global/quotaPreferences/a100"}]
+        elif "compute project-info describe" in joined:
+            payload = {
+                "quotas": [{"metric": "GPUS_ALL_REGIONS", "usage": 1.0, "limit": 1.0}]
+            }
+        elif "compute regions describe" in joined:
+            payload = {
+                "quotas": [
+                    {
+                        "metric": "PREEMPTIBLE_NVIDIA_A100_GPUS",
+                        "usage": 1.0,
+                        "limit": 1.0,
+                    },
+                    {"metric": "CPUS", "usage": 4.0, "limit": 72.0},
+                    {"metric": "UNRELATED", "usage": 0.0, "limit": 999.0},
+                ]
+            }
+        else:
+            raise AssertionError(f"unexpected command: {joined}")
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+
+def test_collect_audit_lists_cost_resources_and_router_nats() -> None:
+    fake = FakeGcloud()
+
+    audit = gcp_cleanup_audit.collect_audit(
+        project="p",
+        account="user@example.com",
+        regions=["us-central1"],
+        runner=fake,
+    )
+
+    assert audit["resources"]["instances"]["items"][0]["name"] == "smartgrid-a100-demo"
+    assert audit["resources"]["router_nats"]["items"][0]["region"] == "us-central1"
+    assert (
+        audit["resources"]["router_nats"]["items"][0]["items"][0]["name"]
+        == "smartgrid-nat"
+    )
+    assert audit["quota_preferences"]["items"][0]["name"].endswith("/a100")
+    assert audit["quota_snapshot"]["global"]["items"][0]["metric"] == "GPUS_ALL_REGIONS"
+    assert [
+        q["metric"] for q in audit["quota_snapshot"]["regions"]["us-central1"]["items"]
+    ] == [
+        "PREEMPTIBLE_NVIDIA_A100_GPUS",
+        "CPUS",
+    ]
+    assert any(
+        "--account=user@example.com" in command
+        for cmd in fake.commands
+        for command in cmd
+    )
+
+
+def test_render_text_surfaces_resource_counts_and_quota_lines() -> None:
+    audit = gcp_cleanup_audit.collect_audit(
+        project="p",
+        regions=["us-central1"],
+        runner=FakeGcloud(),
+    )
+
+    text = gcp_cleanup_audit.render_text(audit)
+
+    assert "instances: 1 [ok]" in text
+    assert "router_nats: 1 [ok]" in text
+    assert "quota_preferences: 1 [ok]" in text
+    assert "GPUS_ALL_REGIONS: usage=1.0 limit=1.0" in text
+
+
+def test_main_writes_json_artifact_in_dry_run(tmp_path: Path, capsys) -> None:
+    out = tmp_path / "audit.json"
+
+    rc = gcp_cleanup_audit.main(
+        [
+            "--project",
+            "p",
+            "--regions",
+            "us-central1",
+            "--dry-run",
+            "--json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    printed = json.loads(capsys.readouterr().out)
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert printed["dry_run"] is True
+    assert written["resources"]["instances"]["command"][:4] == [
+        "gcloud",
+        "compute",
+        "instances",
+        "list",
+    ]

--- a/tests/test_gcp_cleanup_audit.py
+++ b/tests/test_gcp_cleanup_audit.py
@@ -70,6 +70,12 @@ def test_collect_audit_lists_cost_resources_and_router_nats() -> None:
     )
 
     assert audit["resources"]["instances"]["items"][0]["name"] == "smartgrid-a100-demo"
+    assert audit["resources"]["router_nats"]["command"][0][:4] == [
+        "gcloud",
+        "compute",
+        "routers",
+        "nats",
+    ]
     assert audit["resources"]["router_nats"]["items"][0]["region"] == "us-central1"
     assert (
         audit["resources"]["router_nats"]["items"][0]["items"][0]["name"]
@@ -131,3 +137,72 @@ def test_main_writes_json_artifact_in_dry_run(tmp_path: Path, capsys) -> None:
         "instances",
         "list",
     ]
+
+
+def test_run_json_surfaces_failed_process_and_invalid_json() -> None:
+    failed = gcp_cleanup_audit._run_json(
+        ["gcloud", "bad"],
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command, 1, "", "permission denied"
+        ),
+        timeout_seconds=10,
+    )
+    invalid = gcp_cleanup_audit._run_json(
+        ["gcloud", "bad-json"],
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, "{", ""),
+        timeout_seconds=10,
+    )
+
+    assert failed == {
+        "ok": False,
+        "command": ["gcloud", "bad"],
+        "items": [],
+        "error": "permission denied",
+    }
+    assert invalid["ok"] is False
+    assert invalid["command"] == ["gcloud", "bad-json"]
+    assert "invalid JSON from gcloud" in invalid["error"]
+
+
+def test_run_json_surfaces_timeout() -> None:
+    def timeout_runner(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, timeout=kwargs["timeout"])
+
+    result = gcp_cleanup_audit._run_json(
+        ["gcloud", "slow"], timeout_runner, timeout_seconds=3
+    )
+
+    assert result["ok"] is False
+    assert result["command"] == ["gcloud", "slow"]
+    assert "timed out after 3s" in result["error"]
+
+
+def test_router_nat_status_follows_router_list_failure() -> None:
+    def failing_routers(command, **kwargs):
+        joined = " ".join(command)
+        if "compute routers list" in joined:
+            return subprocess.CompletedProcess(
+                command, 1, "", "router permission denied"
+            )
+        if "compute routers nats list" in joined:
+            raise AssertionError("NAT commands should be skipped when routers fail")
+        if (
+            "compute project-info describe" in joined
+            or "compute regions describe" in joined
+        ):
+            return subprocess.CompletedProcess(
+                command, 0, json.dumps({"quotas": []}), ""
+            )
+        return subprocess.CompletedProcess(command, 0, "[]", "")
+
+    audit = gcp_cleanup_audit.collect_audit(
+        project="p",
+        regions=["us-central1"],
+        runner=failing_routers,
+    )
+
+    router_nats = audit["resources"]["router_nats"]
+    assert router_nats["ok"] is False
+    assert router_nats["command"] == []
+    assert router_nats["items"] == []
+    assert "router permission denied" in router_nats["error"]

--- a/tests/test_gcp_cleanup_audit.py
+++ b/tests/test_gcp_cleanup_audit.py
@@ -70,7 +70,13 @@ def test_collect_audit_lists_cost_resources_and_router_nats() -> None:
     )
 
     assert audit["resources"]["instances"]["items"][0]["name"] == "smartgrid-a100-demo"
-    assert audit["resources"]["router_nats"]["command"][0][:4] == [
+    assert audit["resources"]["router_nats"]["command"][:4] == [
+        "gcloud",
+        "compute",
+        "routers",
+        "list",
+    ]
+    assert audit["resources"]["router_nats"]["commands"][0][:4] == [
         "gcloud",
         "compute",
         "routers",
@@ -203,6 +209,7 @@ def test_router_nat_status_follows_router_list_failure() -> None:
 
     router_nats = audit["resources"]["router_nats"]
     assert router_nats["ok"] is False
-    assert router_nats["command"] == []
+    assert router_nats["command"][:4] == ["gcloud", "compute", "routers", "list"]
+    assert router_nats["commands"] == []
     assert router_nats["items"] == []
     assert "router permission denied" in router_nats["error"]


### PR DESCRIPTION
## Summary
- Adds `scripts/gcp_cleanup_audit.py`, a read-only GCP cleanup audit helper for fallback/cost-control checks.
- Lists SmartGrid-relevant instances, disks, snapshots, routers/router NATs, static IPs, active quota preferences, and selected quota snapshots without stopping or deleting resources.
- Documents usage in `docs/gcp_fallback.md` and `scripts/README.md`, adds focused tests, and records the change in `CHANGELOG.md`.

## Scope
Refs #91. This covers the cleanup/audit helper portion.

The automatic launcher that tries zones first, then regions, provisions the target, and writes the selected project/zone/instance/run-directory handoff file remains future work.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_gcp_cleanup_audit.py` — 3 passed
- `python scripts/gcp_cleanup_audit.py --project test-project --regions us-central1 --dry-run --json | python -m json.tool >/dev/null`
- `python -m py_compile scripts/gcp_cleanup_audit.py`
- `git diff --check team13/main..HEAD`
- `black --check scripts/gcp_cleanup_audit.py tests/test_gcp_cleanup_audit.py`
